### PR TITLE
Phase 28: sidebar — global navigation with play and create-agent entries

### DIFF
--- a/frontend/app/Sidebar.tsx
+++ b/frontend/app/Sidebar.tsx
@@ -1,0 +1,198 @@
+// Phase 28: global sidebar navigation.
+//
+// Two entries:
+//   1. "Play with agent" — links to /match with the most recently played
+//      agentId (read from localStorage, set by the match page on mount).
+//      Falls back to agentId=1 when no prior game exists.
+//   2. "Create new agent" — reveals an inline form that calls
+//      AgentRegistry.mintAgent via the connected wallet (onlyOwner on the
+//      contract). On success the page redirects to "/" so the new agent
+//      appears immediately in AgentsList.
+//
+// The component is SSR-safe: localStorage is read inside useEffect after
+// hydration so the server-rendered HTML never diverges from the initial
+// client render.
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useAccount, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
+
+import { useChainContracts } from "./contracts";
+
+// Inline ABI fragment for mintAgent. Kept here so the sidebar builds
+// independently of the Hardhat compile step (same pattern as ClaimForm
+// using SELF_MINT_ABI). The full artifact ABI covers all other reads.
+const MINT_AGENT_ABI = [
+  {
+    type: "function",
+    name: "mintAgent",
+    inputs: [
+      { name: "to", type: "address", internalType: "address" },
+      { name: "metadataURI", type: "string", internalType: "string" },
+      { name: "tier_", type: "uint8", internalType: "uint8" },
+    ],
+    outputs: [{ name: "agentId", type: "uint256", internalType: "uint256" }],
+    stateMutability: "nonpayable",
+  },
+] as const;
+
+export function Sidebar() {
+  // Defer localStorage access until after hydration to avoid SSR mismatch.
+  const [mounted, setMounted] = useState(false);
+  const [lastAgentId, setLastAgentId] = useState<number | null>(null);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+
+  // Create-agent form state.
+  const [agentLabel, setAgentLabel] = useState("");
+  const [agentTier, setAgentTier] = useState<number>(0);
+
+  const { address } = useAccount();
+  const { agentRegistry } = useChainContracts();
+
+  const {
+    writeContract,
+    data: txHash,
+    error: writeError,
+    isPending: signing,
+    reset,
+  } = useWriteContract();
+
+  const { isLoading: confirming, isSuccess } = useWaitForTransactionReceipt({
+    hash: txHash,
+  });
+
+  // Read last active agentId from localStorage after hydration.
+  useEffect(() => {
+    setMounted(true);
+    const stored = window.localStorage.getItem("lastAgentId");
+    if (stored) setLastAgentId(Number(stored));
+  }, []);
+
+  // Redirect to home after agent creation so the new agent appears in AgentsList.
+  useEffect(() => {
+    if (isSuccess) {
+      window.location.href = "/";
+    }
+  }, [isSuccess]);
+
+  const creating = signing || confirming;
+
+  const submit = () => {
+    if (!address || !agentLabel.trim()) return;
+    reset();
+    writeContract({
+      address: agentRegistry,
+      abi: MINT_AGENT_ABI,
+      functionName: "mintAgent",
+      args: [address, agentLabel.trim(), agentTier],
+    });
+  };
+
+  // Before hydration, render only the structural shell so the server HTML
+  // matches the initial client render.
+  const playHref =
+    mounted && lastAgentId ? `/match?agentId=${lastAgentId}` : "/match?agentId=1";
+
+  const playSubtitle =
+    mounted && lastAgentId ? `Agent #${lastAgentId}` : "Start a match";
+
+  return (
+    <aside
+      data-testid="sidebar"
+      className="flex w-56 shrink-0 flex-col border-r border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950"
+    >
+      <div className="border-b border-zinc-200 px-4 py-4 dark:border-zinc-800">
+        <span className="text-xs font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+          Navigation
+        </span>
+      </div>
+
+      <nav className="flex flex-col gap-1 p-3">
+        {/* Entry 1: current play with agent */}
+        <Link
+          href={playHref}
+          data-testid="sidebar-play"
+          className="flex flex-col gap-0.5 rounded-md px-3 py-3 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800"
+        >
+          <span className="font-semibold text-zinc-900 dark:text-zinc-50">
+            Play with agent
+          </span>
+          <span className="text-xs text-zinc-500 dark:text-zinc-400">
+            {playSubtitle}
+          </span>
+        </Link>
+
+        {/* Entry 2: create a new agent */}
+        <button
+          type="button"
+          data-testid="sidebar-create-agent"
+          onClick={() => setShowCreateForm((v) => !v)}
+          className="flex flex-col gap-0.5 rounded-md px-3 py-3 text-left text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800"
+        >
+          <span className="font-semibold text-zinc-900 dark:text-zinc-50">
+            Create new agent
+          </span>
+          <span className="text-xs text-zinc-500 dark:text-zinc-400">
+            Mint an iNFT agent
+          </span>
+        </button>
+
+        {/* Inline create-agent form — shown when the entry above is clicked */}
+        {showCreateForm && (
+          <div
+            data-testid="create-agent-form"
+            className="flex flex-col gap-2 rounded-md border border-zinc-200 p-3 dark:border-zinc-700"
+          >
+            <input
+              data-testid="agent-label-input"
+              type="text"
+              value={agentLabel}
+              onChange={(e) => {
+                setAgentLabel(e.target.value);
+                reset();
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") submit();
+              }}
+              placeholder="agent-label"
+              className="h-8 rounded border border-zinc-300 bg-white px-2 font-mono text-xs text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-50"
+              disabled={creating}
+            />
+            <select
+              data-testid="agent-tier-select"
+              value={agentTier}
+              onChange={(e) => setAgentTier(Number(e.target.value))}
+              className="h-8 rounded border border-zinc-300 bg-white px-2 text-xs text-zinc-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-50"
+              disabled={creating}
+            >
+              <option value={0}>Tier 0</option>
+              <option value={1}>Tier 1</option>
+              <option value={2}>Tier 2</option>
+              <option value={3}>Tier 3</option>
+            </select>
+            <button
+              data-testid="create-agent-submit"
+              type="button"
+              onClick={submit}
+              disabled={creating || !agentLabel.trim() || !address}
+              className="rounded bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+            >
+              {signing ? "Signing…" : confirming ? "Confirming…" : "Create"}
+            </button>
+            {!address && (
+              <p className="text-xs text-amber-600 dark:text-amber-400">
+                Connect wallet to create an agent.
+              </p>
+            )}
+            {writeError && (
+              <p className="text-xs text-red-600 dark:text-red-400">
+                {writeError.message.split("\n")[0]}
+              </p>
+            )}
+          </div>
+        )}
+      </nav>
+    </aside>
+  );
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,7 +1,12 @@
+// Phase 28: root layout updated to include global sidebar.
+// The sidebar (client component) appears on every page via the flex
+// wrapper inside <Providers>. Both the sidebar and page content share
+// the wagmi + react-query context provided by <Providers>.
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
+import { Sidebar } from "./Sidebar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,7 +34,12 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
-        <Providers>{children}</Providers>
+        <Providers>
+          <div className="flex flex-1">
+            <Sidebar />
+            <div className="flex flex-1 flex-col min-w-0">{children}</div>
+          </div>
+        </Providers>
       </body>
     </html>
   );

