### PR TITLE
Phase 21: ENS name chooser — auto-shown claim form, label validation, fallback suggestion

### DIFF
--- a/frontend/app/ProfileBadge.tsx
+++ b/frontend/app/ProfileBadge.tsx
@@ -1,12 +1,11 @@
-// Phase 15: connected-wallet identity badge.
+// Phase 21: ENS name selection UX improvements.
 //
-// Three states:
-//   1. Looking up name → "…"
-//   2. No subname → shortened address + "Claim name" inline form. Submitting
-//      POSTs to the server's /subname/mint (the server is the registrar
-//      owner and signs `mintSubname` on the user's behalf).
-//   3. Subname found → "<label>.chaingammon.eth (1547)" with the ELO
-//      pulled from the registrar's `elo` text record (Phase 11 writes it).
+// ClaimForm is now shown automatically when a connected wallet has no
+// chaingammon.eth subname — no extra "Claim name" button click required.
+// Input is validated against ENS label rules (lowercase alphanumeric +
+// hyphens, 1-63 chars). If the chosen name is already taken the component
+// surfaces a fallback suggestion (<label><3-digit suffix>) so the user
+// can claim a name without starting over.
 "use client";
 
 import { useState } from "react";
@@ -20,14 +19,145 @@ function shorten(addr: string) {
   return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
 }
 
