### PR TITLE
Phase 27: clickable board — click-to-move UI

### DIFF
--- a/frontend/app/Board.tsx
+++ b/frontend/app/Board.tsx
@@ -1,4 +1,4 @@
-// Phase 14: visual backgammon board.
+// Phase 14: visual backgammon board. Phase 27: click-to-move interaction.
 //
 // Layout (from player 0 / human's perspective):
 //   Top row  — points 13..24 left→right (player 0 enters at 24, moves left)
@@ -10,12 +10,24 @@
 //
 // bar[0] = player 0 checkers on bar, bar[1] = player 1 checkers on bar.
 // off[0] = player 0 borne off, off[1] = player 1 borne off.
+//
+// Phase 27 additions:
+//   onPointClick(n) — called when the user clicks a point column (1-24).
+//   onBarClick()    — called when the user clicks the bar zone.
+//   onOffClick()    — called when the user clicks the bear-off button.
+//   selectedPoint   — highlights the currently-selected source (1-24 or 25=bar).
+//   data-point / data-count attributes on every PointCell for Playwright selectors.
 
 interface BoardProps {
   board: number[]; // length 24; index = point - 1
   bar: number[]; // [p0_bar, p1_bar]
   off: number[]; // [p0_off, p1_off]
   turn: number; // 0 = human, 1 = agent
+  // Click-to-move (all optional — Board is a pure visual component when omitted).
+  onPointClick?: (point: number) => void;
+  onBarClick?: () => void;
+  onOffClick?: () => void;
+  selectedPoint?: number | null; // 1-24 = board point, 25 = bar
 }
 
 // Maximum checkers shown as dots before falling back to a "+N" label.
@@ -25,9 +37,11 @@ interface PointProps {
   point: number; // 1-indexed point number
   count: number; // signed: positive = p0, negative = p1
   flip?: boolean; // true for top row (dots grow downward)
+  onClick?: () => void;
+  isSelected?: boolean;
 }
 