--- a/frontend/app/match/page.tsx
+++ b/frontend/app/match/page.tsx
@@ -170,6 +170,12 @@ function MatchInner() {
   const params = useSearchParams();
   const agentId = Number(params.get("agentId") ?? "1");
 
+  // Phase 28: persist the most-recently-played agentId so the sidebar can
+  // link back to this agent on subsequent visits.
+  useEffect(() => {
+    window.localStorage.setItem("lastAgentId", String(agentId));
+  }, [agentId]);
+
   const [game, setGame] = useState<MatchState | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);

--- a/frontend/tests/sidebar.spec.ts
+++ b/frontend/tests/sidebar.spec.ts
@@ -1,0 +1,60 @@
+// Phase 28: sidebar regression coverage.
+//
+// Asserts that the global sidebar renders on the home page with both
+// required navigation entries, and that clicking "Create new agent"
+// reveals the inline creation form.
+//
+// The sidebar is a client component that uses wagmi hooks — all reads
+// degrade gracefully when no wallet is connected, so these tests run
+// without MetaMask.
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Sidebar", () => {
+  test("renders both navigation entries on the home page", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const sidebar = page.locator('[data-testid="sidebar"]');
+    await expect(sidebar).toBeVisible({ timeout: 5000 });
+
+    // Entry 1: "Play with agent"
+    const playLink = page.locator('[data-testid="sidebar-play"]');
+    await expect(playLink).toBeVisible({ timeout: 5000 });
+    await expect(playLink).toContainText("Play with agent");
+
+    // Entry 2: "Create new agent"
+    const createButton = page.locator('[data-testid="sidebar-create-agent"]');
+    await expect(createButton).toBeVisible({ timeout: 5000 });
+    await expect(createButton).toContainText("Create new agent");
+  });
+
+  test("clicking Create new agent reveals the inline form", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Form must not be visible before the toggle.
+    const form = page.locator('[data-testid="create-agent-form"]');
+    await expect(form).not.toBeVisible();
+
+    // Click the toggle button.
+    await page.locator('[data-testid="sidebar-create-agent"]').click();
+
+    // Form should now be visible with label input, tier select, and submit.
+    await expect(form).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[data-testid="agent-label-input"]')).toBeVisible();
+    await expect(page.locator('[data-testid="agent-tier-select"]')).toBeVisible();
+    await expect(page.locator('[data-testid="create-agent-submit"]')).toBeVisible();
+  });
+
+  test("Play with agent link points to /match route", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const playLink = page.locator('[data-testid="sidebar-play"]');
+    await expect(playLink).toBeVisible({ timeout: 5000 });
+
+    const href = await playLink.getAttribute("href");
+    expect(href).toMatch(/^\/match\?agentId=/);
+  });
+});

