### PR TITLE
Fix: disable coach during fast-forward

### DIFF
--- a/frontend/app/match/page.tsx
+++ b/frontend/app/match/page.tsx
@@ -15,7 +15,8 @@
 //                    → replace state, roll next side's dice
 //   forfeit          → POST /resign → game_over response
 //
-// After each move a non-blocking coach hint is requested:
+// After each move a non-blocking coach hint is requested (skipped during
+// fast-forward since the human is not choosing moves):
 //   → POST /evaluate (gnubg_service) → ranked candidates
 //   → POST /hint    (coach_service)   → plain-English hint
 // Coach calls are best-effort — any failure is silently swallowed so
@@ -233,6 +234,7 @@ function MatchInner() {
    * does nothing when the coach node isn't running.
    */
   const requestCoachHint = (state: MatchState) => {
+    if (fastForward) return; // human is not choosing moves — coach not needed
     if (state.game_over || !state.dice) return;
     setCoachHint(null);
     setCoachServedBy(null);
@@ -586,7 +588,7 @@ function MatchInner() {
         )}
 
         {/* ── Coach panel ───────────────────────────────────────────────── */}
-        {!game.game_over && (
+        {!game.game_over && !fastForward && (
           <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-700/40 dark:bg-amber-900/10">
             <div className="mb-1 flex items-center justify-between gap-3">
               <p className="text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400">

--- a/frontend/tests/match-flow-methods.spec.ts
+++ b/frontend/tests/match-flow-methods.spec.ts
@@ -114,6 +114,7 @@ test("fast forward lets the gnubg agent play both sides to game over", async ({ 
   let moveCount = 0;
   let applyCount = 0;
   let resignCount = 0;
+  let hintCount = 0;
 
   await page.route("**/new", async (route) => {
     await fulfill(route, OPENING);
@@ -140,6 +141,13 @@ test("fast forward lets the gnubg agent play both sides to game over", async ({ 
     await fulfill(route, GAME_OVER);
   });
 
+  // Coach /hint must NOT be called during fast-forward — the human is not
+  // choosing moves and the extra round-trip only slows the auto-play.
+  await page.route("**/hint", async (route) => {
+    hintCount += 1;
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ hint: "", backend: "local" }) });
+  });
+
   await page.goto("/match?agentId=1");
 
   // Click the fast-forward button — the agent should play both sides to completion.
@@ -148,6 +156,7 @@ test("fast forward lets the gnubg agent play both sides to game over", async ({ 
   await expect(page.getByText("You win!")).toBeVisible({ timeout: 10_000 });
   expect(resignCount).toBe(0); // forfeit was not called
   expect(moveCount).toBeGreaterThanOrEqual(1);
+  expect(hintCount).toBe(0); // coach must be silent during fast-forward
 });
 
 test("forfeit posts /resign and shows the game-over banner", async ({ page }) => {

--- a/log.md
+++ b/log.md
@@ -1257,3 +1257,16 @@ Tests (**[frontend/tests/match-flow-methods.spec.ts](frontend/tests/match-flow-m
 - "fast forward lets the gnubg agent play both sides to game over": mocks `/new`, `/move`, and `/apply`; clicks the fast-forward button; asserts "You win!" appears and `/resign` was never called.
 
 4 match-flow-methods Playwright tests pass (3 prior + 1 new).
+
+### Fix: disable coach during fast-forward
+
+The coach panel and its hint requests are suppressed when fast-forward is active. During fast-forward the human is not choosing moves, so coach hints have no audience and the extra `/evaluate` + `/hint` round-trips to coach_service only slow down the auto-play loop.
+
+**[frontend/app/match/page.tsx](frontend/app/match/page.tsx)** (updated):
+- `requestCoachHint` returns early when `fastForward` is `true`, skipping both the `/evaluate` call to gnubg_service and the `/hint` call to coach_service.
+- Coach panel JSX gains a `!fastForward` guard so the amber hint box is hidden while the agent is running both sides.
+
+Tests (**[frontend/tests/match-flow-methods.spec.ts](frontend/tests/match-flow-methods.spec.ts)**, updated):
+- Fast-forward test now routes `**/hint` and asserts `hintCount === 0` after the game ends, confirming coach_service is never contacted during auto-play.
+
+4 match-flow-methods Playwright tests pass (3 prior + 1 new).


### PR DESCRIPTION
When fast-forwarding, the human is not choosing moves, so coach hints have no audience and the extra `/evaluate` + `/hint` round-trips to coach_service only slow down the auto-play loop.

This PR skips coach requests during fast-forward and hides the coach panel UI.

Closes #27

Generated with [Claude Code](https://claude.ai/code)