### PR TITLE
localhost dev mode: MockOgStorage contract and og-bridge localhost routing

### DIFF
--- a/contracts/script/deploy.js
+++ b/contracts/script/deploy.js
@@ -57,6 +57,17 @@ async function main() {
   const matchAddr = await matchRegistry.getAddress();
   console.log(`MatchRegistry deployed: ${matchAddr}`);
 
+  // Deploy MockOgStorage on localhost/hardhat only — stands in for 0G Storage so a
+  // dev can iterate without making any 0G testnet calls (see og-bridge OG_STORAGE_MODE=localhost).
+  let mockOgStorageAddr;
+  if (network.name === "localhost" || network.name === "hardhat") {
+    const MockOgStorage = await ethers.getContractFactory("MockOgStorage");
+    const mock = await MockOgStorage.deploy();
+    await mock.waitForDeployment();
+    mockOgStorageAddr = await mock.getAddress();
+    console.log(`MockOgStorage deployed: ${mockOgStorageAddr} (localhost only)`);
+  }
+
   const AgentRegistry = await ethers.getContractFactory("AgentRegistry");
   const agentRegistry = await AgentRegistry.deploy(matchAddr, INITIAL_BASE_WEIGHTS_HASH);
   await agentRegistry.waitForDeployment();
@@ -83,6 +94,7 @@ async function main() {
       MatchRegistry: matchAddr,
       AgentRegistry: agentAddr,
       PlayerSubnameRegistrar: registrarAddr,
+      ...(mockOgStorageAddr ? { MockOgStorage: mockOgStorageAddr } : {}),
     },
     agentRegistryConstructorArgs: {
       matchRegistry: matchAddr,

--- a/contracts/src/MockOgStorage.sol
+++ b/contracts/src/MockOgStorage.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/**
+ * @title MockOgStorage
+ * @notice Localhost-only stand-in for 0G Storage (0G's distributed blob-store network).
+ * Uses keccak256 as the content address rather than 0G's Merkle root. The on-chain
+ * consumers — gameRecordHash on MatchRegistry and dataHashes[*] on AgentRegistry — treat
+ * the stored value as an opaque bytes32, so the swap is safe within a single network.
+ * Hashes produced on localhost have no meaning on testnet and vice versa.
+ */
+contract MockOgStorage {
+    /// @dev Content-addressed blob store. Key is keccak256(data).
+    mapping(bytes32 => bytes) private blobs;
+
+    /// @dev Existence flag separate from blobs so a stored zero-length value (which we
+    /// reject at put time) cannot be confused with "not present."
+    mapping(bytes32 => bool) private stored;
+
+    /// @notice Emitted when a blob is successfully stored.
+    event Stored(bytes32 indexed rootHash, uint256 length);
+
+    /**
+     * @notice Store bytes and return their keccak256 content hash.
+     * @dev Idempotent: putting the same bytes twice does not revert and produces the same
+     * rootHash. Empty data is rejected.
+     * @param data Raw bytes to store.
+     * @return rootHash keccak256 of data — used as the address for get() and exists().
+     */
+    function put(bytes calldata data) external returns (bytes32 rootHash) {
+        require(data.length != 0, "MockOgStorage: empty data");
+        rootHash = keccak256(data);
+        blobs[rootHash] = data;
+        stored[rootHash] = true;
+        emit Stored(rootHash, data.length);
+    }
+
+    /**
+     * @notice Retrieve bytes by their content hash.
+     * @param rootHash keccak256 of the data, as returned by put().
+     * @return The stored bytes.
+     */
+    function get(bytes32 rootHash) external view returns (bytes memory) {
+        require(stored[rootHash], "MockOgStorage: blob not found");
+        return blobs[rootHash];
+    }
+
+    /**
+     * @notice Check whether a blob has been stored.
+     * @param rootHash keccak256 of the data.
+     * @return True if the blob was previously stored via put().
+     */
+    function exists(bytes32 rootHash) external view returns (bool) {
+        return stored[rootHash];
+    }
+}

--- a/contracts/test/phase_MockOgStorage.test.js
+++ b/contracts/test/phase_MockOgStorage.test.js
@@ -1,0 +1,81 @@
+// localhost dev mode — MockOgStorage unit tests.
+//
+// Written BEFORE the contract so they fail red first (TDD). Each case covers
+// one behaviour slice: content-addressing, retrieval, event emission,
+// existence flip, idempotency, distinct-content isolation, and error paths.
+
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("Phase — MockOgStorage", function () {
+  let mock;
+
+  beforeEach(async function () {
+    const MockOgStorage = await ethers.getContractFactory("MockOgStorage");
+    mock = await MockOgStorage.deploy();
+  });
+
+  it("put returns keccak256(data)", async function () {
+    const data = ethers.toUtf8Bytes("hello chaingammon");
+    const expected = ethers.keccak256(data);
+    // staticCall makes the return value observable without consuming state.
+    const actual = await mock.put.staticCall(data);
+    expect(actual).to.equal(expected);
+  });
+
+  it("get returns the bytes that were put", async function () {
+    const data = ethers.toUtf8Bytes("round trip data");
+    await mock.put(data);
+    const rootHash = ethers.keccak256(data);
+    const returned = await mock.get(rootHash);
+    expect(returned).to.equal(ethers.hexlify(data));
+  });
+
+  it("put emits Stored(rootHash, length)", async function () {
+    const data = ethers.toUtf8Bytes("emit test payload");
+    const rootHash = ethers.keccak256(data);
+    await expect(mock.put(data))
+      .to.emit(mock, "Stored")
+      .withArgs(rootHash, data.length);
+  });
+
+  it("exists flips false to true after a put", async function () {
+    const data = ethers.toUtf8Bytes("existence check");
+    const rootHash = ethers.keccak256(data);
+    expect(await mock.exists(rootHash)).to.equal(false);
+    await mock.put(data);
+    expect(await mock.exists(rootHash)).to.equal(true);
+  });
+
+  it("identical-content puts are idempotent", async function () {
+    const data = ethers.toUtf8Bytes("idempotent content");
+    const rootHash = ethers.keccak256(data);
+    await mock.put(data);
+    await expect(mock.put(data)).not.to.be.reverted;
+    const returned = await mock.get(rootHash);
+    expect(returned).to.equal(ethers.hexlify(data));
+  });
+
+  it("distinct content yields distinct hashes and bytes", async function () {
+    const dataA = ethers.toUtf8Bytes("payload A");
+    const dataB = ethers.toUtf8Bytes("payload B");
+    await mock.put(dataA);
+    await mock.put(dataB);
+    const hashA = ethers.keccak256(dataA);
+    const hashB = ethers.keccak256(dataB);
+    expect(hashA).to.not.equal(hashB);
+    expect(await mock.get(hashA)).to.equal(ethers.hexlify(dataA));
+    expect(await mock.get(hashB)).to.equal(ethers.hexlify(dataB));
+  });
+
+  it("get reverts 'MockOgStorage: blob not found' for an unknown hash", async function () {
+    const unknownHash = ethers.keccak256(ethers.toUtf8Bytes("never stored"));
+    await expect(mock.get(unknownHash)).to.be.revertedWith(
+      "MockOgStorage: blob not found",
+    );
+  });
+
+  it("put('0x') reverts 'MockOgStorage: empty data'", async function () {
+    await expect(mock.put("0x")).to.be.revertedWith("MockOgStorage: empty data");
+  });
+});

--- a/log.md
+++ b/log.md
@@ -1100,3 +1100,48 @@ Tests (**agent/tests/test_coach_service.py**, updated, +1 test):
 27 agent tests pass (17 prior + 10 new). Frontend type-checks clean (`pnpm exec tsc --noEmit`). Smoke-tested both legs of the toggle on a live coach service: `backend: "local"` request returns a hint with zero 0G markers in the log; `backend: "compute"` request attempts the 0G path and falls back to local when the wallet/env is unavailable.
 
 Live 0G Compute path (Qwen 2.5 7B at provider `0xa48f01287233509FD694a22Bf840225062E67836`) is reachable from the bridge but requires the wallet at `0xa2219C4f48bC9e6806Bce3B391aB9e23f55FEbb5` to be funded above the testnet ledger's minimum (`addLedger(0.05 OG)` reverts at the current 0.099 OG balance). Once topped up via the 0G faucet, no code changes are needed — the next `/hint` with `backend: "compute"` mints the ledger and routes to Qwen.
+
+### localhost dev mode: MockOgStorage contract and og-bridge localhost routing
+
+Adds a fully self-contained Hardhat localhost dev mode so engineers can iterate with `pnpm exec hardhat node` plus a localhost deploy and make zero 0G testnet calls. A new MockOgStorage Solidity contract (MIT, `^0.8.24`) stands in for 0G Storage (0G's distributed blob-store network), using `keccak256` as the content address rather than 0G's Merkle root. The on-chain consumers — `gameRecordHash` on MatchRegistry and `dataHashes[*]` on AgentRegistry — treat the hash as an opaque `bytes32`, so the swap is safe within a single network; hashes produced on localhost have no meaning on testnet and vice versa.
+
+MockOgStorage (**contracts/src/MockOgStorage.sol**, new):
+- `mapping(bytes32 => bytes) private blobs` plus `mapping(bytes32 => bool) private stored` so an absent key and a stored zero-length blob (rejected at `put` time) can never be confused.
+- `put(bytes calldata data) external returns (bytes32 rootHash)` — reverts `"MockOgStorage: empty data"` on empty input; otherwise computes `rootHash = keccak256(data)`, stores bytes, emits `Stored(rootHash, length)`. Idempotent on identical content.
+- `get(bytes32 rootHash) external view returns (bytes memory)` — reverts `"MockOgStorage: blob not found"` when `!stored[rootHash]`.
+- `exists(bytes32 rootHash) external view returns (bool)` — reads the existence flag.
+- `event Stored(bytes32 indexed rootHash, uint256 length)`.
+- NatSpec header explains localhost-only scope, keccak256 vs 0G Merkle-root distinction, and cross-network hash incompatibility.
+
+deploy.js (**contracts/script/deploy.js**, updated):
+- Localhost/hardhat-only block inserted between MatchRegistry and AgentRegistry deploys — deploys MockOgStorage, logs address, stores it under `contracts.MockOgStorage` in the output JSON.
+- Testnet deploys are unaffected (block is guarded by `network.name === "localhost" || network.name === "hardhat"`).
+
+og-bridge upload (**og-bridge/src/upload.mjs**, updated):
+- New `OG_STORAGE_MODE=localhost` branch at the top of `main()`.
+  - Reads `LOCALHOST_RPC` (default `http://127.0.0.1:8545`) and MockOgStorage address from `LOCALHOST_MOCK_OG_STORAGE` or falls back to `contracts/deployments/localhost.json → contracts.MockOgStorage` with a clear error on missing file.
+  - Reads `LOCALHOST_PRIVATE_KEY` (default: Hardhat's first well-known test key `0xac0974...`; comment notes not to reuse on a real network).
+  - Computes `rootHash = ethers.keccak256(bytes)` locally (deterministic, avoids a `staticCall` round-trip), calls `mock.put(bytes)`, waits for receipt, emits `{rootHash, txHash}` JSON on stdout.
+  - ABI constructed inline (6-line array — no artifact import).
+- Testnet path (`OG_STORAGE_MODE` unset or `"testnet"`) is unchanged; env checks moved inside `main()` after the localhost branch.
+
+og-bridge download (**og-bridge/src/download.mjs**, updated):
+- New `OG_STORAGE_MODE=localhost` branch mirrors the upload change: resolves MockOgStorage address the same way, calls `mock.get(rootHash)` on a read-only provider, converts the returned hex string to raw bytes, writes to stdout.
+- Testnet path unchanged; `OG_STORAGE_INDEXER` check moved inside `main()` after the localhost branch.
+
+round-trip test (**og-bridge/test/round_trip.mjs**, new):
+- Standalone Node script (no test runner required); takes `--mock-address 0x...` plus optional `--rpc` and `--private-key` flags.
+- Uploads three payloads (two text strings; one five-byte binary edge case with `0x00`/`0xff` values) via the localhost branch of upload.mjs and downloads each by the returned `rootHash`.
+- Asserts byte-for-byte equality with `Buffer.equals`; prints `Payload N: OK` per case plus `OK` on success; exits 1 with a hex diff on mismatch.
+
+Tests (**contracts/test/phase_MockOgStorage.test.js**, new, 8 tests):
+- `put` returns `keccak256(data)` via `staticCall` (return value observable without state side-effects).
+- `get(rootHash)` returns the bytes stored by `put` (compared with `ethers.hexlify`).
+- `put` emits `Stored(rootHash, length)` verified with `to.emit(...).withArgs(...)`.
+- `exists` flips `false → true` after a `put`.
+- Identical-content puts are idempotent: second `put` does not revert and `get` still returns the bytes.
+- Distinct content yields distinct hashes and distinct bytes on retrieval.
+- `get` reverts `"MockOgStorage: blob not found"` for an unknown hash.
+- `put("0x")` reverts `"MockOgStorage: empty data"`.
+
+8 new Hardhat tests pass (45 prior + 8 new).

--- a/og-bridge/src/download.mjs
+++ b/og-bridge/src/download.mjs
@@ -1,27 +1,80 @@
 #!/usr/bin/env node
-// CLI: download a 0G Storage blob by rootHash and write its bytes to stdout.
+// CLI: download a blob by rootHash and write its bytes to stdout.
 //
 // Usage: node src/download.mjs <rootHash>
 //
-// Required env: OG_STORAGE_INDEXER
+// Testnet mode (default, OG_STORAGE_MODE unset or "testnet"):
+//   Required env: OG_STORAGE_INDEXER
+//
+// Localhost mode (OG_STORAGE_MODE=localhost):
+//   Optional env: LOCALHOST_RPC (default http://127.0.0.1:8545)
+//   Required:     LOCALHOST_MOCK_OG_STORAGE or contracts/deployments/localhost.json
 
 // SDK progress goes to stderr so stdout stays clean for the binary blob.
 console.log = (...args) => process.stderr.write(args.map(String).join(" ") + "\n");
 
 import { Indexer } from "@0gfoundation/0g-ts-sdk";
+import { ethers } from "ethers";
+import fs from "fs";
+import path from "path";
 
 function fail(msg, code = 1) {
   process.stderr.write(msg + "\n");
   process.exit(code);
 }
 
-const INDEXER = process.env.OG_STORAGE_INDEXER;
-if (!INDEXER) fail("Missing OG_STORAGE_INDEXER in env.");
+// Minimal ABI for MockOgStorage — only the two functions used here.
+const MOCK_ABI = [
+  "function put(bytes calldata data) external returns (bytes32 rootHash)",
+  "function get(bytes32 rootHash) external view returns (bytes memory)",
+];
 
 const rootHash = process.argv[2];
 if (!rootHash) fail("Usage: node src/download.mjs <rootHash>");
 
 async function main() {
+  if (process.env.OG_STORAGE_MODE === "localhost") {
+    const rpc = process.env.LOCALHOST_RPC ?? "http://127.0.0.1:8545";
+
+    // Resolve MockOgStorage address from env or fallback to deployments JSON.
+    let mockAddr = process.env.LOCALHOST_MOCK_OG_STORAGE;
+    if (!mockAddr) {
+      const deployPath = path.resolve(
+        import.meta.dirname,
+        "../../contracts/deployments/localhost.json",
+      );
+      let deployment;
+      try {
+        deployment = JSON.parse(fs.readFileSync(deployPath, "utf8"));
+      } catch {
+        fail(
+          `LOCALHOST_MOCK_OG_STORAGE is not set and ${deployPath} is missing or unreadable. ` +
+            `Deploy first: pnpm exec hardhat run script/deploy.js --network localhost`,
+        );
+      }
+      mockAddr = deployment?.contracts?.MockOgStorage;
+      if (!mockAddr) {
+        fail(
+          `MockOgStorage address not found in ${deployPath}. ` +
+            `Redeploy to localhost to include MockOgStorage.`,
+        );
+      }
+    }
+
+    const provider = new ethers.JsonRpcProvider(rpc);
+    const mock = new ethers.Contract(mockAddr, MOCK_ABI, provider);
+
+    const hexData = await mock.get(rootHash);
+    // hexData is a "0x..." hex string from ethers — strip the prefix and write raw bytes.
+    const buf = Buffer.from(hexData.slice(2), "hex");
+    process.stdout.write(buf);
+    return;
+  }
+
+  // Testnet / default path — behaviour unchanged from prior phases.
+  const INDEXER = process.env.OG_STORAGE_INDEXER;
+  if (!INDEXER) fail("Missing OG_STORAGE_INDEXER in env.");
+
   const indexer = new Indexer(INDEXER);
   const [blob, err] = await indexer.downloadToBlob(rootHash);
   if (err) fail(`Download failed: ${err.message ?? err}`);

--- a/og-bridge/src/upload.mjs
+++ b/og-bridge/src/upload.mjs
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
-// CLI: upload bytes from stdin to 0G Storage, print {rootHash, txHash} as JSON to stdout.
+// CLI: upload bytes from stdin to 0G Storage or MockOgStorage on localhost.
 //
 // Usage: cat blob.bin | node src/upload.mjs
 //
-// Required env: OG_STORAGE_RPC, OG_STORAGE_INDEXER, OG_STORAGE_PRIVATE_KEY
+// Testnet mode (default, OG_STORAGE_MODE unset or "testnet"):
+//   Required env: OG_STORAGE_RPC, OG_STORAGE_INDEXER, OG_STORAGE_PRIVATE_KEY
+//
+// Localhost mode (OG_STORAGE_MODE=localhost):
+//   Optional env: LOCALHOST_RPC (default http://127.0.0.1:8545)
+//   Required:     LOCALHOST_MOCK_OG_STORAGE or contracts/deployments/localhost.json
+//   Optional env: LOCALHOST_PRIVATE_KEY (default: Hardhat's first well-known test key)
 
 // The 0G SDK logs progress via console.log. Redirect to stderr so stdout
 // stays clean for the single JSON payload we emit at the end.
@@ -12,18 +18,19 @@ console.log = (...args) => process.stderr.write(args.map(String).join(" ") + "\n
 
 import { Indexer, MemData } from "@0gfoundation/0g-ts-sdk";
 import { ethers } from "ethers";
+import fs from "fs";
+import path from "path";
 
 function fail(msg, code = 1) {
   process.stderr.write(msg + "\n");
   process.exit(code);
 }
 
-const RPC = process.env.OG_STORAGE_RPC;
-const INDEXER = process.env.OG_STORAGE_INDEXER;
-const PRIVATE_KEY = process.env.OG_STORAGE_PRIVATE_KEY;
-if (!RPC || !INDEXER || !PRIVATE_KEY) {
-  fail("Missing one of OG_STORAGE_RPC, OG_STORAGE_INDEXER, OG_STORAGE_PRIVATE_KEY in env.");
-}
+// Minimal ABI for MockOgStorage — only the two functions used here.
+const MOCK_ABI = [
+  "function put(bytes calldata data) external returns (bytes32 rootHash)",
+  "function get(bytes32 rootHash) external view returns (bytes memory)",
+];
 
 async function readStdin() {
   const chunks = [];
@@ -34,6 +41,59 @@ async function readStdin() {
 async function main() {
   const bytes = await readStdin();
   if (bytes.length === 0) fail("No bytes on stdin.");
+
+  if (process.env.OG_STORAGE_MODE === "localhost") {
+    const rpc = process.env.LOCALHOST_RPC ?? "http://127.0.0.1:8545";
+
+    // Resolve MockOgStorage address from env or fallback to deployments JSON.
+    let mockAddr = process.env.LOCALHOST_MOCK_OG_STORAGE;
+    if (!mockAddr) {
+      const deployPath = path.resolve(
+        import.meta.dirname,
+        "../../contracts/deployments/localhost.json",
+      );
+      let deployment;
+      try {
+        deployment = JSON.parse(fs.readFileSync(deployPath, "utf8"));
+      } catch {
+        fail(
+          `LOCALHOST_MOCK_OG_STORAGE is not set and ${deployPath} is missing or unreadable. ` +
+            `Deploy first: pnpm exec hardhat run script/deploy.js --network localhost`,
+        );
+      }
+      mockAddr = deployment?.contracts?.MockOgStorage;
+      if (!mockAddr) {
+        fail(
+          `MockOgStorage address not found in ${deployPath}. ` +
+            `Redeploy to localhost to include MockOgStorage.`,
+        );
+      }
+    }
+
+    // Hardhat's first well-known test key — publicly known, do not reuse on a real network.
+    const privateKey =
+      process.env.LOCALHOST_PRIVATE_KEY ??
+      "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+    const provider = new ethers.JsonRpcProvider(rpc);
+    const signer = new ethers.Wallet(privateKey, provider);
+    const mock = new ethers.Contract(mockAddr, MOCK_ABI, signer);
+
+    // keccak256 is deterministic — compute locally to avoid a staticCall round-trip.
+    const rootHash = ethers.keccak256(bytes);
+    const tx = await mock.put(bytes);
+    const receipt = await tx.wait();
+    _origLog(JSON.stringify({ rootHash, txHash: receipt.hash }));
+    return;
+  }
+
+  // Testnet / default path — behaviour unchanged from prior phases.
+  const RPC = process.env.OG_STORAGE_RPC;
+  const INDEXER = process.env.OG_STORAGE_INDEXER;
+  const PRIVATE_KEY = process.env.OG_STORAGE_PRIVATE_KEY;
+  if (!RPC || !INDEXER || !PRIVATE_KEY) {
+    fail("Missing one of OG_STORAGE_RPC, OG_STORAGE_INDEXER, OG_STORAGE_PRIVATE_KEY in env.");
+  }
 
   const provider = new ethers.JsonRpcProvider(RPC);
   const signer = new ethers.Wallet(PRIVATE_KEY, provider);

--- a/og-bridge/test/round_trip.mjs
+++ b/og-bridge/test/round_trip.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// Round-trip integration test for MockOgStorage via og-bridge upload/download.
+//
+// Uploads three known payloads (including a binary edge case) through the
+// localhost branch of upload.mjs, downloads each by the returned rootHash,
+// and asserts byte-for-byte equality. Prints OK and exits 0 on success;
+// exits 1 with a diff summary on any mismatch.
+//
+// Usage:
+//   node og-bridge/test/round_trip.mjs --mock-address 0x<address>
+//     [--rpc http://127.0.0.1:8545]
+//     [--private-key 0x<key>]
+
+import { execFileSync } from "child_process";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function fail(msg) {
+  process.stderr.write(msg + "\n");
+  process.exit(1);
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const result = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--mock-address") result.mockAddress = args[++i];
+    else if (args[i] === "--rpc") result.rpc = args[++i];
+    else if (args[i] === "--private-key") result.privateKey = args[++i];
+  }
+  if (!result.mockAddress) {
+    fail("Usage: node test/round_trip.mjs --mock-address 0x...");
+  }
+  return result;
+}
+
+const { mockAddress, rpc = "http://127.0.0.1:8545", privateKey } = parseArgs();
+
+// Three payloads: two text strings and one binary edge case.
+const PAYLOADS = [
+  Buffer.from("chaingammon round trip payload A"),
+  Buffer.from("chaingammon round trip payload B — slightly longer content"),
+  Buffer.from(new Uint8Array([0x00, 0x01, 0x02, 0xfe, 0xff])),
+];
+
+const env = {
+  ...process.env,
+  OG_STORAGE_MODE: "localhost",
+  LOCALHOST_RPC: rpc,
+  LOCALHOST_MOCK_OG_STORAGE: mockAddress,
+};
+if (privateKey) env.LOCALHOST_PRIVATE_KEY = privateKey;
+
+const uploadScript = path.resolve(__dirname, "../src/upload.mjs");
+const downloadScript = path.resolve(__dirname, "../src/download.mjs");
+
+let allOk = true;
+
+for (let i = 0; i < PAYLOADS.length; i++) {
+  const payload = PAYLOADS[i];
+
+  // Upload via upload.mjs (reads payload from stdin).
+  let uploadStdout;
+  try {
+    uploadStdout = execFileSync("node", [uploadScript], { input: payload, env });
+  } catch (e) {
+    process.stderr.write(`Payload ${i}: upload failed: ${e.message}\n`);
+    allOk = false;
+    continue;
+  }
+
+  let rootHash;
+  try {
+    ({ rootHash } = JSON.parse(uploadStdout.toString().trim()));
+  } catch {
+    process.stderr.write(
+      `Payload ${i}: upload output is not valid JSON: ${uploadStdout}\n`,
+    );
+    allOk = false;
+    continue;
+  }
+
+  // Download via download.mjs (writes raw bytes to stdout).
+  let downloaded;
+  try {
+    downloaded = execFileSync("node", [downloadScript, rootHash], { env });
+  } catch (e) {
+    process.stderr.write(`Payload ${i}: download failed: ${e.message}\n`);
+    allOk = false;
+    continue;
+  }
+
+  // Assert byte-for-byte equality.
+  if (!downloaded.equals(payload)) {
+    process.stderr.write(
+      `Payload ${i}: MISMATCH\n` +
+        `  expected: ${payload.toString("hex")}\n` +
+        `  got:      ${downloaded.toString("hex")}\n`,
+    );
+    allOk = false;
+  } else {
+    process.stdout.write(`Payload ${i}: OK (rootHash ${rootHash})\n`);
+  }
+}
+
+if (!allOk) process.exit(1);
+process.stdout.write("OK\n");


### PR DESCRIPTION
Adds a self-contained Hardhat localhost dev mode with MockOgStorage standing in for 0G Storage. Engineers can now iterate with `pnpm exec hardhat node` and make zero 0G testnet calls.

Closes #11

Generated with [Claude Code](https://claude.ai/code)