-export function ProfileBadge({ address }: { address: `0x${string}` }) {
-  const { label, name, isLoading: nameLoading } = useChaingammonName(address);
-  const { elo } = useChaingammonProfile(label);
+/** ENS label rules: starts/ends with alphanumeric, only a-z 0-9 and hyphens, 1–63 chars. */
+function isValidLabel(s: string): boolean {
+  return s.length >= 1 && s.length <= 63 && /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(s);
+}
 
-  const [showClaim, setShowClaim] = useState(false);
+/** Returns a human-readable validation problem, or null if the label is valid. */
+function labelValidationMessage(s: string): string | null {
+  if (!s) return null;
+  if (s.length > 63) return "Name must be 63 characters or fewer.";
+  if (!/^[a-z0-9]/.test(s)) return "Name must start with a letter or number.";
+  if (s.endsWith("-")) return "Name cannot end with a hyphen.";
+  if (!/^[a-z0-9-]+$/.test(s)) return "Only lowercase letters, numbers, and hyphens allowed.";
+  return null;
+}
+
+/** Deterministic-ish 3-digit suffix for fallback name suggestions. */
+function randomSuffix(): string {
+  return String(Math.floor(Math.random() * 900) + 100);
+}
+
+/**
+ * Standalone claim form — shown automatically when the wallet has no subname.
+ * Exported separately so a test fixture page can render it without the
+ * name-lookup hooks that ProfileBadge wraps around it.
+ */
+export function ClaimForm({ address }: { address: `0x${string}` }) {
   const [claimInput, setClaimInput] = useState("");
   const [claiming, setClaiming] = useState(false);
   const [claimError, setClaimError] = useState<string | null>(null);
+  const [suggestion, setSuggestion] = useState<string | null>(null);
+
+  const submit = async (labelToUse?: string) => {
+    const trimmed = (labelToUse ?? claimInput).trim();
+    if (!trimmed || !isValidLabel(trimmed)) return;
+    setClaiming(true);
+    setClaimError(null);
+    setSuggestion(null);
+    try {
+      const res = await fetch(`${API_URL}/subname/mint`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label: trimmed, owner_address: address }),
+      });
+      if (!res.ok) {
+        const detail = await res.text().catch(() => res.statusText);
+        // 409 = name already taken; surface a fallback suggestion.
+        if (res.status === 409 || detail.toLowerCase().includes("already taken")) {
+          const fallback = `${trimmed}${randomSuffix()}`;
+          setSuggestion(fallback);
+          throw new Error(`"${trimmed}" is already taken.`);
+        }
+        throw new Error(detail);
+      }
+      // Reload so every component re-runs its log scan and re-fetches text
+      // records. The subname doesn't show up via wagmi's cache otherwise.
+      window.location.reload();
+    } catch (e: unknown) {
+      setClaimError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setClaiming(false);
+    }
+  };
+
+  const validationError = claimInput ? labelValidationMessage(claimInput) : null;
+  const canSubmit = !claiming && isValidLabel(claimInput);
+
+  return (
+    <div data-testid="profile-badge" className="flex flex-col items-end gap-1">
+      <div className="flex items-center gap-1.5">
+        <input
+          data-testid="ens-claim-input"
+          value={claimInput}
+          onChange={(e) => {
+            // Auto-lowercase so users don't need to think about casing.
+            setClaimInput(e.target.value.toLowerCase());
+            setClaimError(null);
+            setSuggestion(null);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") submit();
+          }}
+          placeholder="your-name"
+          className="h-8 w-32 rounded-md border border-zinc-300 bg-white px-2 font-mono text-sm text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-50"
+          disabled={claiming}
+          autoFocus
+        />
+        <span
+          data-testid="ens-suffix"
+          className="font-mono text-xs text-zinc-500 dark:text-zinc-400"
+        >
+          .chaingammon.eth
+        </span>
+        <button
+          data-testid="ens-claim-button"
+          type="button"
+          onClick={() => submit()}
+          disabled={!canSubmit}
+          className="h-8 rounded-md bg-indigo-600 px-3 text-xs font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+        >
+          {claiming ? "Claiming…" : "Claim"}
+        </button>
+      </div>
+
+      {validationError ? (
+        <span
+          data-testid="ens-validation-error"
+          className="max-w-xs text-right text-xs text-amber-600 dark:text-amber-400"
+        >
+          {validationError}
+        </span>
+      ) : null}
+
+      {claimError ? (
+        <div className="flex flex-col items-end gap-0.5">
+          <span className="max-w-xs text-right text-xs text-red-600 dark:text-red-400">
+            {claimError}
+          </span>
+          {suggestion ? (
+            <button
+              data-testid="ens-suggestion-button"
+              type="button"
+              onClick={() => {
+                setClaimInput(suggestion);
+                submit(suggestion);
+              }}
+              className="text-xs text-indigo-600 hover:underline dark:text-indigo-400"
+            >
+              Try &ldquo;{suggestion}.chaingammon.eth&rdquo; instead
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function ProfileBadge({ address }: { address: `0x${string}` }) {
+  const { label, name, isLoading: nameLoading } = useChaingammonName(address);
+  const { elo } = useChaingammonProfile(label);
 
   if (nameLoading) {
     return (
@@ -54,78 +184,6 @@ export function ProfileBadge({ address }: { address: `0x${string}` }) {
     );
   }
 
-  if (showClaim) {
-    const submit = async () => {
-      const trimmed = claimInput.trim();
-      if (!trimmed) return;
-      setClaiming(true);
-      setClaimError(null);
-      try {
-        const res = await fetch(`${API_URL}/subname/mint`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ label: trimmed, owner_address: address }),
-        });
-        if (!res.ok) {
-          const detail = await res.text().catch(() => res.statusText);
-          throw new Error(detail);
-        }
-        // Reload so every component re-runs its log scan and re-fetches text
-        // records. The subname doesn't show up via wagmi's cache otherwise.
-        window.location.reload();
-      } catch (e: unknown) {
-        setClaimError(e instanceof Error ? e.message : String(e));
-      } finally {
-        setClaiming(false);
-      }
-    };
-    return (
-      <div data-testid="profile-badge" className="flex flex-col items-end gap-1">
-        <div className="flex items-center gap-1.5">
-          <input
-            value={claimInput}
-            onChange={(e) => setClaimInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") submit();
-            }}
-            placeholder="alice"
-            className="h-8 w-32 rounded-md border border-zinc-300 bg-white px-2 font-mono text-sm text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-50"
-            disabled={claiming}
-            autoFocus
-          />
-          <span className="font-mono text-xs text-zinc-500 dark:text-zinc-400">
-            .chaingammon.eth
-          </span>
-          <button
-            type="button"
-            onClick={submit}
-            disabled={claiming || !claimInput.trim()}
-            className="h-8 rounded-md bg-indigo-600 px-3 text-xs font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
-          >
-            {claiming ? "Claiming…" : "Claim"}
-          </button>
-        </div>
-        {claimError ? (
-          <span className="max-w-xs text-right text-xs text-red-600 dark:text-red-400">
-            {claimError}
-          </span>
-        ) : null}
-      </div>
-    );
-  }
-
-  return (
-    <div data-testid="profile-badge" className="flex items-center gap-2">
-      <span className="font-mono text-sm text-zinc-700 dark:text-zinc-300">
-        {shorten(address)}
-      </span>
-      <button
-        type="button"
-        onClick={() => setShowClaim(true)}
-        className="inline-flex h-8 items-center rounded-full border border-zinc-300 px-3 text-xs font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900"
-      >
-        Claim name
-      </button>
-    </div>
-  );
+  // No subname — show the claim form immediately; no extra button click needed.
+  return <ClaimForm address={address} />;
 }

--- a/frontend/app/test-ens-claim/page.tsx
+++ b/frontend/app/test-ens-claim/page.tsx
@@ -1,0 +1,16 @@
+// Phase 21: fixture page for Playwright ENS-name-claim validation tests.
+//
+// Renders ClaimForm in isolation with a hard-coded test address so the
+// Playwright suite can assert validation messages and button states without
+// needing a live wallet or a blockchain connection.
+import { ClaimForm } from "../ProfileBadge";
+
+const TEST_ADDRESS = "0x1111111111111111111111111111111111111111" as const;
+
+export default function TestEnsClaimPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-8">
+      <ClaimForm address={TEST_ADDRESS} />
+    </div>
+  );
+}

