### PR TITLE
Phase 31: drag-and-drop checker movement + optimistic board display + undo

### DIFF
--- a/frontend/app/Board.tsx
+++ b/frontend/app/Board.tsx
@@ -1,4 +1,5 @@
 // Phase 14: visual backgammon board. Phase 27: click-to-move interaction.
+// Phase 31: drag-and-drop — onDragStart/onDrop on PointCell enable HTML5 drag.
 //
 // Layout (from player 0 / human's perspective):
 //   Top row  — points 13..24 left→right (player 0 enters at 24, moves left)
@@ -17,6 +18,12 @@
 //   onOffClick()    — called when the user clicks the bear-off button.
 //   selectedPoint   — highlights the currently-selected source (1-24 or 25=bar).
 //   data-point / data-count attributes on every PointCell for Playwright selectors.
+//
+// Phase 31 additions:
+//   onDragStart(n)  — fired when the user begins dragging from point n (1-24).
+//   onDrop(n)       — fired when the user drops onto point n (1-24).
+//   A PointCell is draggable only when it has player-0 checkers and onDragStart
+//   is provided. All PointCells accept drops when onDrop is provided.
 
 interface BoardProps {
   board: number[]; // length 24; index = point - 1
@@ -28,6 +35,9 @@ interface BoardProps {
   onBarClick?: () => void;
   onOffClick?: () => void;
   selectedPoint?: number | null; // 1-24 = board point, 25 = bar
+  // Drag-and-drop (Phase 31 — optional, independent of click props).
+  onDragStart?: (point: number) => void;
+  onDrop?: (point: number) => void;
 }
 
 // Maximum checkers shown as dots before falling back to a "+N" label.
@@ -39,9 +49,12 @@ interface PointProps {
   flip?: boolean; // true for top row (dots grow downward)
   onClick?: () => void;
   isSelected?: boolean;
+  // Drag-and-drop (Phase 31).
+  onDragStart?: () => void; // drag begins from this cell
+  onDrop?: () => void;      // checker dropped onto this cell
 }
 
-function PointCell({ point, count, flip = false, onClick, isSelected }: PointProps) {
+function PointCell({ point, count, flip = false, onClick, isSelected, onDragStart, onDrop }: PointProps) {
   const abs = Math.abs(count);
   const isP0 = count > 0;
   const dotsToShow = Math.min(abs, MAX_DOTS);
@@ -67,9 +80,13 @@ function PointCell({ point, count, flip = false, onClick, isSelected }: PointPro
     </span>
   );
 
+  // Cell is draggable when it has player-0 (blue) checkers and the drag handler is wired.
+  const isDraggable = !!onDragStart && count > 0;
+
   const classes = [
     "flex flex-col items-center gap-0.5",
     onClick ? "cursor-pointer hover:opacity-75" : "",
+    isDraggable ? "cursor-grab" : "",
     isSelected
       ? "rounded bg-amber-100 ring-1 ring-amber-400 dark:bg-amber-900/30"
       : "",
@@ -88,6 +105,10 @@ function PointCell({ point, count, flip = false, onClick, isSelected }: PointPro
       className={classes}
       style={{ width: 24 }}
       onClick={onClick}
+      draggable={isDraggable}
+      onDragStart={isDraggable ? (e) => { e.dataTransfer.effectAllowed = "move"; onDragStart!(); } : undefined}
+      onDragOver={onDrop ? (e) => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; } : undefined}
+      onDrop={onDrop ? (e) => { e.preventDefault(); onDrop(); } : undefined}
     >
       {/* Point label */}
       {!flip && (
@@ -182,6 +203,8 @@ export function Board({
   onBarClick,
   onOffClick,
   selectedPoint,
+  onDragStart,
+  onDrop,
 }: BoardProps) {
   // Top row: points 13–24 (indices 12–23), displayed left→right.
   const topPoints = Array.from({ length: 12 }, (_, i) => i + 13); // [13..24]
@@ -211,6 +234,8 @@ export function Board({
                 flip={true}
                 onClick={onPointClick ? () => onPointClick(pt) : undefined}
                 isSelected={selectedPoint === pt}
+                onDragStart={onDragStart ? () => onDragStart(pt) : undefined}
+                onDrop={onDrop ? () => onDrop(pt) : undefined}
               />
             ))}
             <BarCell
@@ -227,6 +252,8 @@ export function Board({
                 flip={true}
                 onClick={onPointClick ? () => onPointClick(pt) : undefined}
                 isSelected={selectedPoint === pt}
+                onDragStart={onDragStart ? () => onDragStart(pt) : undefined}
+                onDrop={onDrop ? () => onDrop(pt) : undefined}
               />
             ))}
           </div>
@@ -244,6 +271,8 @@ export function Board({
                 flip={false}
                 onClick={onPointClick ? () => onPointClick(pt) : undefined}
                 isSelected={selectedPoint === pt}
+                onDragStart={onDragStart ? () => onDragStart(pt) : undefined}
+                onDrop={onDrop ? () => onDrop(pt) : undefined}
               />
             ))}
             <div className="flex w-8 items-center justify-center">
@@ -257,6 +286,8 @@ export function Board({
                 flip={false}
                 onClick={onPointClick ? () => onPointClick(pt) : undefined}
                 isSelected={selectedPoint === pt}
+                onDragStart={onDragStart ? () => onDragStart(pt) : undefined}
+                onDrop={onDrop ? () => onDrop(pt) : undefined}
               />
             ))}
           </div>

--- a/frontend/app/match/page.tsx
+++ b/frontend/app/match/page.tsx
@@ -1,4 +1,5 @@
 // Phase 26: match flow over the AXL gnubg agent node.
+// Phase 31: drag-and-drop checker movement with optimistic board display and undo.
 //
 // URL: /match?agentId=<N>
 //
@@ -14,6 +15,18 @@
 //                    → POST /apply with that move
 //                    → replace state, roll next side's dice
 //   forfeit          → POST /resign → game_over response
+//
+// Phase 31 additions:
+//   stagedMoves      — array of "from/to" segments the human has clicked/dragged
+//   displayBoardState — optimistic board/bar/off after applying staged moves locally;
+//                       null when no moves staged (falls back to game.board)
+//   stageMove        — appends a segment, applies it to displayBoardState, and
+//                       auto-submits via doMoveWithNotation when all dice are used
+//   Undo button      — clears staged moves and resets display to start-of-turn
+//   Drag events      — onDragStart/onDrop forwarded to Board so users can drag
+//                       checkers in addition to clicking source then destination
+//   Text input + Move button still present for backward compatibility with tests
+//   and power users who prefer notation.
 //
 // After each move a non-blocking coach hint is requested (skipped during
 // fast-forward since the human is not choosing moves):
@@ -152,6 +165,46 @@ function withFreshDice(state: MatchState): MatchState {
   return { ...state, dice: rollDice() };
 }
 
+// ── Phase 31: Optimistic board helper ────────────────────────────────────
+
+/**
+ * Apply one checker movement to board/bar/off and return the new state.
+ * Player 0 (human) is always the mover. Handles blot hits (single
+ * opponent checker at destination is sent to the bar).
+ */
+function applyMoveSegment(
+  board: number[],
+  bar: [number, number],
+  off: [number, number],
+  from: number | "bar",
+  to: number | "off",
+): { board: number[]; bar: [number, number]; off: [number, number] } {
+  const newBoard = [...board];
+  const newBar: [number, number] = [bar[0], bar[1]];
+  const newOff: [number, number] = [off[0], off[1]];
+
+  // Remove one checker from the source.
+  if (from === "bar") {
+    newBar[0] = Math.max(0, newBar[0] - 1);
+  } else {
+    newBoard[from - 1] -= 1;
+  }
+
+  // Place the checker at the destination (or bear it off).
+  if (to === "off") {
+    newOff[0] += 1;
+  } else {
+    // Hit a blot: if exactly one opponent checker is there, send it to the bar.
+    if (newBoard[to - 1] === -1) {
+      newBoard[to - 1] = 0;
+      newBar[1] += 1;
+    }
+    newBoard[to - 1] += 1;
+  }
+
+  return { board: newBoard, bar: newBar, off: newOff };
+}
+
 // ── Component ─────────────────────────────────────────────────────────────
 
 export default function MatchPage() {
@@ -186,6 +239,16 @@ function MatchInner() {
   // Phase 27: click-to-move state.
   // null = no checker selected, 1-24 = board point, 25 = bar (player 0).
   const [selectedSource, setSelectedSource] = useState<number | null>(null);
+
+  // Phase 31: staged moves and optimistic board display.
+  // Each element is a "from/to" notation segment, e.g. "8/5" or "bar/24".
+  const [stagedMoves, setStagedMoves] = useState<string[]>([]);
+  // Optimistic board state while moves are staged; null = show game.board.
+  const [displayBoardState, setDisplayBoardState] = useState<{
+    board: number[];
+    bar: [number, number];
+    off: [number, number];
+  } | null>(null);
 
   // Coach state — best-effort; failures leave hint null.
   const [coachHint, setCoachHint] = useState<string | null>(null);
@@ -226,6 +289,20 @@ function MatchInner() {
 
   // Whether the human has handed off to the gnubg agent to finish the game.
   const [fastForward, setFastForward] = useState(false);
+
+  // ── Phase 31: Derived board display state ─────────────────────────────
+
+  // Current visual board — optimistic while moves are staged, otherwise
+  // the authoritative server state.
+  const currentBoard = displayBoardState?.board ?? game?.board ?? [];
+  const currentBar = (displayBoardState?.bar ?? game?.bar ?? [0, 0]) as [number, number];
+  const currentOff = (displayBoardState?.off ?? game?.off ?? [0, 0]) as [number, number];
+
+  // How many move segments we expect before auto-submitting.
+  // Doubles → 4 moves; any other roll → 2 moves.
+  const diceCount = game?.dice
+    ? game.dice[0] === game.dice[1] ? 4 : 2
+    : 0;
 
   // ── Coach hint after each move ─────────────────────────────────────────
 
@@ -339,56 +416,23 @@ function MatchInner() {
 
   // ── Human actions ──────────────────────────────────────────────────────
 
-  // Clear click selection whenever it is no longer the human's turn.
+  // Clear click selection and staged moves whenever it is no longer the human's turn.
   useEffect(() => {
-    if (!game || game.turn !== 0) setSelectedSource(null);
+    if (!game || game.turn !== 0) {
+      setSelectedSource(null);
+      setStagedMoves([]);
+      setDisplayBoardState(null);
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [game?.turn]);
 
   /**
-   * Handle a click on a board point (Phase 27 click-to-move).
-   *
-   * First click: selects the point as the move source (only valid if the point
-   * has a player-0 checker and player-0 has no checkers on the bar).
-   * Second click on the same point: deselects.
-   * Second click on a different point: appends "from/to" to the move input and
-   * clears the selection so the user can start the next checker move.
+   * Submit a move notation string to /apply. Shared by the manual Move
+   * button (text input) and the auto-submit path (click/drag staging).
+   * Clears all staged state on success or error.
    */
-  const handlePointClick = (point: number) => {
-    // needsMove = !!game.dice && game.turn === 0
-    if (!game || !game.dice || game.turn !== 0) return;
-
-    if (selectedSource === null) {
-      // Player 0 must clear the bar before moving board checkers.
-      if (game.bar[0] > 0) return;
-      if (game.board[point - 1] > 0) setSelectedSource(point);
-    } else if (selectedSource === point) {
-      setSelectedSource(null); // deselect
-    } else {
-      const from = selectedSource === 25 ? "bar" : String(selectedSource);
-      const seg = `${from}/${point}`;
-      setMoveInput((prev) => (prev.trim() ? `${prev.trim()} ${seg}` : seg));
-      setSelectedSource(null);
-    }
-  };
-
-  /** Click the bar zone to select it as the move source (enter from bar). */
-  const handleBarClick = () => {
-    if (!game || !game.dice || game.turn !== 0 || game.bar[0] === 0) return;
-    setSelectedSource(25);
-  };
-
-  /** Click the bear-off zone when a source is already selected. */
-  const handleOffClick = () => {
-    if (!game || !game.dice || game.turn !== 0 || selectedSource === null) return;
-    const from = selectedSource === 25 ? "bar" : String(selectedSource);
-    const seg = `${from}/off`;
-    setMoveInput((prev) => (prev.trim() ? `${prev.trim()} ${seg}` : seg));
-    setSelectedSource(null);
-  };
-
-  const doMove = async () => {
-    if (!game || !moveInput.trim() || !game.dice) return;
+  const doMoveWithNotation = async (notation: string) => {
+    if (!game || !game.dice) return;
     setLoading(true);
     setError(null);
     setSelectedSource(null);
@@ -397,17 +441,118 @@ function MatchInner() {
         position_id: game.position_id,
         match_id: game.match_id,
         dice: game.dice,
-        move: moveInput.trim(),
+        move: notation,
       });
       const nextWithDice = next.game_over ? next : withFreshDice(next);
       setGame(nextWithDice);
+      setStagedMoves([]);
+      setDisplayBoardState(null);
       setMoveInput("");
       requestCoachHint(nextWithDice);
     } catch (e: unknown) {
       setError(String(e));
+      // On error, reset optimistic state so the board snaps back.
+      setStagedMoves([]);
+      setDisplayBoardState(null);
     } finally {
       setLoading(false);
     }
+  };
+
+  /**
+   * Stage one checker movement (Phase 31 click/drag-to-move).
+   *
+   * Appends the segment to stagedMoves, applies it to displayBoardState
+   * so the checker appears at its destination immediately, then
+   * auto-submits when all dice have been used.
+   */
+  const stageMove = (from: number | "bar", to: number | "off") => {
+    if (!game || !game.dice) return;
+
+    const fromStr = from === "bar" ? "bar" : String(from);
+    const toStr = to === "off" ? "off" : String(to);
+    const seg = `${fromStr}/${toStr}`;
+    const newStaged = [...stagedMoves, seg];
+
+    // Apply the move locally for immediate visual feedback.
+    const curBoard = displayBoardState?.board ?? game.board;
+    const curBar = displayBoardState?.bar ?? game.bar;
+    const curOff = displayBoardState?.off ?? game.off;
+    const newDisplay = applyMoveSegment(curBoard, curBar, curOff, from, to);
+
+    setStagedMoves(newStaged);
+    setDisplayBoardState(newDisplay);
+    setSelectedSource(null);
+
+    // Auto-submit when all dice are consumed.
+    if (newStaged.length >= diceCount) {
+      void doMoveWithNotation(newStaged.join(" "));
+    }
+  };
+
+  /**
+   * Handle a click on a board point (Phase 27 click-to-move, extended in Phase 31).
+   *
+   * First click: selects the point as the move source (only valid if the point
+   * has a player-0 checker and player-0 has no checkers on the bar).
+   * Second click on the same point: deselects.
+   * Second click on a different point: stages the move and updates the display
+   * board optimistically.
+   */
+  const handlePointClick = (point: number) => {
+    if (!game || !game.dice || game.turn !== 0) return;
+
+    // Use the display board (post-staging) for source validation.
+    const curBar = displayBoardState?.bar ?? game.bar;
+    const curBoard = displayBoardState?.board ?? game.board;
+
+    if (selectedSource === null) {
+      // Player 0 must clear the bar before moving board checkers.
+      if (curBar[0] > 0) return;
+      if (curBoard[point - 1] > 0) setSelectedSource(point);
+    } else if (selectedSource === point) {
+      setSelectedSource(null); // deselect
+    } else {
+      const from: number | "bar" = selectedSource === 25 ? "bar" : selectedSource;
+      stageMove(from, point);
+    }
+  };
+
+  /** Click the bar zone to select it as the move source (enter from bar). */
+  const handleBarClick = () => {
+    if (!game || !game.dice || game.turn !== 0) return;
+    const curBar = displayBoardState?.bar ?? game.bar;
+    if (curBar[0] === 0) return;
+    setSelectedSource(25);
+  };
+
+  /** Click the bear-off zone when a source is already selected. */
+  const handleOffClick = () => {
+    if (!game || !game.dice || game.turn !== 0 || selectedSource === null) return;
+    const from: number | "bar" = selectedSource === 25 ? "bar" : selectedSource;
+    stageMove(from, "off");
+  };
+
+  /** Phase 31: drag-start — select the dragged point as the move source. */
+  const handleDragStart = (point: number) => {
+    if (!game || !game.dice || game.turn !== 0) return;
+    const curBar = displayBoardState?.bar ?? game.bar;
+    const curBoard = displayBoardState?.board ?? game.board;
+    if (curBar[0] > 0) return; // must enter from bar first
+    if (curBoard[point - 1] > 0) setSelectedSource(point);
+  };
+
+  /** Phase 31: drop — stage the move from selectedSource to the dropped point. */
+  const handleDrop = (point: number) => {
+    if (selectedSource === null || !game || !game.dice || game.turn !== 0) return;
+    const from: number | "bar" = selectedSource === 25 ? "bar" : selectedSource;
+    stageMove(from, point);
+  };
+
+  /** Manual submit via the text input + Move button (backward compat). */
+  const doMove = async () => {
+    if (!game || !moveInput.trim() || !game.dice) return;
+    await doMoveWithNotation(moveInput.trim());
   };
 
   const doForfeit = async () => {
@@ -466,6 +611,13 @@ function MatchInner() {
   const isAgentTurn = game.turn === 1;
   const needsMove = !!game.dice && isHumanTurn;
 
+  // Show the Undo button whenever there is something to undo.
+  const canUndo = stagedMoves.length > 0 || moveInput.trim() !== "" || selectedSource !== null;
+
+  // Show Apply button when moves are staged but not all dice are used (player
+  // can't use remaining dice — let them submit a partial move for gnubg to validate).
+  const canApplyPartial = stagedMoves.length > 0 && diceCount > 0 && stagedMoves.length < diceCount;
+
   const winnerLabel =
     game.winner === 0 ? "You win!" : game.winner === 1 ? "Agent wins." : "Draw";
 
@@ -523,15 +675,18 @@ function MatchInner() {
           </div>
         )}
 
+        {/* Board renders the optimistic display state during staging, otherwise game.board */}
         <Board
-          board={game.board}
-          bar={game.bar}
-          off={game.off}
+          board={currentBoard}
+          bar={currentBar}
+          off={currentOff}
           turn={game.turn}
           onPointClick={needsMove ? handlePointClick : undefined}
           onBarClick={needsMove ? handleBarClick : undefined}
           onOffClick={needsMove && selectedSource !== null ? handleOffClick : undefined}
           selectedPoint={selectedSource}
+          onDragStart={needsMove ? handleDragStart : undefined}
+          onDrop={needsMove ? handleDrop : undefined}
         />
 
         {game.dice && (
@@ -551,14 +706,24 @@ function MatchInner() {
 
         {!game.game_over && isHumanTurn && needsMove && !fastForward && (
           <div className="flex flex-col gap-3">
-            {/* Click-to-move instruction */}
+            {/* Instruction */}
             <p className="text-xs text-zinc-500 dark:text-zinc-400">
-              <span className="font-medium text-zinc-700 dark:text-zinc-300">Click</span>{" "}
-              a blue checker to select it (amber highlight), then click a destination
-              point. Repeat for each checker. Use the{" "}
+              <span className="font-medium text-zinc-700 dark:text-zinc-300">Drag or click</span>{" "}
+              a blue checker to select it (amber highlight), then drag or click a destination point.
+              The checker moves immediately — after using all dice the move is submitted automatically.
+              Use the{" "}
               <span className="font-medium text-zinc-700 dark:text-zinc-300">Bear off →</span>{" "}
-              button when bearing off. Or type the notation directly below.
+              button to bear off. Or type the notation directly below.
             </p>
+
+            {/* Staged-move status */}
+            {stagedMoves.length > 0 && (
+              <p className="text-xs text-indigo-600 dark:text-indigo-400">
+                {stagedMoves.length}/{diceCount} move{stagedMoves.length !== 1 ? "s" : ""} staged
+                {stagedMoves.length < diceCount && " — click the next checker to continue"}
+              </p>
+            )}
+
             <div className="flex gap-2">
               <input
                 value={moveInput}
@@ -567,17 +732,31 @@ function MatchInner() {
                 placeholder='e.g. "8/5 6/5" or "off"'
                 className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 font-mono text-sm text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-50"
               />
-              {/* Reset clears both the typed/built notation and any click selection */}
-              {(moveInput.trim() || selectedSource !== null) && (
+              {/* Undo clears staged moves, the text input, and any click selection */}
+              {canUndo && (
                 <button
                   type="button"
                   onClick={() => {
+                    setStagedMoves([]);
+                    setDisplayBoardState(null);
                     setMoveInput("");
                     setSelectedSource(null);
                   }}
                   className="rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-500 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800"
                 >
-                  Reset
+                  Undo
+                </button>
+              )}
+              {/* Apply button lets player submit with fewer moves than diceCount
+                  when some dice cannot legally be used. */}
+              {canApplyPartial && (
+                <button
+                  type="button"
+                  onClick={() => void doMoveWithNotation(stagedMoves.join(" "))}
+                  disabled={loading}
+                  className="rounded-md border border-indigo-300 px-3 py-2 text-sm text-indigo-600 hover:bg-indigo-50 disabled:opacity-50 dark:border-indigo-700 dark:text-indigo-400 dark:hover:bg-indigo-900/20"
+                >
+                  Apply ({stagedMoves.length}/{diceCount})
                 </button>
               )}
               <button

--- a/frontend/tests/board-click-moves.spec.ts
+++ b/frontend/tests/board-click-moves.spec.ts
@@ -1,16 +1,17 @@
 // Phase 27: click-to-move regression coverage.
+// Phase 31: updated for drag-and-drop + optimistic board display + auto-submit + undo.
 //
 // Drives /match?agentId=1 against mocked gnubg_service endpoints and
 // verifies that:
 //   1. Clicking a blue checker selects it (data-selected="true").
-//   2. Clicking a destination point appends the "from/to" segment to the
-//      move input, so the existing Move button can submit the full notation.
-//   3. Clicking the same source twice deselects it.
-//   4. Multiple click pairs accumulate into a space-separated notation
-//      string identical to what a user would type by hand.
+//   2. Clicking the same source twice deselects it.
+//   3. Clicking source then destination moves the checker immediately on
+//      the display board (data-count changes optimistically).
+//   4. Two click pairs auto-submit to /apply when both dice are used.
+//   5. Undo button resets the board to the start-of-turn position.
 //
-// The text input and Move button are left unchanged (backward-compatible)
-// so all pre-existing tests continue to exercise the same paths.
+// The text input and Move button are unchanged — all pre-existing tests
+// that type notation and click Move continue to exercise those paths.
 
 import { test, expect, type Route } from "@playwright/test";
 
@@ -83,6 +84,31 @@ async function setupRoutes(
   });
 }
 
+/**
+ * Override crypto.getRandomValues so rollDice() always returns [3, 2]
+ * (non-doubles → diceCount = 2). Must be called via page.addInitScript
+ * before page.goto so it runs before the module initialises.
+ *
+ * Values: floor(buf / 2^32 * 6) + 1 = die face.
+ *   1431655765 / 2^32 * 6 ≈ 2.000 → face 3
+ *   715827883  / 2^32 * 6 ≈ 1.000 → face 2
+ */
+function deterministicDiceScript() {
+  return `
+    (function() {
+      var _orig = crypto.getRandomValues.bind(crypto);
+      crypto.getRandomValues = function(arr) {
+        if (arr instanceof Uint32Array && arr.length === 2) {
+          arr[0] = 1431655765;
+          arr[1] = 715827883;
+          return arr;
+        }
+        return _orig(arr);
+      };
+    })();
+  `;
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 test("clicking a blue checker selects it (amber highlight via data-selected)", async ({
@@ -119,36 +145,38 @@ test("clicking same point twice deselects it", async ({ page }) => {
   await expect(page.locator("[data-point='8']")).not.toHaveAttribute("data-selected");
 });
 
-test("two click pairs build '8/5 6/5' in the move input", async ({ page }) => {
+test("click pair moves checker to destination on the display board immediately", async ({
+  page,
+}) => {
   await setupRoutes(page);
   await page.goto("/match?agentId=1");
 
   await expect(page.locator("[data-point='8']")).toBeVisible({ timeout: 10_000 });
 
-  // First checker: point 8 → point 5.
+  // Opening: point 8 has 3 blue checkers, point 5 is empty.
+  await expect(page.locator("[data-point='8']")).toHaveAttribute("data-count", "3");
+  await expect(page.locator("[data-point='5']")).toHaveAttribute("data-count", "0");
+
+  // First pair: click source (8) then destination (5).
   await page.locator("[data-point='8']").click();
-  await expect(page.locator("[data-point='8']")).toHaveAttribute("data-selected", "true");
   await page.locator("[data-point='5']").click();
 
-  // After the first pair, input shows "8/5" and nothing is selected.
-  const moveInput = page.getByPlaceholder('e.g. "8/5 6/5" or "off"');
-  await expect(moveInput).toHaveValue("8/5");
+  // After staging 8/5, the board reflects the move immediately.
+  await expect(page.locator("[data-point='8']")).toHaveAttribute("data-count", "2");
+  await expect(page.locator("[data-point='5']")).toHaveAttribute("data-count", "1");
+
+  // Point 8 is no longer selected (selection cleared after staging).
   await expect(page.locator("[data-point='8']")).not.toHaveAttribute("data-selected");
-
-  // Second checker: point 6 → point 5.
-  await page.locator("[data-point='6']").click();
-  await expect(page.locator("[data-point='6']")).toHaveAttribute("data-selected", "true");
-  await page.locator("[data-point='5']").click();
-
-  // Input now accumulates "8/5 6/5".
-  await expect(moveInput).toHaveValue("8/5 6/5");
 });
 
-test("click-built notation is submitted via the Move button to /apply", async ({
+test("two click pairs auto-submit to /apply when both dice are used", async ({
   page,
 }) => {
-  let capturedMove = "";
+  // Force dice to [3, 2] (non-doubles) so diceCount = 2 — exactly two click
+  // pairs trigger auto-submit without any manual Move button press.
+  await page.addInitScript(deterministicDiceScript());
 
+  let capturedMove = "";
   await setupRoutes(page, {
     applyCallback: (body) => {
       capturedMove = String(body.move ?? "");
@@ -159,25 +187,19 @@ test("click-built notation is submitted via the Move button to /apply", async ({
   await page.goto("/match?agentId=1");
   await expect(page.locator("[data-point='8']")).toBeVisible({ timeout: 10_000 });
 
-  // Build "8/5 6/5" by clicking.
+  // Two click pairs: 8 → 5, then 6 → 5.
   await page.locator("[data-point='8']").click();
   await page.locator("[data-point='5']").click();
   await page.locator("[data-point='6']").click();
   await page.locator("[data-point='5']").click();
 
-  const moveInput = page.getByPlaceholder('e.g. "8/5 6/5" or "off"');
-  await expect(moveInput).toHaveValue("8/5 6/5");
-
-  // Submit via the Move button.
-  await page.getByRole("button", { name: "Move" }).click();
-
-  // /apply must receive the click-assembled notation exactly.
+  // Auto-submit fires after the second pair — /apply receives "8/5 6/5".
   await expect
     .poll(() => capturedMove, { timeout: 5_000 })
     .toBe("8/5 6/5");
 });
 
-test("Reset button clears the assembled notation and deselects any source", async ({
+test("Undo button resets the board to start-of-turn position", async ({
   page,
 }) => {
   await setupRoutes(page);
@@ -185,20 +207,18 @@ test("Reset button clears the assembled notation and deselects any source", asyn
 
   await expect(page.locator("[data-point='8']")).toBeVisible({ timeout: 10_000 });
 
-  // Build one segment.
+  // Stage one move: 8 → 5. One staged move is always < diceCount (2 or 4),
+  // so auto-submit does not fire regardless of the dice value.
   await page.locator("[data-point='8']").click();
   await page.locator("[data-point='5']").click();
 
-  const moveInput = page.getByPlaceholder('e.g. "8/5 6/5" or "off"');
-  await expect(moveInput).toHaveValue("8/5");
+  // Optimistic display: point 8 shows 2, point 5 shows 1.
+  await expect(page.locator("[data-point='8']")).toHaveAttribute("data-count", "2");
+  await expect(page.locator("[data-point='5']")).toHaveAttribute("data-count", "1");
 
-  // Select a second source to leave a pending selection.
-  await page.locator("[data-point='6']").click();
-  await expect(page.locator("[data-point='6']")).toHaveAttribute("data-selected", "true");
+  // Click Undo — staged moves discarded and board resets to opening.
+  await page.getByRole("button", { name: "Undo" }).click();
 
-  // Click Reset — both the notation and the selection should clear.
-  await page.getByRole("button", { name: "Reset" }).click();
-
-  await expect(moveInput).toHaveValue("");
-  await expect(page.locator("[data-point='6']")).not.toHaveAttribute("data-selected");
+  await expect(page.locator("[data-point='8']")).toHaveAttribute("data-count", "3");
+  await expect(page.locator("[data-point='5']")).toHaveAttribute("data-count", "0");
 });

--- a/log.md
+++ b/log.md
@@ -1270,3 +1270,35 @@ Tests (**[frontend/tests/match-flow-methods.spec.ts](frontend/tests/match-flow-m
 - Fast-forward test now routes `**/hint` and asserts `hintCount === 0` after the game ends, confirming coach_service is never contacted during auto-play.
 
 4 match-flow-methods Playwright tests pass (3 prior + 1 new).
+
+### Phase 31: drag-and-drop checker movement + optimistic board display + undo
+
+Replace the text-input-only move workflow with a click-and-drag interaction where each checker movement is reflected on the board immediately. The player clicks or drags a blue checker to select it (amber highlight), then clicks or drags to a destination — the checker appears there at once via an optimistic local board update. After all dice are consumed (2 for non-doubles, 4 for doubles) the full move notation auto-submits to gnubg_service without requiring the user to click Move. An Undo button resets the board and all staged moves to the start-of-turn position. The text input and Move button remain for power users and backward compatibility with existing tests.
+
+**[frontend/app/Board.tsx](frontend/app/Board.tsx)** (updated):
+- `PointCell` gains `onDragStart` and `onDrop` props; the outer `<div>` becomes `draggable` when the cell has player-0 checkers and `onDragStart` is wired; `onDragOver` calls `e.preventDefault()` to enable drop; `cursor-grab` class added for draggable points.
+- `BoardProps` gains `onDragStart?: (point: number) => void` and `onDrop?: (point: number) => void`; both are forwarded to every `PointCell` in the top and bottom rows.
+
+**[frontend/app/match/page.tsx](frontend/app/match/page.tsx)** (updated):
+- `applyMoveSegment(board, bar, off, from, to)` — pure helper outside the component that applies one checker movement locally, handling blot hits (single opponent checker sent to bar).
+- `stagedMoves: string[]` state — accumulated "from/to" segments not yet submitted.
+- `displayBoardState` state — optimistic board/bar/off after staging; `null` while no moves are staged (falls back to `game.board`).
+- `diceCount` derived value — 4 for doubles, 2 otherwise; determines when to auto-submit.
+- `doMoveWithNotation(notation)` — extracted async helper that POSTs to `/apply`, updates game state, and clears all staged state on success or error. Used by both the manual Move button and the auto-submit path.
+- `stageMove(from, to)` — stages one segment, applies it to `displayBoardState`, and calls `doMoveWithNotation` automatically when `stagedMoves.length >= diceCount`.
+- `handleDragStart(point)` / `handleDrop(point)` — drag events wired to the same select/stage logic as click events.
+- `handlePointClick` / `handleBarClick` / `handleOffClick` updated to read from `displayBoardState` (post-staging counts) rather than `game.board` when validating source selection.
+- Board rendered with `currentBoard / currentBar / currentOff` — optimistic state when staging, server state otherwise.
+- "Reset" button renamed to "Undo"; handler also clears `stagedMoves` and `displayBoardState`.
+- "Apply (N/M)" button appears when moves are staged but fewer than `diceCount` (escape hatch when some dice cannot legally be used).
+- `useEffect([game?.turn])` extended to clear staged moves and display state when the turn flips.
+
+Tests (**[frontend/tests/board-click-moves.spec.ts](frontend/tests/board-click-moves.spec.ts)**, updated, 5 tests):
+- `deterministicDiceScript()` helper overrides `crypto.getRandomValues` so `rollDice()` always returns `[3, 2]` (non-doubles, `diceCount = 2`) — needed for tests that depend on knowing when auto-submit fires.
+- "clicking a blue checker selects it" — unchanged.
+- "clicking same point twice deselects it" — unchanged.
+- "click pair moves checker to destination on the display board immediately" — replaces "build notation in text input"; asserts `data-count` on source and destination points change immediately after one click pair.
+- "two click pairs auto-submit to /apply when both dice are used" — replaces "submit via Move button"; uses deterministic dice, clicks two pairs, asserts `/apply` receives `"8/5 6/5"` without any Move button click.
+- "Undo button resets the board to start-of-turn position" — replaces "Reset button clears notation"; stages one move, asserts optimistic `data-count` changes, clicks Undo, asserts `data-count` reverts.
+
+5 board-click-moves Playwright tests updated.


### PR DESCRIPTION
Implements drag-and-drop checker movement with optimistic board display and an Undo button.

- Click or drag a checker to a destination — it moves there immediately
- After all dice are used, the move auto-submits to gnubg
- Undo button resets the board to start-of-turn state

Closes #26

Generated with [Claude Code](https://claude.ai/code)