--- a/log.md
+++ b/log.md
@@ -1215,3 +1215,29 @@ Also fixes the previously-failing `piece-stability.spec.ts` suite (5 tests): `Po
 4 new frontend Playwright tests pass.
 
 8 new contract tests pass (prior count + 8 new).
+
+### Phase 28: sidebar — global navigation with play and create-agent entries
+
+Add a persistent sidebar to the Chaingammon frontend so users can navigate to their current match or mint a new AI agent from any page. The sidebar renders on every route via the root layout and uses wagmi hooks for wallet-aware writes, following the same inline-ABI pattern as `ClaimForm` to stay independent of the Hardhat compile step.
+
+**[frontend/app/Sidebar.tsx](frontend/app/Sidebar.tsx)** (new):
+- `Sidebar` — client component, rendered in `layout.tsx`; uses `mounted` guard for SSR safety.
+- Entry 1 — "Play with agent": `<Link>` to `/match?agentId=<last>` where `lastAgentId` is read from `localStorage` (set by the match page on mount). Falls back to `agentId=1` when no prior match exists.
+- Entry 2 — "Create new agent": toggle button that reveals an inline form with a label input, tier `<select>` (0–3), and a Create button that calls `AgentRegistry.mintAgent` via wagmi `useWriteContract`. On tx confirmation (`useWaitForTransactionReceipt`), redirects to `/` so the new agent appears immediately in `AgentsList`.
+- Inline `MINT_AGENT_ABI` fragment (same pattern as `ClaimForm`'s `SELF_MINT_ABI`) avoids a compile dependency.
+- Shows "Connect wallet to create an agent." when no wallet is connected; surfaces the wagmi write error (first line only) when the tx fails (e.g. caller is not the contract owner).
+- `data-testid` attributes on sidebar, both entries, form, inputs, and submit button for Playwright selectors.
+
+**[frontend/app/layout.tsx](frontend/app/layout.tsx)** (updated):
+- Wraps `<Providers>` children in a `flex flex-1` div: `<Sidebar />` on the left (fixed `w-56`) and a `flex flex-1 flex-col min-w-0` div for page content on the right.
+- `<Sidebar>` is inside `<Providers>` so it shares the wagmi + react-query context.
+
+**[frontend/app/match/page.tsx](frontend/app/match/page.tsx)** (updated):
+- `MatchInner` gains a `useEffect([agentId])` that writes `lastAgentId` to `localStorage` on mount and whenever `agentId` changes, so the sidebar's "Play with agent" link always points back to the most-recently-visited agent.
+
+Tests (**[frontend/tests/sidebar.spec.ts](frontend/tests/sidebar.spec.ts)**, new, 3 tests):
+- Sidebar renders on the home page with both navigation entries visible.
+- Clicking "Create new agent" reveals the inline form (label input, tier select, submit button).
+- "Play with agent" `href` matches `/match?agentId=…`.
+
+3 new frontend Playwright tests pass.


### PR DESCRIPTION
Adds a persistent sidebar to the Chaingammon frontend.

Two navigation entries:
1. **Play with agent** — links to the most-recently-played match (agentId persisted in localStorage)
2. **Create new agent** — inline form that calls AgentRegistry.mintAgent via wagmi; on success redirects to / so the new agent appears in AgentsList

Closes #22

Generated with [Claude Code](https://claude.ai/code)