--- a/frontend/tests/ens-name-claim.spec.ts
+++ b/frontend/tests/ens-name-claim.spec.ts
@@ -1,0 +1,64 @@
+// Phase 21: ENS name-claim form validation tests.
+//
+// Renders ClaimForm via the /test-ens-claim fixture page (no wallet / no
+// blockchain connection needed) and asserts:
+//   - the input + ".chaingammon.eth" suffix + Claim button are all visible
+//   - the Claim button is disabled when the input is empty
+//   - inline validation messages fire for invalid labels
+//   - the Claim button becomes enabled for a valid label
+
+import { test, expect } from "@playwright/test";
+
+test.describe("ENS name-claim form", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/test-ens-claim");
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("renders input, suffix, and Claim button", async ({ page }) => {
+    await expect(page.getByTestId("ens-claim-input")).toBeVisible();
+    await expect(page.getByTestId("ens-suffix")).toBeVisible();
+    await expect(page.getByTestId("ens-suffix")).toHaveText(".chaingammon.eth");
+    await expect(page.getByTestId("ens-claim-button")).toBeVisible();
+  });
+
+  test("Claim button is disabled when input is empty", async ({ page }) => {
+    await expect(page.getByTestId("ens-claim-button")).toBeDisabled();
+  });
+
+  test("shows validation error for label starting with hyphen", async ({ page }) => {
+    await page.getByTestId("ens-claim-input").fill("-bad");
+    await expect(page.getByTestId("ens-validation-error")).toBeVisible();
+    await expect(page.getByTestId("ens-claim-button")).toBeDisabled();
+  });
+
+  test("shows validation error for label ending with hyphen", async ({ page }) => {
+    await page.getByTestId("ens-claim-input").fill("bad-");
+    await expect(page.getByTestId("ens-validation-error")).toBeVisible();
+    await expect(page.getByTestId("ens-claim-button")).toBeDisabled();
+  });
+
+  test("shows validation error for label with special characters", async ({
+    page,
+  }) => {
+    await page.getByTestId("ens-claim-input").fill("bad_name");
+    await expect(page.getByTestId("ens-validation-error")).toBeVisible();
+    await expect(page.getByTestId("ens-claim-button")).toBeDisabled();
+  });
+
+  test("auto-lowercases input", async ({ page }) => {
+    await page.getByTestId("ens-claim-input").fill("Alice");
+    await expect(page.getByTestId("ens-claim-input")).toHaveValue("alice");
+  });
+
+  test("enables Claim button for a valid label", async ({ page }) => {
+    await page.getByTestId("ens-claim-input").fill("alice");
+    await expect(page.getByTestId("ens-validation-error")).not.toBeVisible();
+    await expect(page.getByTestId("ens-claim-button")).toBeEnabled();
+  });
+
+  test("enables Claim button for a label with hyphens", async ({ page }) => {
+    await page.getByTestId("ens-claim-input").fill("alice-bob");
+    await expect(page.getByTestId("ens-claim-button")).toBeEnabled();
+  });
+});

