### PR TITLE
Phase 29: fast-forward button — let the gnubg agent finish the game for the human

### DIFF
--- a/frontend/app/match/page.tsx
+++ b/frontend/app/match/page.tsx
@@ -222,6 +222,9 @@ function MatchInner() {
   // React re-renders while an agent step is mid-flight.
   const agentMoving = useRef(false);
 
+  // Whether the human has handed off to the gnubg agent to finish the game.
+  const [fastForward, setFastForward] = useState(false);
+
   // ── Coach hint after each move ─────────────────────────────────────────
 
   /**
@@ -275,11 +278,13 @@ function MatchInner() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // ── Auto-drive the agent when it's their turn ──────────────────────────
+  // ── Auto-drive the agent when it's their turn OR fast-forward is active ──
   useEffect(() => {
-    if (!game || game.game_over || game.turn !== 1 || agentMoving.current) {
-      return;
-    }
+    // Fire when it's the agent's turn (turn === 1), or when the human has
+    // activated fast-forward and it's still their turn (turn === 0). In fast-
+    // forward mode the gnubg agent plays both sides until game_over.
+    if (!game || game.game_over || agentMoving.current) return;
+    if (game.turn !== 1 && !fastForward) return;
     if (!game.dice) return; // dice are seeded by withFreshDice on the previous step
     agentMoving.current = true;
 
@@ -318,7 +323,7 @@ function MatchInner() {
     const timer = setTimeout(step, 400);
     return () => clearTimeout(timer);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [game]);
+  }, [game, fastForward]);
 
   // ── Human actions ──────────────────────────────────────────────────────
 
@@ -532,7 +537,7 @@ function MatchInner() {
           </p>
         )}
 
-        {!game.game_over && isHumanTurn && needsMove && (
+        {!game.game_over && isHumanTurn && needsMove && !fastForward && (
           <div className="flex flex-col gap-3">
             {/* Click-to-move instruction */}
             <p className="text-xs text-zinc-500 dark:text-zinc-400">
@@ -574,9 +579,9 @@ function MatchInner() {
           </div>
         )}
 
-        {!game.game_over && isAgentTurn && (
+        {!game.game_over && (isAgentTurn || fastForward) && (
           <p className="text-sm text-zinc-500 dark:text-zinc-400 animate-pulse">
-            Agent is thinking…
+            {fastForward ? "Fast forwarding…" : "Agent is thinking…"}
           </p>
         )}
 
@@ -649,11 +654,19 @@ function MatchInner() {
         )}
 
         {!game.game_over && (
-          <div className="mt-2 flex justify-end">
+          <div className="mt-2 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setFastForward(true)}
+              disabled={loading || fastForward}
+              className="rounded-md border border-zinc-300 px-3 py-1 text-xs font-medium text-zinc-600 hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700/60 dark:text-zinc-400 dark:hover:bg-zinc-800"
+            >
+              {fastForward ? "Fast forwarding…" : "⏩ Fast forward"}
+            </button>
             <button
               type="button"
               onClick={doForfeit}
-              disabled={loading}
+              disabled={loading || fastForward}
               className="rounded-md border border-red-300 px-3 py-1 text-xs font-medium text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-700/60 dark:text-red-400 dark:hover:bg-red-900/20"
             >
               Forfeit match

--- a/frontend/tests/match-flow-methods.spec.ts
+++ b/frontend/tests/match-flow-methods.spec.ts
@@ -110,6 +110,46 @@ test("match flow walks /new → /apply → /move → /apply through to game over
   for (const m of seen.move) expect(m).toBe("POST");
 });
 
+test("fast forward lets the gnubg agent play both sides to game over", async ({ page }) => {
+  let moveCount = 0;
+  let applyCount = 0;
+  let resignCount = 0;
+
+  await page.route("**/new", async (route) => {
+    await fulfill(route, OPENING);
+  });
+
+  // Every /move returns a valid move string.
+  await page.route("**/move", async (route) => {
+    moveCount += 1;
+    await fulfill(route, { move: "13/10", candidates: [] });
+  });
+
+  // /apply: first call gives the agent the next turn; second ends the game.
+  await page.route("**/apply", async (route) => {
+    applyCount += 1;
+    if (applyCount === 1) {
+      await fulfill(route, { ...OPENING, position_id: "step1", turn: 1, dice: null });
+    } else {
+      await fulfill(route, GAME_OVER);
+    }
+  });
+
+  await page.route("**/resign", async (route) => {
+    resignCount += 1;
+    await fulfill(route, GAME_OVER);
+  });
+
+  await page.goto("/match?agentId=1");
+
+  // Click the fast-forward button — the agent should play both sides to completion.
+  await page.getByRole("button", { name: /fast forward/i }).click();
+
+  await expect(page.getByText("You win!")).toBeVisible({ timeout: 10_000 });
+  expect(resignCount).toBe(0); // forfeit was not called
+  expect(moveCount).toBeGreaterThanOrEqual(1);
+});
+
 test("forfeit posts /resign and shows the game-over banner", async ({ page }) => {
   await page.route("**/new", async (route) => {
     await fulfill(route, OPENING);

--- a/log.md
+++ b/log.md
@@ -1241,3 +1241,19 @@ Tests (**[frontend/tests/sidebar.spec.ts](frontend/tests/sidebar.spec.ts)**, new
 - "Play with agent" `href` matches `/match?agentId=…`.
 
 3 new frontend Playwright tests pass.
+
+### Phase 29: fast-forward button — let the gnubg agent finish the game for the human
+
+Add a "⏩ Fast forward" button next to Forfeit on the match page. When clicked, the gnubg agent (the same service that drives the AI opponent) takes over the human's turn and plays both sides of the board to completion. This lets developers skip the remaining moves of a debug session without clicking through every turn manually.
+
+**[frontend/app/match/page.tsx](frontend/app/match/page.tsx)** (updated):
+- New `fastForward` boolean state (default `false`), set to `true` when the button is clicked and never reset — the agent plays to `game_over`.
+- Agent auto-drive `useEffect` extended: the existing `game.turn !== 1` guard gains an `&& !fastForward` clause so the effect also fires on the human's turn when fast-forward is active. Dependency array widens from `[game]` to `[game, fastForward]`.
+- Move input block gains a `!fastForward` guard so the text field and click-to-move UI hide while the agent is running.
+- "Agent is thinking…" paragraph now renders when `fastForward` is true as well; copy switches to "Fast forwarding…" to distinguish the two modes.
+- Fast-forward button rendered to the left of Forfeit; disabled once active. Forfeit is also disabled while fast-forwarding to prevent an ambiguous partial handoff.
+
+Tests (**[frontend/tests/match-flow-methods.spec.ts](frontend/tests/match-flow-methods.spec.ts)**, updated, 1 new test):
+- "fast forward lets the gnubg agent play both sides to game over": mocks `/new`, `/move`, and `/apply`; clicks the fast-forward button; asserts "You win!" appears and `/resign` was never called.
+
+4 match-flow-methods Playwright tests pass (3 prior + 1 new).


### PR DESCRIPTION
Closes #24

Adds a "⏩ Fast forward" button next to Forfeit on the match page. When clicked, the gnubg agent plays both sides to game over, letting developers skip the remaining moves of a debug session.

Generated with [Claude Code](https://claude.ai/code)