-function PointCell({ point, count, flip = false }: PointProps) {
+function PointCell({ point, count, flip = false, onClick, isSelected }: PointProps) {
   const abs = Math.abs(count);
   const isP0 = count > 0;
   const dotsToShow = Math.min(abs, MAX_DOTS);
@@ -53,15 +67,27 @@ function PointCell({ point, count, flip = false }: PointProps) {
     </span>
   );
 
+  const classes = [
+    "flex flex-col items-center gap-0.5",
+    onClick ? "cursor-pointer hover:opacity-75" : "",
+    isSelected
+      ? "rounded bg-amber-100 ring-1 ring-amber-400 dark:bg-amber-900/30"
+      : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <div
-      // data-testid is keyed by zero-based index so Playwright can read
-      // a point cell directly: `[data-testid="point-0"]` for point 1,
-      // `[data-testid="point-23"]` for point 24. Keeps the test
-      // selector stable across renders.
+      // data-testid keyed by zero-based index for match-board-state.spec.ts.
+      // data-point / data-count are 1-indexed signed attrs for piece-stability.spec.ts.
       data-testid={`point-${point - 1}`}
-      className="flex flex-col items-center gap-0.5"
+      data-point={point}
+      data-count={count}
+      data-selected={isSelected ? "true" : undefined}
+      className={classes}
       style={{ width: 24 }}
+      onClick={onClick}
     >
       {/* Point label */}
       {!flip && (
@@ -90,9 +116,26 @@ function PointCell({ point, count, flip = false }: PointProps) {
   );
 }
 
-function BarCell({ p0Bar, p1Bar }: { p0Bar: number; p1Bar: number }) {
+interface BarCellProps {
+  p0Bar: number;
+  p1Bar: number;
+  onBarClick?: () => void;
+  isBarSelected?: boolean;
+}
+
+function BarCell({ p0Bar, p1Bar, onBarClick, isBarSelected }: BarCellProps) {
+  const classes = [
+    "flex w-8 flex-col items-center justify-center gap-1 border-x border-zinc-300 dark:border-zinc-600",
+    onBarClick ? "cursor-pointer hover:opacity-75" : "",
+    isBarSelected
+      ? "bg-amber-100 ring-1 ring-amber-400 dark:bg-amber-900/30"
+      : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <div className="flex w-8 flex-col items-center justify-center gap-1 border-x border-zinc-300 dark:border-zinc-600">
+    <div className={classes} onClick={onBarClick}>
       {p1Bar > 0 && (
         <div className="flex flex-col items-center gap-0.5">
           {Array.from({ length: Math.min(p1Bar, 3) }, (_, i) => (
@@ -130,7 +173,16 @@ function BarCell({ p0Bar, p1Bar }: { p0Bar: number; p1Bar: number }) {
   );
 }
 
-export function Board({ board, bar, off, turn }: BoardProps) {
+export function Board({
+  board,
+  bar,
+  off,
+  turn,
+  onPointClick,
+  onBarClick,
+  onOffClick,
+  selectedPoint,
+}: BoardProps) {
   // Top row: points 13–24 (indices 12–23), displayed left→right.
   const topPoints = Array.from({ length: 12 }, (_, i) => i + 13); // [13..24]
   // Bottom row: points 12–1 (indices 11–0), displayed left→right (12 down to 1).
@@ -157,15 +209,24 @@ export function Board({ board, bar, off, turn }: BoardProps) {
                 point={pt}
                 count={board[pt - 1]}
                 flip={true}
+                onClick={onPointClick ? () => onPointClick(pt) : undefined}
+                isSelected={selectedPoint === pt}
               />
             ))}
-            <BarCell p0Bar={bar[0]} p1Bar={bar[1]} />
+            <BarCell
+              p0Bar={bar[0]}
+              p1Bar={bar[1]}
+              onBarClick={onBarClick}
+              isBarSelected={selectedPoint === 25}
+            />
             {topPoints.slice(6).map((pt) => (
               <PointCell
                 key={pt}
                 point={pt}
                 count={board[pt - 1]}
                 flip={true}
+                onClick={onPointClick ? () => onPointClick(pt) : undefined}
+                isSelected={selectedPoint === pt}
               />
             ))}
           </div>
@@ -181,6 +242,8 @@ export function Board({ board, bar, off, turn }: BoardProps) {
                 point={pt}
                 count={board[pt - 1]}
                 flip={false}
+                onClick={onPointClick ? () => onPointClick(pt) : undefined}
+                isSelected={selectedPoint === pt}
               />
             ))}
             <div className="flex w-8 items-center justify-center">
@@ -192,11 +255,25 @@ export function Board({ board, bar, off, turn }: BoardProps) {
                 point={pt}
                 count={board[pt - 1]}
                 flip={false}
+                onClick={onPointClick ? () => onPointClick(pt) : undefined}
+                isSelected={selectedPoint === pt}
               />
             ))}
           </div>
         </div>
       </div>
+
+      {/* Bear-off button — shown only when a source checker is selected */}
+      {onOffClick && (
+        <button
+          type="button"
+          onClick={onOffClick}
+          aria-label="Bear off selected checker"
+          className="self-start rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-100 dark:border-zinc-600 dark:text-zinc-400 dark:hover:bg-zinc-800"
+        >
+          Bear off →
+        </button>
+      )}
 
       {/* Off-board checkers */}
       <div className="flex gap-6 text-sm text-zinc-600 dark:text-zinc-400">

--- a/frontend/app/match/page.tsx
+++ b/frontend/app/match/page.tsx
@@ -175,6 +175,10 @@ function MatchInner() {
   const [loading, setLoading] = useState(false);
   const [moveInput, setMoveInput] = useState("");
 
+  // Phase 27: click-to-move state.
+  // null = no checker selected, 1-24 = board point, 25 = bar (player 0).
+  const [selectedSource, setSelectedSource] = useState<number | null>(null);
+
   // Coach state — best-effort; failures leave hint null.
   const [coachHint, setCoachHint] = useState<string | null>(null);
   const [coachLoading, setCoachLoading] = useState(false);
@@ -312,10 +316,59 @@ function MatchInner() {
 
   // ── Human actions ──────────────────────────────────────────────────────
 
+  // Clear click selection whenever it is no longer the human's turn.
+  useEffect(() => {
+    if (!game || game.turn !== 0) setSelectedSource(null);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [game?.turn]);
+
+  /**
+   * Handle a click on a board point (Phase 27 click-to-move).
+   *
+   * First click: selects the point as the move source (only valid if the point
+   * has a player-0 checker and player-0 has no checkers on the bar).
+   * Second click on the same point: deselects.
+   * Second click on a different point: appends "from/to" to the move input and
+   * clears the selection so the user can start the next checker move.
+   */
+  const handlePointClick = (point: number) => {
+    // needsMove = !!game.dice && game.turn === 0
+    if (!game || !game.dice || game.turn !== 0) return;
+
+    if (selectedSource === null) {
+      // Player 0 must clear the bar before moving board checkers.
+      if (game.bar[0] > 0) return;
+      if (game.board[point - 1] > 0) setSelectedSource(point);
+    } else if (selectedSource === point) {
+      setSelectedSource(null); // deselect
+    } else {
+      const from = selectedSource === 25 ? "bar" : String(selectedSource);
+      const seg = `${from}/${point}`;
+      setMoveInput((prev) => (prev.trim() ? `${prev.trim()} ${seg}` : seg));
+      setSelectedSource(null);
+    }
+  };
+
+  /** Click the bar zone to select it as the move source (enter from bar). */
+  const handleBarClick = () => {
+    if (!game || !game.dice || game.turn !== 0 || game.bar[0] === 0) return;
+    setSelectedSource(25);
+  };
+
+  /** Click the bear-off zone when a source is already selected. */
+  const handleOffClick = () => {
+    if (!game || !game.dice || game.turn !== 0 || selectedSource === null) return;
+    const from = selectedSource === 25 ? "bar" : String(selectedSource);
+    const seg = `${from}/off`;
+    setMoveInput((prev) => (prev.trim() ? `${prev.trim()} ${seg}` : seg));
+    setSelectedSource(null);
+  };
+
   const doMove = async () => {
     if (!game || !moveInput.trim() || !game.dice) return;
     setLoading(true);
     setError(null);
+    setSelectedSource(null);
     try {
       const next = await gnubgPost<MatchState>("/apply", {
         position_id: game.position_id,
@@ -452,6 +505,10 @@ function MatchInner() {
           bar={game.bar}
           off={game.off}
           turn={game.turn}
+          onPointClick={needsMove ? handlePointClick : undefined}
+          onBarClick={needsMove ? handleBarClick : undefined}
+          onOffClick={needsMove && selectedSource !== null ? handleOffClick : undefined}
+          selectedPoint={selectedSource}
         />
 
         {game.dice && (
@@ -471,6 +528,14 @@ function MatchInner() {
 
         {!game.game_over && isHumanTurn && needsMove && (
           <div className="flex flex-col gap-3">
+            {/* Click-to-move instruction */}
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">
+              <span className="font-medium text-zinc-700 dark:text-zinc-300">Click</span>{" "}
+              a blue checker to select it (amber highlight), then click a destination
+              point. Repeat for each checker. Use the{" "}
+              <span className="font-medium text-zinc-700 dark:text-zinc-300">Bear off →</span>{" "}
+              button when bearing off. Or type the notation directly below.
+            </p>
             <div className="flex gap-2">
               <input
                 value={moveInput}
@@ -479,6 +544,19 @@ function MatchInner() {
                 placeholder='e.g. "8/5 6/5" or "off"'
                 className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 font-mono text-sm text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-50"
               />
+              {/* Reset clears both the typed/built notation and any click selection */}
+              {(moveInput.trim() || selectedSource !== null) && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setMoveInput("");
+                    setSelectedSource(null);
+                  }}
+                  className="rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-500 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800"
+                >
+                  Reset
+                </button>
+              )}
               <button
                 onClick={doMove}
                 disabled={loading || !moveInput.trim()}
@@ -487,11 +565,6 @@ function MatchInner() {
                 {loading ? "…" : "Move"}
               </button>
             </div>
-            <p className="text-xs text-zinc-400 dark:text-zinc-500">
-              Notation: <code className="font-mono">from/to</code> per checker,
-              space-separated. Bar: <code className="font-mono">bar/N</code>.
-              Bear-off: <code className="font-mono">N/off</code>.
-            </p>
           </div>
         )}
 

--- a/frontend/tests/board-click-moves.spec.ts
+++ b/frontend/tests/board-click-moves.spec.ts
@@ -1,0 +1,204 @@
+// Phase 27: click-to-move regression coverage.
+//
+// Drives /match?agentId=1 against mocked gnubg_service endpoints and
+// verifies that:
+//   1. Clicking a blue checker selects it (data-selected="true").
+//   2. Clicking a destination point appends the "from/to" segment to the
+//      move input, so the existing Move button can submit the full notation.
+//   3. Clicking the same source twice deselects it.
+//   4. Multiple click pairs accumulate into a space-separated notation
+//      string identical to what a user would type by hand.
+//
+// The text input and Move button are left unchanged (backward-compatible)
+// so all pre-existing tests continue to exercise the same paths.
+
+import { test, expect, type Route } from "@playwright/test";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+// Standard backgammon opening position.
+// Blue (player 0) at points 6(5), 8(3), 13(5), 24(2).
+// Red  (player 1) at points 1(2), 12(5), 17(3), 19(5).
+const OPENING_BOARD = [
+  -2, 0, 0, 0, 0, 5, 0, 3, 0, 0, 0, -5,
+  5, 0, 0, 0, -3, 0, -5, 0, 0, 0, 0, 2,
+];
+
+function makeState(
+  board: number[],
+  turn: 0 | 1 = 0,
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    position_id: "click_pos",
+    match_id: "click_mid",
+    board,
+    bar: [0, 0],
+    off: [0, 0],
+    turn,
+    dice: null,
+    score: [0, 0],
+    match_length: 3,
+    game_over: false,
+    winner: null,
+    ...extra,
+  };
+}
+
+const fulfill = (route: Route, body: unknown) =>
+  route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+
+// ── Shared route setup ────────────────────────────────────────────────────────
+
+/** Wire up the four gnubg_service routes that every match-page test needs. */
+async function setupRoutes(
+  page: import("@playwright/test").Page,
+  opts: {
+    applyCallback?: (body: Record<string, unknown>) => unknown;
+  } = {},
+) {
+  await page.route("**/new", async (route) => {
+    await fulfill(route, makeState(OPENING_BOARD, 0));
+  });
+
+  await page.route("**/apply", async (route) => {
+    const raw = route.request().postData() ?? "{}";
+    const body = JSON.parse(raw) as Record<string, unknown>;
+    const responseBody = opts.applyCallback
+      ? opts.applyCallback(body)
+      : makeState(OPENING_BOARD, 1);
+    await fulfill(route, responseBody);
+  });
+
+  await page.route("**/move", async (route) => {
+    await fulfill(route, { move: "13/10 13/11", candidates: [] });
+  });
+
+  await page.route("**/resign", async (route) => {
+    await fulfill(route, makeState(OPENING_BOARD, 0, { game_over: true, winner: 1 }));
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test("clicking a blue checker selects it (amber highlight via data-selected)", async ({
+  page,
+}) => {
+  await setupRoutes(page);
+  await page.goto("/match?agentId=1");
+
+  // Wait for the board to render the opening position.
+  await expect(page.locator("[data-point='8']")).toBeVisible({ timeout: 10_000 });
+
+  // Point 8 has 3 blue checkers in the opening — it should be clickable.
+  await page.locator("[data-point='8']").click();
+
+  // The PointCell sets data-selected="true" when it is the selected source.
+  await expect(page.locator("[data-point='8']")).toHaveAttribute(
+    "data-selected",
+    "true",
+  );
+});
+
+test("clicking same point twice deselects it", async ({ page }) => {
+  await setupRoutes(page);
+  await page.goto("/match?agentId=1");
+
+  await expect(page.locator("[data-point='8']")).toBeVisible({ timeout: 10_000 });
+
+  // First click: select.
+  await page.locator("[data-point='8']").click();
+  await expect(page.locator("[data-point='8']")).toHaveAttribute("data-selected", "true");
+
+  // Second click: deselect.
+  await page.locator("[data-point='8']").click();
+  await expect(page.locator("[data-point='8']")).not.toHaveAttribute("data-selected");
+});
+
+test("two click pairs build '8/5 6/5' in the move input", async ({ page }) => {
+  await setupRoutes(page);
+  await page.goto("/match?agentId=1");
+
+  await expect(page.locator("[data-point='8']")).toBeVisible({ timeout: 10_000 });
+
+  // First checker: point 8 → point 5.
+  await page.locator("[data-point='8']").click();
+  await expect(page.locator("[data-point='8']")).toHaveAttribute("data-selected", "true");
+  await page.locator("[data-point='5']").click();
+
+  // After the first pair, input shows "8/5" and nothing is selected.
+  const moveInput = page.getByPlaceholder('e.g. "8/5 6/5" or "off"');
+  await expect(moveInput).toHaveValue("8/5");
+  await expect(page.locator("[data-point='8']")).not.toHaveAttribute("data-selected");
+
+  // Second checker: point 6 → point 5.
+  await page.locator("[data-point='6']").click();
+  await expect(page.locator("[data-point='6']")).toHaveAttribute("data-selected", "true");
+  await page.locator("[data-point='5']").click();
+
+  // Input now accumulates "8/5 6/5".
+  await expect(moveInput).toHaveValue("8/5 6/5");
+});
+
+test("click-built notation is submitted via the Move button to /apply", async ({
+  page,
+}) => {
+  let capturedMove = "";
+
+  await setupRoutes(page, {
+    applyCallback: (body) => {
+      capturedMove = String(body.move ?? "");
+      return makeState(OPENING_BOARD, 1);
+    },
+  });
+
+  await page.goto("/match?agentId=1");
+  await expect(page.locator("[data-point='8']")).toBeVisible({ timeout: 10_000 });
+
+  // Build "8/5 6/5" by clicking.
+  await page.locator("[data-point='8']").click();
+  await page.locator("[data-point='5']").click();
+  await page.locator("[data-point='6']").click();
+  await page.locator("[data-point='5']").click();
+
+  const moveInput = page.getByPlaceholder('e.g. "8/5 6/5" or "off"');
+  await expect(moveInput).toHaveValue("8/5 6/5");
+
+  // Submit via the Move button.
+  await page.getByRole("button", { name: "Move" }).click();
+
+  // /apply must receive the click-assembled notation exactly.
+  await expect
+    .poll(() => capturedMove, { timeout: 5_000 })
+    .toBe("8/5 6/5");
+});
+
+test("Reset button clears the assembled notation and deselects any source", async ({
+  page,
+}) => {
+  await setupRoutes(page);
+  await page.goto("/match?agentId=1");
+
+  await expect(page.locator("[data-point='8']")).toBeVisible({ timeout: 10_000 });
+
+  // Build one segment.
+  await page.locator("[data-point='8']").click();
+  await page.locator("[data-point='5']").click();
+
+  const moveInput = page.getByPlaceholder('e.g. "8/5 6/5" or "off"');
+  await expect(moveInput).toHaveValue("8/5");
+
+  // Select a second source to leave a pending selection.
+  await page.locator("[data-point='6']").click();
+  await expect(page.locator("[data-point='6']")).toHaveAttribute("data-selected", "true");
+
+  // Click Reset — both the notation and the selection should clear.
+  await page.getByRole("button", { name: "Reset" }).click();
+
+  await expect(moveInput).toHaveValue("");
+  await expect(page.locator("[data-point='6']")).not.toHaveAttribute("data-selected");
+});

--- a/log.md
+++ b/log.md
@@ -1185,4 +1185,33 @@ Tests (**[contracts/test/phase22_selfMintSubname.test.js](contracts/test/phase22
 - Subname owner can update their own text record after self-mint.
 - Two wallets can each claim their own subname independently.
 
+### Phase 27: clickable board — click-to-move UI
+
+Replace the text-only move input with a click-to-move interaction on the backgammon board. Instead of typing `8/5 6/5`, the player clicks a blue checker to select it (amber highlight), then clicks a destination point to append the `from/to` segment to the move input automatically. Successive click pairs accumulate into the full notation string; the existing Move button submits whatever is in the input. The text input remains as a power-user fallback — all prior Playwright tests still exercise the same code paths.
+
+**[frontend/app/Board.tsx](frontend/app/Board.tsx)** (updated):
+- `PointCell` gains `onClick`, `isSelected` props; outer `<div>` gets `data-point` (1-indexed), `data-count` (signed), and `data-selected` attributes for Playwright selectors.
+- `BarCell` gains `onBarClick` and `isBarSelected` props for click-to-enter-from-bar.
+- `Board` gains four optional props: `onPointClick`, `onBarClick`, `onOffClick`, `selectedPoint`; all default to `undefined` so pure-visual usages are unchanged.
+- Bear-off button rendered below the board only when `onOffClick` is defined.
+
+**[frontend/app/match/page.tsx](frontend/app/match/page.tsx)** (updated):
+- `selectedSource` state (null | 1-24 | 25=bar) tracks the in-progress click source.
+- `handlePointClick` / `handleBarClick` / `handleOffClick` build `from/to` segments and append them to `moveInput`.
+- `doMove` clears `selectedSource` on submit.
+- `useEffect` clears `selectedSource` when the turn flips to the agent.
+- Reset button appears when `moveInput` is non-empty or a source is selected; clears both.
+- Click-to-move instruction text shown above the input on the human's turn.
+
+Tests (**[frontend/tests/board-click-moves.spec.ts](frontend/tests/board-click-moves.spec.ts)**, new, 4 tests):
+- Clicking a blue checker sets `data-selected="true"` on the PointCell.
+- Clicking the same point twice deselects it (no `data-selected`).
+- Two click pairs build `8/5 6/5` in the move input.
+- The Move button submits the click-assembled notation to `/apply` unchanged.
+- Reset button clears both notation and click selection.
+
+Also fixes the previously-failing `piece-stability.spec.ts` suite (5 tests): `PointCell` now emits `data-point` and `data-count` attributes that `readBoardDOM` requires.
+
+4 new frontend Playwright tests pass.
+
 8 new contract tests pass (prior count + 8 new).


### PR DESCRIPTION
Closes #20

Adds a click-to-move interaction to the backgammon board: click a blue checker to select it (amber highlight), then click a destination point to build the move notation automatically. The text input remains as a fallback so all existing Playwright tests pass unchanged. Also fixes the pre-existing failing piece-stability test by adding `data-point` / `data-count` attrs to PointCell.

Generated with [Claude Code](https://claude.ai/code)