--- a/log.md
+++ b/log.md
@@ -1100,3 +1100,39 @@ Tests (**agent/tests/test_coach_service.py**, updated, +1 test):
 27 agent tests pass (17 prior + 10 new). Frontend type-checks clean (`pnpm exec tsc --noEmit`). Smoke-tested both legs of the toggle on a live coach service: `backend: "local"` request returns a hint with zero 0G markers in the log; `backend: "compute"` request attempts the 0G path and falls back to local when the wallet/env is unavailable.
 
 Live 0G Compute path (Qwen 2.5 7B at provider `0xa48f01287233509FD694a22Bf840225062E67836`) is reachable from the bridge but requires the wallet at `0xa2219C4f48bC9e6806Bce3B391aB9e23f55FEbb5` to be funded above the testnet ledger's minimum (`addLedger(0.05 OG)` reverts at the current 0.099 OG balance). Once topped up via the 0G faucet, no code changes are needed — the next `/hint` with `backend: "compute"` mints the ledger and routes to Qwen.
+
+---
+
+### Phase 21 — ENS name selection UX ✅
+
+Phase 21: ENS name chooser — auto-shown claim form, label validation, fallback suggestion
+
+The `ClaimForm` in `ProfileBadge` previously required a "Claim name" button click before the name-entry field appeared. This phase surfaces the form immediately on wallet connect (no extra click), enforces ENS label rules client- and server-side, and suggests a fallback name when the chosen name is already taken.
+
+ClaimForm (**frontend/app/ProfileBadge.tsx**, updated):
+- `ClaimForm` is now a named export so the Playwright fixture page can render it without wallet hooks.
+- `isValidLabel(s)` — returns true when `s` matches `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$` and is ≤ 63 chars; mirrors the server-side `_LABEL_RE`.
+- `labelValidationMessage(s)` — returns a human-readable problem string (start/end with hyphen, bad chars, too long) or `null` when the label is valid; shown as an amber inline hint below the input.
+- `randomSuffix()` — generates a 3-digit numeric string for fallback suggestions.
+- Input auto-lowercases via `onChange` so users never need to think about casing.
+- On a 409 response or a "already taken" server message, `suggestion` state is set to `<label><suffix>`; a "Try … instead" button appears that sets the input and re-submits in one click.
+- `data-testid` attributes added to input, suffix span, Claim button, validation-error span, and suggestion button so Playwright can locate them without fragile CSS selectors.
+- `ProfileBadge` no longer has a `showClaim` state; it renders `<ClaimForm address={address} />` directly when no subname label is found.
+
+Server (**server/app/main.py**, updated):
+- `import re` added; `_LABEL_RE` pattern defined at module level.
+- `mint_subname` now lowercases the incoming label, validates length (≤ 63) and `_LABEL_RE` before touching the chain, returning HTTP 400 with a descriptive message on violation.
+- Pre-availability check: calls `ens.owner_of(node)` before minting; returns HTTP 409 `"label already taken"` when the node is already owned. This avoids a wasted on-chain transaction and gives the frontend a clean status code to branch on for the fallback UX.
+
+Test fixture (**frontend/app/test-ens-claim/page.tsx**, new):
+- Renders `ClaimForm` with a hard-coded test address so Playwright can exercise validation without a wallet or live chain.
+
+Tests (**frontend/tests/ens-name-claim.spec.ts**, new, 7 tests):
+- Claim button disabled when input is empty.
+- Input + `.chaingammon.eth` suffix + Claim button all visible.
+- Validation error shown and button disabled for labels starting with hyphen, ending with hyphen, or containing underscores.
+- Input auto-lowercases uppercase characters.
+- Claim button enabled for a valid lowercase label.
+- Claim button enabled for a label containing a hyphen.
+
+27 agent tests unchanged. Frontend type-check clean.

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -5,7 +5,13 @@ from pydantic import BaseModel
 from typing import Dict, Optional
 import json
 import os
+import re
 import uuid
+
+# ENS label rules: lowercase alphanumeric + hyphens, must start and end with
+# an alphanumeric char, 1–63 characters.  Mirrors the validation in the
+# frontend's ProfileBadge so both layers agree on what is acceptable.
+_LABEL_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 
 from .agent_overlay import Overlay, OverlayError, apply_overlay, update_overlay
 from .chain_client import ChainClient, ChainError
@@ -332,18 +338,36 @@ class MintSubnameResponse(BaseModel):
 
 @app.post("/subname/mint", response_model=MintSubnameResponse)
 def mint_subname(req: MintSubnameRequest):
-    if not req.label.strip():
+    # Phase 21: validate label against ENS rules before hitting the chain.
+    label = req.label.strip().lower()
+    if not label:
         raise HTTPException(status_code=400, detail="label cannot be empty")
+    if len(label) > 63:
+        raise HTTPException(status_code=400, detail="label must be 63 characters or fewer")
+    if not _LABEL_RE.match(label):
+        raise HTTPException(
+            status_code=400,
+            detail="label must contain only lowercase letters, numbers, and hyphens, "
+            "and cannot start or end with a hyphen",
+        )
     try:
         ens = EnsClient.from_env()
     except EnsError as e:
         raise HTTPException(status_code=500, detail=f"ens client misconfigured: {e}") from e
+    # Pre-check: ownerOf returns the zero address for unclaimed subnames.
     try:
-        tx_hash = ens.mint_subname(req.label, req.owner_address)
-        node = ens.subname_node(req.label)
+        node = ens.subname_node(label)
+        owner = ens.owner_of(node)
+    except EnsError as e:
+        raise HTTPException(status_code=502, detail=f"availability check failed: {e}") from e
+    _ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+    if owner and owner.lower() != _ZERO_ADDRESS:
+        raise HTTPException(status_code=409, detail="label already taken")
+    try:
+        tx_hash = ens.mint_subname(label, req.owner_address)
     except EnsError as e:
         raise HTTPException(status_code=502, detail=f"mintSubname failed: {e}") from e
-    return MintSubnameResponse(label=req.label, node=node, tx_hash=tx_hash)
+    return MintSubnameResponse(label=label, node=node, tx_hash=tx_hash)
 
 
 class FinalizeRequest(BaseModel):


### PR DESCRIPTION
Implements #issue-12: allow users to choose their ENS name in the chaingammon.eth subnet.

**Changes:**
- Claim form auto-shows on wallet connect (no extra button click)
- ENS label validation (lowercase, alphanumeric + hyphens, ≤ 63 chars)
- Fallback suggestion when name is already taken (409)
- Server-side label validation + pre-availability check
- 7 new Playwright tests

Closes #12

Generated with [Claude Code](https://claude.ai/code)