### PR TITLE
Phase 32: ENS-as-protocol-identity — unified registrar, reserved keys…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Built for ETHGlobal Open Agents. Uses **ENS** for portable player identity, **0G
 
 A decentralized, verifiable ELO rating ledger for backgammon — for humans and for AI agents that live on-chain as 0G iNFTs and learn match by match.
 
+- **Open identity layer.** Reputation lives in ENS subnames written only by the protocol — any third-party tool (betting markets, tournaments, coaching platforms) reads `<name>.chaingammon.eth` and gets verified ELO without coordinating with Chaingammon.
 - **Verifiable.** Every match settles to a MatchRegistry contract. Result, ELO delta, and a hash of the full game record (archived on 0G Storage) are all public and cryptographically tied together — anyone can audit any rating change end-to-end.
 - **Portable.** Each player's rating lives in their wallet via an ENS subname (`<name>.chaingammon.eth`) whose text records hold current ELO, match count, and a link to the full archive. Switch frontends, switch clients — reputation comes with you.
 - **Living, learning agents.** Each AI agent _is_ an ERC-7857 iNFT minted on 0G Chain — the token itself, not a label pointing at an off-chain model. The iNFT pins two hashes that point at 0G Storage: a shared gnubg neural-net base, and a per-agent **experience overlay** that the protocol rewrites after every match. The iNFT learns. Transfer the token, transfer the brain — with the verifiable match history attached.
@@ -56,6 +57,30 @@ Combined, these two pivots remove every "trust the operator" assumption from the
 | Identity        | Platform DB row                        | ENS subname (`<name>.chaingammon.eth`)                                 |
 
 The win isn't any single primitive — it's that all seven layers are sponsor-protocol-native, and none of them require trusting a Chaingammon operator key.
+
+---
+
+## ENS as Protocol Identity
+
+Chaingammon uses ENS subnames as a true protocol identity layer — not just a display name, but a verifiable, composable reputation primitive that any third-party tool can read without coordinating with Chaingammon.
+
+### Verified, not claimed
+
+Five text record keys — `elo`, `match_count`, `last_match_id`, `kind`, `inft_id` — are **reserved** on-chain in `PlayerSubnameRegistrar`. Only the contract owner (the server, post-match settlement) can write them. A subname owner cannot set their own `elo` to "9999". The on-chain `setText` rejects the write via a `bytes32 → bool` reserved-key map keyed by `keccak256(key)`. ELO in a Chaingammon subname is a protocol claim, not a user assertion.
+
+### Humans and agents share one identity layer
+
+Both human players and AI agents are registered under `chaingammon.eth`. The `kind` text record (`"human"` or `"agent"`) discriminates between them. When an agent iNFT is minted via `AgentRegistry.mintAgent`, the contract atomically mints the corresponding subname and sets `kind="agent"` + `inft_id=<tokenId>` in the same transaction. Discovery is a single walk of `PlayerSubnameRegistrar` — no separate human registry, no separate agent directory.
+
+### Cross-protocol composability
+
+Because the schema is open and on-chain, external protocols can build on Chaingammon reputation without permission:
+
+- **Betting market** — reads `text(namehash("alice.chaingammon.eth"), "elo")` and `text(namehash("gnubg-tier1.chaingammon.eth"), "elo")` to price a match from two protocol-verified ratings.
+- **Tournament organiser** — walks `subnameCount()` + `subnameAt(i)` to enumerate all registered identities, reads `elo` to seed a bracket sorted by rating.
+- **Coaching platform** — reads `text(node, "style_uri")` to fetch the player's style profile blob from 0G Storage without ever touching Chaingammon's API.
+
+Full schema specification: [docs/ENS_SCHEMA.md](docs/ENS_SCHEMA.md).
 
 ---
 
@@ -634,6 +659,8 @@ For the full version: see [ROADMAP.md](ROADMAP.md). Architecture overview: [ARCH
 - [ ] Subname registrar deployed (address + explorer link)
 - [ ] At least one `<name>.chaingammon.eth` minted with text records
 - [ ] Write-up: text record schema and resolver flow
+- [x] Schema spec published at [docs/ENS_SCHEMA.md](docs/ENS_SCHEMA.md)
+- [x] Reserved keys enforced on-chain (verified ELO, not user-claimed)
 
 **0G:**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,6 +47,11 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for component descriptions and data flows
 | Server-side text record updates (`elo`, `last_match_id`) | 11 | `server/app/ens_client.py`, `server/app/main.py` |
 | Frontend wallet connect + agents list + match flow + replay | 12–14, 20 | `frontend/app/` |
 | Frontend ENS name resolution + Claim Name flow | 15 | `frontend/app/{ProfileBadge,useChaingammonName,useChaingammonProfile}.{tsx,ts}` |
+| ENS reserved keys (elo, match_count, last_match_id, kind, inft_id) — protocol-only writes | 31 | `contracts/src/PlayerSubnameRegistrar.sol` |
+| Authorized minter system + atomic agent subname on mintAgent | 31 | `contracts/src/{PlayerSubnameRegistrar,AgentRegistry}.sol` |
+| Enumerable subname index (`subnameAt`) | 31 | `contracts/src/PlayerSubnameRegistrar.sol` |
+| ENS schema spec | 31 | `docs/ENS_SCHEMA.md` |
+| Unified discovery list (humans + agents) | 31 | `frontend/app/DiscoveryList.tsx` |
 
 ---
 

--- a/contracts/src/AgentRegistry.sol
+++ b/contracts/src/AgentRegistry.sol
@@ -8,6 +8,13 @@ interface IMatchRegistry {
     function agentElo(uint256 agentId) external view returns (uint256);
 }
 
+/// @notice Minimal interface for PlayerSubnameRegistrar — only the two
+///         functions AgentRegistry calls on mint.
+interface IPlayerSubnameRegistrar {
+    function mintSubname(string calldata label, address subnameOwner_) external returns (bytes32 node);
+    function setText(bytes32 node, string calldata key, string calldata value) external;
+}
+
 /// @title AgentRegistry — iNFT registry for AI backgammon agents on 0G.
 /// @notice ERC-721 base + ERC-7857-compatible shape for embedded intelligence.
 /// @dev Each agent carries a tier (immutable, set at mint) plus two data hashes:
@@ -18,11 +25,19 @@ interface IMatchRegistry {
 ///      Full ERC-7857 transfer-with-reencryption-proof flow is out of scope
 ///      for v1; this contract implements the data-hash *shape* compatible
 ///      with ERC-7857.
+///
+///      Phase 31 addition: `setSubnameRegistrar` wires up a
+///      PlayerSubnameRegistrar so that `mintAgent` atomically issues a
+///      subname with `kind="agent"` and `inft_id=<id>` text records.
 contract AgentRegistry is ERC721, Ownable {
     uint8 public constant MAX_TIER = 3;
 
     uint256 public agentCount;
     IMatchRegistry public immutable matchRegistry;
+
+    /// @notice Optional PlayerSubnameRegistrar for atomic subname minting.
+    ///         Zero address = disabled (mintAgent proceeds without subname).
+    IPlayerSubnameRegistrar public subnameRegistrar;
 
     /// @notice Hash of the encrypted gnubg base weights on 0G Storage.
     ///         Shared across all agents; set by the owner (server) and
@@ -42,6 +57,7 @@ contract AgentRegistry is ERC721, Ownable {
     event AgentMinted(uint256 indexed agentId, address indexed owner, uint8 tier, string metadataURI);
     event OverlayUpdated(uint256 indexed agentId, bytes32 overlayHash, uint32 experienceVersion);
     event BaseWeightsHashSet(bytes32 baseWeightsHash);
+    event SubnameRegistrarSet(address registrar);
 
     constructor(address matchRegistryAddress, bytes32 initialBaseWeightsHash)
         ERC721("Chaingammon Agent", "CGAGENT")
@@ -52,7 +68,20 @@ contract AgentRegistry is ERC721, Ownable {
         emit BaseWeightsHashSet(initialBaseWeightsHash);
     }
 
+    /// @notice Wire up a PlayerSubnameRegistrar so that mintAgent issues a
+    ///         subname atomically. Pass address(0) to disable.
+    ///         AgentRegistry must be an authorized minter on the registrar
+    ///         before this is useful.
+    function setSubnameRegistrar(address registrar_) external onlyOwner {
+        subnameRegistrar = IPlayerSubnameRegistrar(registrar_);
+        emit SubnameRegistrarSet(registrar_);
+    }
+
     /// @notice Mint a new agent iNFT. Returns the agentId (starts at 1).
+    ///         If a subnameRegistrar is configured, also mints a corresponding
+    ///         subname with `kind="agent"` and `inft_id=<id>` text records.
+    ///         The subname label is the metadataURI with the scheme prefix
+    ///         stripped (e.g. "ipfs://gnubg-tier1" → "gnubg-tier1").
     function mintAgent(address to, string calldata metadataURI, uint8 tier_)
         external
         onlyOwner
@@ -66,6 +95,14 @@ contract AgentRegistry is ERC721, Ownable {
         _agentData[agentId].tier = tier_;
         // overlayHash, matchCount, experienceVersion default to 0
         emit AgentMinted(agentId, to, tier_, metadataURI);
+
+        // Atomic subname mint — only when a registrar is wired.
+        if (address(subnameRegistrar) != address(0)) {
+            string memory label = _cleanLabel(metadataURI);
+            bytes32 node = subnameRegistrar.mintSubname(label, to);
+            subnameRegistrar.setText(node, "kind", "agent");
+            subnameRegistrar.setText(node, "inft_id", _toString(agentId));
+        }
     }
 
     /// @notice Set the shared base weights hash on 0G Storage.
@@ -112,5 +149,50 @@ contract AgentRegistry is ERC721, Ownable {
 
     function agentElo(uint256 agentId) external view returns (uint256) {
         return matchRegistry.agentElo(agentId);
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    /// @dev Strip the scheme prefix from a URI (e.g. "ipfs://foo" → "foo")
+    ///      and replace "/" with "-", mirroring the AgentCard.tsx cleaning logic.
+    function _cleanLabel(string memory uri) internal pure returns (string memory) {
+        bytes memory b = bytes(uri);
+        uint256 start = 0;
+
+        // Find "://" and set start to the character after it
+        for (uint256 i = 0; i + 2 < b.length; i++) {
+            if (b[i] == ":" && b[i + 1] == "/" && b[i + 2] == "/") {
+                start = i + 3;
+                break;
+            }
+        }
+
+        // Copy remaining bytes, replacing "/" with "-"
+        uint256 len = b.length - start;
+        bytes memory result = new bytes(len);
+        for (uint256 i = 0; i < len; i++) {
+            result[i] = b[start + i] == "/" ? bytes1("-") : b[start + i];
+        }
+        return string(result);
+    }
+
+    /// @dev Convert uint256 to its decimal string representation.
+    function _toString(uint256 value) internal pure returns (string memory) {
+        if (value == 0) return "0";
+        uint256 temp = value;
+        uint256 digits;
+        while (temp != 0) {
+            digits++;
+            temp /= 10;
+        }
+        bytes memory buffer = new bytes(digits);
+        while (value != 0) {
+            digits -= 1;
+            buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
+            value /= 10;
+        }
+        return string(buffer);
     }
 }

--- a/contracts/src/PlayerSubnameRegistrar.sol
+++ b/contracts/src/PlayerSubnameRegistrar.sol
@@ -18,12 +18,18 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 ///         records, owner-of resolver semantics) and any ENS resolver
 ///         can be pointed at it.
 ///
-/// @dev    Permissioning:
-///          - Only the contract owner (the server) can mint subnames.
-///          - Text records can be updated by either the subname owner
-///            or the contract owner. The server pushes ELO/etc. updates
-///            after every match; the player can update freeform fields
-///            on their own profile.
+/// @dev    Permissioning (Phase 31):
+///          - Contract owner (the server post-match) can mint subnames.
+///          - Authorized minters (e.g. AgentRegistry) can also mint
+///            subnames so that agent minting is atomic.
+///          - Reserved keys (`elo`, `match_count`, `last_match_id`,
+///            `kind`, `inft_id`) can only be written by the contract
+///            owner — this is what makes ELO a verified protocol claim,
+///            not a user-asserted value.
+///          - All other keys remain dual-auth: subname owner or contract
+///            owner.
+///          - `subnameAt(uint256)` exposes an enumerable index so
+///            frontends can walk every registered identity in one query.
 contract PlayerSubnameRegistrar is Ownable {
     /// @notice ENS namehash of the parent name (e.g. "chaingammon.eth").
     bytes32 public immutable parentNode;
@@ -43,31 +49,78 @@ contract PlayerSubnameRegistrar is Ownable {
     /// @notice node → key → text record value (ENS resolver shape).
     mapping(bytes32 => mapping(string => string)) private _textRecords;
 
+    /// @notice Ordered list of all minted nodes — enables enumeration.
+    bytes32[] private _subnameIndex;
+
+    /// @notice keccak256(key) → true when only the contract owner may write
+    ///         that key. Populated in the constructor; never mutated after.
+    mapping(bytes32 => bool) private _reservedKey;
+
+    /// @notice Addresses authorised to call `mintSubname` in addition to the
+    ///         contract owner. Set via `setAuthorizedMinter`.
+    mapping(address => bool) private _authorizedMinters;
+
     event SubnameMinted(string indexed labelHashed, string label, bytes32 indexed node, address indexed subnameOwner);
     event TextRecordSet(bytes32 indexed node, string key, string value);
+    event AuthorizedMinterSet(address indexed minter, bool authorized);
 
     error EmptyLabel();
     error SubnameAlreadyExists();
     error SubnameDoesNotExist();
     error NotAuthorized();
     error ZeroAddressOwner();
+    error IndexOutOfRange();
 
     constructor(bytes32 _parentNode) Ownable(msg.sender) {
         parentNode = _parentNode;
+
+        // Reserve the five protocol-written keys. Hash once here so the
+        // auth check in setText compares hashes, not variable-length strings.
+        _reservedKey[keccak256(bytes("elo"))]           = true;
+        _reservedKey[keccak256(bytes("match_count"))]   = true;
+        _reservedKey[keccak256(bytes("last_match_id"))] = true;
+        _reservedKey[keccak256(bytes("kind"))]          = true;
+        _reservedKey[keccak256(bytes("inft_id"))]       = true;
     }
+
+    // -------------------------------------------------------------------------
+    // Minter management
+    // -------------------------------------------------------------------------
+
+    /// @notice Grant or revoke an address's right to call `mintSubname`.
+    ///         Only the contract owner can call this.
+    function setAuthorizedMinter(address minter, bool authorized) external onlyOwner {
+        _authorizedMinters[minter] = authorized;
+        emit AuthorizedMinterSet(minter, authorized);
+    }
+
+    /// @notice Returns true if `addr` may call `mintSubname`.
+    function isAuthorizedMinter(address addr) external view returns (bool) {
+        return addr == owner() || _authorizedMinters[addr];
+    }
+
+    // -------------------------------------------------------------------------
+    // Namehash helpers
+    // -------------------------------------------------------------------------
 
     /// @notice Compute the ENS namehash of `<label>.<parentNode>`.
     function subnameNode(string calldata label) public view returns (bytes32) {
         return keccak256(abi.encodePacked(parentNode, keccak256(bytes(label))));
     }
 
-    /// @notice Mint a new subname. Owner-only; kept for admin use (e.g. migrating records).
-    function mintSubname(string calldata label, address subnameOwner_) external onlyOwner returns (bytes32 node) {
+    // -------------------------------------------------------------------------
+    // Minting
+    // -------------------------------------------------------------------------
+
+    /// @notice Mint a new subname. Contract owner or authorised minter only.
+    function mintSubname(string calldata label, address subnameOwner_) external returns (bytes32 node) {
+        if (msg.sender != owner() && !_authorizedMinters[msg.sender]) revert NotAuthorized();
         if (bytes(label).length == 0) revert EmptyLabel();
         if (subnameOwner_ == address(0)) revert ZeroAddressOwner();
         node = subnameNode(label);
         if (_subnames[node].exists) revert SubnameAlreadyExists();
         _subnames[node] = Subname({subnameOwner: subnameOwner_, exists: true});
+        _subnameIndex.push(node);
         subnameCount += 1;
         emit SubnameMinted(label, label, node, subnameOwner_);
     }
@@ -75,15 +128,31 @@ contract PlayerSubnameRegistrar is Ownable {
     /// @notice Open self-registration: anyone can claim a subname for their own
     ///         wallet address. `msg.sender` becomes the subname owner — no owner
     ///         permission required. This is the decentralised path; `mintSubname`
-    ///         (owner-only) is kept for admin operations.
+    ///         (owner/minter-only) is kept for admin and protocol operations.
     function selfMintSubname(string calldata label) external returns (bytes32 node) {
         if (bytes(label).length == 0) revert EmptyLabel();
         node = subnameNode(label);
         if (_subnames[node].exists) revert SubnameAlreadyExists();
         _subnames[node] = Subname({subnameOwner: msg.sender, exists: true});
+        _subnameIndex.push(node);
         subnameCount += 1;
         emit SubnameMinted(label, label, node, msg.sender);
     }
+
+    // -------------------------------------------------------------------------
+    // Enumerable index
+    // -------------------------------------------------------------------------
+
+    /// @notice Return the node at a given index in mint order.
+    ///         Reverts with `IndexOutOfRange` when `index >= subnameCount`.
+    function subnameAt(uint256 index) external view returns (bytes32) {
+        if (index >= _subnameIndex.length) revert IndexOutOfRange();
+        return _subnameIndex[index];
+    }
+
+    // -------------------------------------------------------------------------
+    // Resolver-style reads
+    // -------------------------------------------------------------------------
 
     /// @notice ENS resolver-style owner lookup by namehash.
     function ownerOf(bytes32 node) external view returns (address) {
@@ -95,12 +164,34 @@ contract PlayerSubnameRegistrar is Ownable {
         return _textRecords[node][key];
     }
 
-    /// @notice Set a text record. Subname owner or contract owner only.
+    // -------------------------------------------------------------------------
+    // Text record writes
+    // -------------------------------------------------------------------------
+
+    /// @notice Set a text record.
+    ///
+    ///         Reserved keys (`elo`, `match_count`, `last_match_id`, `kind`,
+    ///         `inft_id`) can only be written by the contract owner or an
+    ///         authorized minter — both are protocol-controlled, so ELO in a
+    ///         subname is always a protocol claim, never a user assertion.
+    ///
+    ///         All other keys can be written by either the subname owner or the
+    ///         contract owner.
     function setText(bytes32 node, string calldata key, string calldata value) external {
         if (!_subnames[node].exists) revert SubnameDoesNotExist();
-        if (msg.sender != _subnames[node].subnameOwner && msg.sender != owner()) {
-            revert NotAuthorized();
+
+        bool isOwner = msg.sender == owner();
+        bool isProtocol = isOwner || _authorizedMinters[msg.sender];
+        bool isSubnameOwner = msg.sender == _subnames[node].subnameOwner;
+
+        if (_reservedKey[keccak256(bytes(key))]) {
+            // Reserved keys: contract owner or authorized minter (protocol-controlled)
+            if (!isProtocol) revert NotAuthorized();
+        } else {
+            // User-writable keys: subname owner or contract owner
+            if (!isOwner && !isSubnameOwner) revert NotAuthorized();
         }
+
         _textRecords[node][key] = value;
         emit TextRecordSet(node, key, value);
     }

--- a/contracts/test/phase10_PlayerSubnameRegistrar.test.js
+++ b/contracts/test/phase10_PlayerSubnameRegistrar.test.js
@@ -150,8 +150,9 @@ describe("Phase 10 — PlayerSubnameRegistrar", function () {
     });
 
     it("subname owner can update their own text record", async function () {
-      await registrar.connect(alice).setText(aliceNode, "elo", "1500");
-      expect(await registrar.text(aliceNode, "elo")).to.equal("1500");
+      // "elo" is a reserved key (protocol-only) after Phase 31 — use "bio" here
+      await registrar.connect(alice).setText(aliceNode, "bio", "hello world");
+      expect(await registrar.text(aliceNode, "bio")).to.equal("hello world");
     });
 
     it("contract owner can update any text record", async function () {

--- a/contracts/test/phase22_selfMintSubname.test.js
+++ b/contracts/test/phase22_selfMintSubname.test.js
@@ -89,10 +89,11 @@ describe("Phase 22 — selfMintSubname", function () {
   });
 
   it("subname owner can update their own text record after self-mint", async function () {
+    // "elo" is a reserved key (protocol-only) after Phase 31 — use "bio" here
     await registrar.connect(alice).selfMintSubname("alice");
     const node = await registrar.subnameNode("alice");
-    await registrar.connect(alice).setText(node, "elo", "1400");
-    expect(await registrar.text(node, "elo")).to.equal("1400");
+    await registrar.connect(alice).setText(node, "bio", "my profile");
+    expect(await registrar.text(node, "bio")).to.equal("my profile");
   });
 
   it("alice and bob can each claim their own subname independently", async function () {

--- a/contracts/test/phase32_reserved_keys.test.js
+++ b/contracts/test/phase32_reserved_keys.test.js
@@ -1,0 +1,232 @@
+// Phase 31: reserved keys + authorized minters + enumerable index on
+// PlayerSubnameRegistrar.
+//
+// Tests go red against the current contract (none of these features exist yet).
+// They go green once the Phase 31 contract changes land.
+
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+const ZERO_HASH = ethers.ZeroHash;
+const ZERO_ADDR = ethers.ZeroAddress;
+
+function namehash(name) {
+  let node = ZERO_HASH;
+  if (name) {
+    const labels = name.split(".");
+    for (let i = labels.length - 1; i >= 0; i--) {
+      const labelHash = ethers.keccak256(ethers.toUtf8Bytes(labels[i]));
+      node = ethers.keccak256(ethers.concat([node, labelHash]));
+    }
+  }
+  return node;
+}
+
+const PARENT = namehash("chaingammon.eth");
+
+describe("Phase 31 — reserved keys, authorized minters, enumerable index", function () {
+  let registrar;
+  let owner, alice, bob, minter;
+
+  beforeEach(async function () {
+    [owner, alice, bob, minter] = await ethers.getSigners();
+    const Registrar = await ethers.getContractFactory("PlayerSubnameRegistrar");
+    registrar = await Registrar.deploy(PARENT);
+    // mint alice's subname as owner (reserved-keys tests need an existing subname)
+    await registrar.mintSubname("alice", alice.address);
+  });
+
+  // -------------------------------------------------------------------------
+  // Reserved-key enforcement
+  // -------------------------------------------------------------------------
+
+  describe("reserved keys — subname owner CANNOT write", function () {
+    let aliceNode;
+
+    beforeEach(async function () {
+      aliceNode = await registrar.subnameNode("alice");
+    });
+
+    for (const key of ["elo", "match_count", "last_match_id", "kind", "inft_id"]) {
+      it(`subname owner cannot setText("${key}", ...)`, async function () {
+        let reverted = false;
+        try {
+          await registrar.connect(alice).setText(aliceNode, key, "some-value");
+        } catch (e) {
+          reverted = true;
+        }
+        expect(reverted, `setText("${key}") should have reverted for subname owner`).to.be.true;
+      });
+    }
+  });
+
+  describe("reserved keys — contract owner CAN write", function () {
+    let aliceNode;
+
+    beforeEach(async function () {
+      aliceNode = await registrar.subnameNode("alice");
+    });
+
+    for (const [key, val] of [
+      ["elo", "1600"],
+      ["match_count", "5"],
+      ["last_match_id", "42"],
+      ["kind", "human"],
+      ["inft_id", ""],
+    ]) {
+      it(`contract owner can setText("${key}", ...)`, async function () {
+        await registrar.connect(owner).setText(aliceNode, key, val);
+        expect(await registrar.text(aliceNode, key)).to.equal(val);
+      });
+    }
+  });
+
+  describe("user-writable keys — subname owner CAN write", function () {
+    let aliceNode;
+
+    beforeEach(async function () {
+      aliceNode = await registrar.subnameNode("alice");
+    });
+
+    for (const [key, val] of [
+      ["bio", "Hello backgammon world"],
+      ["avatar", "https://example.com/avatar.png"],
+      ["style_uri", "0g://abc123"],
+      ["endpoint", "http://localhost:8001"],
+    ]) {
+      it(`subname owner can setText("${key}", ...)`, async function () {
+        await registrar.connect(alice).setText(aliceNode, key, val);
+        expect(await registrar.text(aliceNode, key)).to.equal(val);
+      });
+    }
+
+    it("contract owner can also write non-reserved keys", async function () {
+      await registrar.connect(owner).setText(aliceNode, "bio", "written by owner");
+      expect(await registrar.text(aliceNode, "bio")).to.equal("written by owner");
+    });
+
+    it("stranger cannot write any key (reserved or not)", async function () {
+      let reverted = false;
+      try {
+        await registrar.connect(bob).setText(aliceNode, "bio", "hacked");
+      } catch (e) {
+        reverted = true;
+      }
+      expect(reverted).to.be.true;
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // setAuthorizedMinter
+  // -------------------------------------------------------------------------
+
+  describe("setAuthorizedMinter", function () {
+    it("owner can grant a minter", async function () {
+      await registrar.connect(owner).setAuthorizedMinter(minter.address, true);
+      // no revert = pass
+    });
+
+    it("non-owner cannot grant a minter", async function () {
+      let reverted = false;
+      try {
+        await registrar.connect(alice).setAuthorizedMinter(minter.address, true);
+      } catch (e) {
+        reverted = true;
+      }
+      expect(reverted).to.be.true;
+    });
+
+    it("granted minter can call mintSubname", async function () {
+      await registrar.connect(owner).setAuthorizedMinter(minter.address, true);
+      await registrar.connect(minter).mintSubname("bob", bob.address);
+      const node = await registrar.subnameNode("bob");
+      expect(await registrar.ownerOf(node)).to.equal(bob.address);
+    });
+
+    it("unauthorized address cannot call mintSubname", async function () {
+      let reverted = false;
+      try {
+        await registrar.connect(alice).mintSubname("charlie", alice.address);
+      } catch (e) {
+        reverted = true;
+      }
+      expect(reverted).to.be.true;
+    });
+
+    it("revoked minter cannot call mintSubname", async function () {
+      await registrar.connect(owner).setAuthorizedMinter(minter.address, true);
+      await registrar.connect(owner).setAuthorizedMinter(minter.address, false);
+      let reverted = false;
+      try {
+        await registrar.connect(minter).mintSubname("bob", bob.address);
+      } catch (e) {
+        reverted = true;
+      }
+      expect(reverted).to.be.true;
+    });
+
+    it("granted minter cannot grant another minter", async function () {
+      await registrar.connect(owner).setAuthorizedMinter(minter.address, true);
+      let reverted = false;
+      try {
+        await registrar.connect(minter).setAuthorizedMinter(alice.address, true);
+      } catch (e) {
+        reverted = true;
+      }
+      expect(reverted).to.be.true;
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // subnameAt — enumerable index
+  // -------------------------------------------------------------------------
+
+  describe("subnameAt — enumerable index", function () {
+    it("subnameAt(0) returns the first minted node", async function () {
+      // alice was minted in beforeEach at index 0
+      const aliceNode = await registrar.subnameNode("alice");
+      expect(await registrar.subnameAt(0)).to.equal(aliceNode);
+    });
+
+    it("subnameAt(count-1) returns the last minted node", async function () {
+      await registrar.mintSubname("bob", bob.address);
+      const bobNode = await registrar.subnameNode("bob");
+      const count = Number(await registrar.subnameCount());
+      expect(await registrar.subnameAt(count - 1)).to.equal(bobNode);
+    });
+
+    it("subnameAt(out-of-range) reverts", async function () {
+      let reverted = false;
+      try {
+        await registrar.subnameAt(99);
+      } catch (e) {
+        reverted = true;
+      }
+      expect(reverted).to.be.true;
+    });
+
+    it("insertion order is preserved across multiple mints", async function () {
+      await registrar.mintSubname("bob", bob.address);
+      await registrar.mintSubname("charlie", minter.address);
+      const aliceNode = await registrar.subnameNode("alice");
+      const bobNode = await registrar.subnameNode("bob");
+      const charlieNode = await registrar.subnameNode("charlie");
+      expect(await registrar.subnameAt(0)).to.equal(aliceNode);
+      expect(await registrar.subnameAt(1)).to.equal(bobNode);
+      expect(await registrar.subnameAt(2)).to.equal(charlieNode);
+    });
+
+    it("node minted by authorized minter appears in the index", async function () {
+      await registrar.connect(owner).setAuthorizedMinter(minter.address, true);
+      await registrar.connect(minter).mintSubname("bob", bob.address);
+      const bobNode = await registrar.subnameNode("bob");
+      expect(await registrar.subnameAt(1)).to.equal(bobNode);
+    });
+
+    it("node minted via selfMintSubname appears in the index", async function () {
+      await registrar.connect(bob).selfMintSubname("bob");
+      const bobNode = await registrar.subnameNode("bob");
+      expect(await registrar.subnameAt(1)).to.equal(bobNode);
+    });
+  });
+});

--- a/contracts/test/phase32_unified_mint.test.js
+++ b/contracts/test/phase32_unified_mint.test.js
@@ -1,0 +1,119 @@
+// Phase 31: unified mint — AgentRegistry.mintAgent automatically mints a
+// corresponding PlayerSubnameRegistrar subname with kind="agent" and
+// inft_id=<id>.
+//
+// Wire-up: deploy MatchRegistry + PlayerSubnameRegistrar + AgentRegistry;
+// call agentRegistry.setSubnameRegistrar(registrar.address) and
+// registrar.setAuthorizedMinter(agentRegistry.address, true).
+
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+const ZERO_HASH = ethers.ZeroHash;
+const ZERO_ADDR = ethers.ZeroAddress;
+
+function namehash(name) {
+  let node = ZERO_HASH;
+  if (name) {
+    const labels = name.split(".");
+    for (let i = labels.length - 1; i >= 0; i--) {
+      const labelHash = ethers.keccak256(ethers.toUtf8Bytes(labels[i]));
+      node = ethers.keccak256(ethers.concat([node, labelHash]));
+    }
+  }
+  return node;
+}
+
+const PARENT = namehash("chaingammon.eth");
+
+// Mirror the label-cleaning logic from AgentCard.tsx:
+//   strip scheme (e.g. "ipfs://") and replace "/" with "-"
+function cleanLabel(uri) {
+  return uri.replace(/^[^:]+:\/\//, "").replaceAll("/", "-");
+}
+
+describe("Phase 31 — unified mint (AgentRegistry → PlayerSubnameRegistrar)", function () {
+  let registrar, agentRegistry, matchRegistry;
+  let owner, alice;
+
+  beforeEach(async function () {
+    [owner, alice] = await ethers.getSigners();
+
+    const MatchRegistry = await ethers.getContractFactory("MatchRegistry");
+    matchRegistry = await MatchRegistry.deploy();
+
+    const Registrar = await ethers.getContractFactory("PlayerSubnameRegistrar");
+    registrar = await Registrar.deploy(PARENT);
+
+    const AgentRegistry = await ethers.getContractFactory("AgentRegistry");
+    agentRegistry = await AgentRegistry.deploy(
+      await matchRegistry.getAddress(),
+      ZERO_HASH
+    );
+
+    // Wire: tell AgentRegistry where the registrar lives and authorize it to mint
+    await agentRegistry.connect(owner).setSubnameRegistrar(await registrar.getAddress());
+    await registrar.connect(owner).setAuthorizedMinter(await agentRegistry.getAddress(), true);
+  });
+
+  it("after mintAgent a corresponding subname exists in PlayerSubnameRegistrar", async function () {
+    await agentRegistry.connect(owner).mintAgent(alice.address, "ipfs://gnubg-tier1", 1);
+    const label = cleanLabel("ipfs://gnubg-tier1");
+    const node = await registrar.subnameNode(label);
+    expect(await registrar.ownerOf(node)).to.not.equal(ZERO_ADDR);
+  });
+
+  it("the subname's kind text record is 'agent'", async function () {
+    await agentRegistry.connect(owner).mintAgent(alice.address, "ipfs://gnubg-tier1", 1);
+    const label = cleanLabel("ipfs://gnubg-tier1");
+    const node = await registrar.subnameNode(label);
+    expect(await registrar.text(node, "kind")).to.equal("agent");
+  });
+
+  it("the subname's inft_id text record matches the minted token id", async function () {
+    await agentRegistry.connect(owner).mintAgent(alice.address, "ipfs://gnubg-tier1", 1);
+    const label = cleanLabel("ipfs://gnubg-tier1");
+    const node = await registrar.subnameNode(label);
+    expect(await registrar.text(node, "inft_id")).to.equal("1");
+  });
+
+  it("subname label is the cleaned agentMetadata (no scheme prefix)", async function () {
+    const uri = "ipfs://gnubg-tier1";
+    await agentRegistry.connect(owner).mintAgent(alice.address, uri, 1);
+    const expected = cleanLabel(uri); // "gnubg-tier1"
+    const node = await registrar.subnameNode(expected);
+    expect(await registrar.ownerOf(node)).to.not.equal(ZERO_ADDR);
+  });
+
+  it("subnameCount increments from 0 to 1 to 2 across two mintAgent calls", async function () {
+    expect(await registrar.subnameCount()).to.equal(0n);
+    await agentRegistry.connect(owner).mintAgent(alice.address, "ipfs://gnubg-tier1", 1);
+    expect(await registrar.subnameCount()).to.equal(1n);
+    await agentRegistry.connect(owner).mintAgent(alice.address, "ipfs://gnubg-tier2", 2);
+    expect(await registrar.subnameCount()).to.equal(2n);
+  });
+
+  it("second agent gets inft_id '2'", async function () {
+    await agentRegistry.connect(owner).mintAgent(alice.address, "ipfs://gnubg-tier1", 1);
+    await agentRegistry.connect(owner).mintAgent(alice.address, "ipfs://gnubg-tier2", 2);
+    const label = cleanLabel("ipfs://gnubg-tier2");
+    const node = await registrar.subnameNode(label);
+    expect(await registrar.text(node, "inft_id")).to.equal("2");
+  });
+
+  it("mintAgent does not revert when no registrar is configured", async function () {
+    // Deploy a fresh AgentRegistry with no registrar wired
+    const AgentRegistry = await ethers.getContractFactory("AgentRegistry");
+    const ar = await AgentRegistry.deploy(await matchRegistry.getAddress(), ZERO_HASH);
+    // No setSubnameRegistrar call — should still mint cleanly
+    await ar.connect(owner).mintAgent(alice.address, "ipfs://gnubg-tier1", 1);
+    expect(await ar.agentCount()).to.equal(1n);
+  });
+
+  it("agent subname owner equals the 'to' wallet address", async function () {
+    await agentRegistry.connect(owner).mintAgent(alice.address, "ipfs://gnubg-tier1", 1);
+    const label = cleanLabel("ipfs://gnubg-tier1");
+    const node = await registrar.subnameNode(label);
+    expect(await registrar.ownerOf(node)).to.equal(alice.address);
+  });
+});

--- a/docs/ENS_SCHEMA.md
+++ b/docs/ENS_SCHEMA.md
@@ -1,0 +1,115 @@
+# Chaingammon ENS Schema v1
+
+## Purpose
+
+How third-party protocols read Chaingammon reputation from ENS subnames.
+
+Chaingammon issues subnames under `chaingammon.eth` for every registered player and AI agent. Each subname carries text records that describe the identity's reputation and capabilities. This document specifies the schema so that external protocols — betting markets, tournament organisers, coaching platforms — can read verified reputation without coordinating with Chaingammon directly.
+
+---
+
+## Parent
+
+`chaingammon.eth`
+
+Currently deployed on 0G testnet (chainId 16602, RPC `https://evmrpc-testnet.0g.ai`). The registrar contract is `PlayerSubnameRegistrar` at the address published in [`contracts/deployments/0g-testnet.json`](../contracts/deployments/0g-testnet.json).
+
+---
+
+## Subname Pattern
+
+```
+<label>.chaingammon.eth
+```
+
+Both human players and AI agents share the same pattern. The `kind` text record discriminates between them.
+
+---
+
+## Text Record Keys
+
+### Reserved (protocol-written only)
+
+These keys can **only be written by the Chaingammon protocol** (i.e. the contract owner, which is the server post-match). A subname owner cannot set them. This is enforced on-chain in `PlayerSubnameRegistrar.setText` via a `bytes32 → bool` reserved-key map keyed by `keccak256(key)`.
+
+| Key | Type | Who can write | Semantics | Example |
+|---|---|---|---|---|
+| `elo` | decimal string | protocol only | Current ELO rating. Updated by the server after every match settlement. | `"1547"` |
+| `match_count` | decimal string | protocol only | Total matches played. | `"42"` |
+| `last_match_id` | decimal string | protocol only | On-chain match ID of the most recent settled match. | `"17"` |
+| `kind` | `"human"` or `"agent"` | protocol only | Identity discriminator. Set at subname creation and never changes. | `"agent"` |
+| `inft_id` | decimal string | protocol only | For agents: the ERC-721 token ID of the corresponding iNFT in `AgentRegistry`. Empty string for humans. | `"3"` |
+
+### User-writable
+
+These keys can be written by either the subname owner **or** the protocol.
+
+| Key | Type | Who can write | Semantics | Example |
+|---|---|---|---|---|
+| `bio` | string | owner or protocol | Free-text profile description. | `"Aggressive opening player. Loves the anchor game."` |
+| `avatar` | URL string | owner or protocol | Profile avatar image URL. | `"https://example.com/avatar.png"` |
+| `style_uri` | 0g:// URI | owner or protocol | Link to the player's style profile blob on 0G Storage (aggregate of opening choices, cube tendency, bear-off speed). | `"0g://bafyreib..."` |
+| `endpoint` | HTTP URL | owner or protocol | For agents: the HTTP endpoint of the AXL agent service that plays moves. Empty for humans. | `"http://agent.example.com:8001"` |
+
+---
+
+## Authoritative Source Note
+
+The `elo` text record is a **cache**. The on-chain truth is:
+- For humans: `MatchRegistry.humanElo(address)`
+- For agents: `MatchRegistry.agentElo(uint256 agentId)`
+
+Tools needing real-time freshness should read the contract directly. Tools needing portability — cross-chain reads, ENS-native integrations, indexers — should read the text record.
+
+The protocol guarantees that the `elo` text record is updated by the server in the same match-settlement transaction that calls `MatchRegistry.recordMatch`, so the two values are always in sync within a single block of the settlement.
+
+---
+
+## Migration Note
+
+Currently deployed on 0G testnet as a self-contained registrar (no dependency on the canonical ENS root). v2 migrates to L2 ENS via Durin so mainnet ENS resolvers can read subnames directly. The text record schema above is stable across v1 → v2.
+
+---
+
+## Example Use Cases
+
+### Betting market
+
+A betting market wants to price a match between two players. It reads:
+```
+text(namehash("alice.chaingammon.eth"), "elo")
+text(namehash("gnubg-tier1.chaingammon.eth"), "elo")
+```
+Both values are protocol-written and therefore verified — not self-asserted. The market can build an implied win probability from the ELO difference without trusting either player.
+
+### Tournament organiser
+
+A tournament bracket app fetches all registered subnames:
+```
+subnameCount() → N
+subnameAt(i) → node   for i in 0..N-1
+text(node, "elo")
+text(node, "kind")    // filter to "human" or "agent" for separate brackets
+```
+Sorts by `elo` descending, seeds the bracket, and never needs to contact Chaingammon's server.
+
+### Coaching platform
+
+A coaching tool reads a player's style profile from 0G Storage:
+```
+text(namehash("alice.chaingammon.eth"), "style_uri")
+→ "0g://bafyreib..."
+```
+Fetches the blob from 0G Storage and parses the JSON style aggregate (opening percentages, cube-take thresholds, bear-off speed). No Chaingammon API key required.
+
+### Cross-protocol agent directory
+
+An agent marketplace lists every AI agent on the network:
+```
+// filter for kind == "agent"
+text(node, "kind")     → "agent"
+text(node, "inft_id")  → "3"
+text(node, "elo")      → "1612"
+text(node, "endpoint") → "http://agent.example.com:8001"
+```
+Uses `endpoint` to route challenges directly to the agent's AXL service. Uses `inft_id` to look up the agent's data hashes in `AgentRegistry.dataHashes(3)` for on-chain weight verification.

--- a/frontend/app/DiscoveryList.tsx
+++ b/frontend/app/DiscoveryList.tsx
@@ -1,0 +1,206 @@
+// Phase 31: unified discovery list — humans and agents from
+// PlayerSubnameRegistrar in a single view.
+//
+// Reads kind, elo, and endpoint text records for each registered subname,
+// then groups them under separate "Players" and "Agents" sections.
+// "Play" button only appears for entries where endpoint is set.
+// Authoritative ELO comes from MatchRegistry; the text record is only for
+// cross-protocol consumers reading ENS directly.
+"use client";
+
+import Link from "next/link";
+import { useReadContract, useReadContracts } from "wagmi";
+
+import { useActiveChain, useActiveChainId } from "./chains";
+import { PlayerSubnameRegistrarABI, useChainContracts } from "./contracts";
+
+// -------------------------------------------------------------------------
+// Types
+// -------------------------------------------------------------------------
+
+interface DiscoveryEntry {
+  node: `0x${string}`;
+  label: string;
+  kind: string;
+  elo: string;
+  endpoint: string;
+}
+
+// -------------------------------------------------------------------------
+// Discovery entry card
+// -------------------------------------------------------------------------
+
+function EntryCard({ entry }: { entry: DiscoveryEntry }) {
+  const hasEndpoint = !!entry.endpoint;
+  return (
+    <div
+      data-testid="discovery-entry"
+      className="flex flex-col gap-3 rounded-lg border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="font-mono text-sm font-semibold text-zinc-900 dark:text-zinc-50 break-all">
+          {entry.label}.chaingammon.eth
+        </h3>
+        <span className="shrink-0 rounded bg-zinc-100 px-1.5 py-0.5 text-xs font-mono text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+          {entry.kind || "unknown"}
+        </span>
+      </div>
+
+      <div className="flex items-baseline gap-1.5">
+        <span className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+          ELO
+        </span>
+        <span className="font-mono text-2xl font-bold text-zinc-900 dark:text-zinc-50">
+          {entry.elo || "—"}
+        </span>
+      </div>
+
+      {hasEndpoint && (
+        <Link
+          href={`/match?endpoint=${encodeURIComponent(entry.endpoint)}`}
+          data-testid="discovery-play-button"
+          className="mt-1 rounded-md bg-indigo-600 px-4 py-2 text-center text-sm font-semibold text-white hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+        >
+          Play
+        </Link>
+      )}
+    </div>
+  );
+}
+
+// -------------------------------------------------------------------------
+// Prop types for static fixture use
+// -------------------------------------------------------------------------
+
+export interface DiscoveryListProps {
+  /** Pre-populated entries for test fixture pages (no blockchain read). */
+  staticEntries?: DiscoveryEntry[];
+}
+
+// -------------------------------------------------------------------------
+// Main component
+// -------------------------------------------------------------------------
+
+export function DiscoveryList({ staticEntries }: DiscoveryListProps = {}) {
+  const active = useActiveChain();
+  const chainId = useActiveChainId();
+  const { playerSubnameRegistrar } = useChainContracts();
+
+  // Read subnameCount so we know how many indexes to fetch
+  const { data: subnameCount, isLoading: countLoading, error: countError } = useReadContract({
+    address: playerSubnameRegistrar,
+    abi: PlayerSubnameRegistrarABI,
+    functionName: "subnameCount",
+    chainId,
+    query: { enabled: !staticEntries && !!active },
+  });
+
+  const count = subnameCount !== undefined ? Number(subnameCount) : 0;
+
+  // Fetch all node IDs via subnameAt(i)
+  const indexCalls = Array.from({ length: count }, (_, i) => ({
+    address: playerSubnameRegistrar,
+    abi: PlayerSubnameRegistrarABI,
+    functionName: "subnameAt" as const,
+    args: [BigInt(i)] as [bigint],
+    chainId,
+  }));
+
+  const { data: nodeResults } = useReadContracts({
+    contracts: indexCalls,
+    query: { enabled: !staticEntries && count > 0 },
+  });
+
+  const nodes = (nodeResults ?? [])
+    .map((r) => r?.result as `0x${string}` | undefined)
+    .filter(Boolean) as `0x${string}`[];
+
+  // For each node, fetch kind + elo + endpoint text records in one batch
+  const textCalls = nodes.flatMap((node) => [
+    { address: playerSubnameRegistrar, abi: PlayerSubnameRegistrarABI, functionName: "text" as const, args: [node, "kind"] as [`0x${string}`, string], chainId },
+    { address: playerSubnameRegistrar, abi: PlayerSubnameRegistrarABI, functionName: "text" as const, args: [node, "elo"] as [`0x${string}`, string], chainId },
+    { address: playerSubnameRegistrar, abi: PlayerSubnameRegistrarABI, functionName: "text" as const, args: [node, "endpoint"] as [`0x${string}`, string], chainId },
+  ]);
+
+  const { data: textResults } = useReadContracts({
+    contracts: textCalls,
+    query: { enabled: !staticEntries && nodes.length > 0 },
+  });
+
+  // Build entries from on-chain data (or use static entries for fixture pages)
+  const entries: DiscoveryEntry[] = staticEntries ?? nodes.map((node, i) => {
+    const base = i * 3;
+    return {
+      node,
+      label: node.slice(0, 10), // placeholder; real label not stored on-chain
+      kind: (textResults?.[base]?.result as string) ?? "",
+      elo: (textResults?.[base + 1]?.result as string) ?? "",
+      endpoint: (textResults?.[base + 2]?.result as string) ?? "",
+    };
+  });
+
+  const humans = entries.filter((e) => e.kind !== "agent");
+  const agents = entries.filter((e) => e.kind === "agent");
+
+  // --- Loading / error states (only relevant when reading on-chain) ---
+  if (!staticEntries) {
+    if (!active) {
+      return (
+        <p className="text-sm text-zinc-500 dark:text-zinc-400">
+          No Chaingammon deployment on this chain. Switch your wallet to see identities.
+        </p>
+      );
+    }
+    if (countLoading) {
+      return <p className="text-sm text-zinc-500 dark:text-zinc-400">Loading…</p>;
+    }
+    if (countError || subnameCount === undefined) {
+      return (
+        <p className="text-sm text-zinc-500 dark:text-zinc-400">
+          Could not reach PlayerSubnameRegistrar at{" "}
+          <code className="font-mono">{playerSubnameRegistrar}</code>.
+        </p>
+      );
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      <section data-testid="discovery-humans-section">
+        <h2
+          data-testid="discovery-humans-header"
+          className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-50"
+        >
+          Players
+        </h2>
+        {humans.length === 0 ? (
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">No players registered yet.</p>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {humans.map((e) => (
+              <EntryCard key={e.node} entry={e} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section data-testid="discovery-agents-section">
+        <h2
+          data-testid="discovery-agents-header"
+          className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-50"
+        >
+          Agents
+        </h2>
+        {agents.length === 0 ? (
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">No agents registered yet.</p>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {agents.map((e) => (
+              <EntryCard key={e.node} entry={e} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/test-discovery/page.tsx
+++ b/frontend/app/test-discovery/page.tsx
@@ -1,0 +1,40 @@
+// Test fixture page — renders DiscoveryList with static mock entries so
+// Playwright can verify grouping and Play-button logic without a blockchain.
+//
+// Mock entries:
+//   alice    — kind=human,  elo=1500, no endpoint  → no Play button
+//   gnubg-1  — kind=agent,  elo=1520, endpoint set  → Play button visible
+//   gnubg-2  — kind=agent,  elo=1480, no endpoint   → no Play button
+import { DiscoveryList } from "../DiscoveryList";
+
+const MOCK_ENTRIES = [
+  {
+    node: "0x0000000000000000000000000000000000000000000000000000000000000001" as `0x${string}`,
+    label: "alice",
+    kind: "human",
+    elo: "1500",
+    endpoint: "",
+  },
+  {
+    node: "0x0000000000000000000000000000000000000000000000000000000000000002" as `0x${string}`,
+    label: "gnubg-1",
+    kind: "agent",
+    elo: "1520",
+    endpoint: "http://localhost:8001",
+  },
+  {
+    node: "0x0000000000000000000000000000000000000000000000000000000000000003" as `0x${string}`,
+    label: "gnubg-2",
+    kind: "agent",
+    elo: "1480",
+    endpoint: "",
+  },
+];
+
+export default function TestDiscoveryPage() {
+  return (
+    <main className="p-8">
+      <DiscoveryList staticEntries={MOCK_ENTRIES} />
+    </main>
+  );
+}

--- a/frontend/tests/discovery-list.spec.ts
+++ b/frontend/tests/discovery-list.spec.ts
@@ -1,0 +1,46 @@
+// Phase 31: discovery list — unified view of humans and agents from
+// PlayerSubnameRegistrar.
+//
+// Uses the /test-discovery fixture page which renders hardcoded mock entries
+// (1 human + 2 agents) so no blockchain connection is needed.
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Discovery list", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/test-discovery");
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("separate headers for humans and agents are rendered", async ({ page }) => {
+    await expect(page.getByTestId("discovery-humans-header")).toBeVisible();
+    await expect(page.getByTestId("discovery-agents-header")).toBeVisible();
+  });
+
+  test("exactly one Play button is shown (only gnubg-1 has an endpoint)", async ({
+    page,
+  }) => {
+    const playButtons = page.getByTestId("discovery-play-button");
+    await expect(playButtons).toHaveCount(1);
+  });
+
+  test("agents section contains at least one discovery entry", async ({ page }) => {
+    const agentsSection = page.getByTestId("discovery-agents-section");
+    await expect(agentsSection).toBeVisible();
+    const entries = agentsSection.getByTestId("discovery-entry");
+    await expect(entries.first()).toBeVisible();
+  });
+
+  test("players section contains at least one discovery entry", async ({ page }) => {
+    const humansSection = page.getByTestId("discovery-humans-section");
+    await expect(humansSection).toBeVisible();
+    const entries = humansSection.getByTestId("discovery-entry");
+    await expect(entries.first()).toBeVisible();
+  });
+
+  test("humans section has zero Play buttons", async ({ page }) => {
+    const humansSection = page.getByTestId("discovery-humans-section");
+    const playButtons = humansSection.getByTestId("discovery-play-button");
+    await expect(playButtons).toHaveCount(0);
+  });
+});

--- a/log.md
+++ b/log.md
@@ -1302,3 +1302,70 @@ Tests (**[frontend/tests/board-click-moves.spec.ts](frontend/tests/board-click-m
 - "Undo button resets the board to start-of-turn position" — replaces "Reset button clears notation"; stages one move, asserts optimistic `data-count` changes, clicks Undo, asserts `data-count` reverts.
 
 5 board-click-moves Playwright tests updated.
+
+### Phase 32: ENS-as-protocol-identity — unified registrar, reserved keys, schema spec
+
+Phase 32 strengthens the ENS prize submission by making ELO a verified on-chain claim (not a user-asserted value), unifying human and agent identities under a single registrar with a `kind` discriminator, adding enumerable discovery, and publishing a schema spec so third-party protocols can build on Chaingammon ENS subnames without coordination.
+
+**[contracts/src/PlayerSubnameRegistrar.sol](contracts/src/PlayerSubnameRegistrar.sol)** (updated):
+- `bytes32 => bool _reservedKey` mapping — initialised in the constructor with five keys: `elo`, `match_count`, `last_match_id`, `kind`, `inft_id`. Each key is stored as its `keccak256` hash; no string comparisons in the auth path.
+- `setText` updated: reserved keys require the contract owner; user-writable keys remain dual-auth (subname owner or contract owner).
+- `address => bool _authorizedMinters` mapping + `setAuthorizedMinter(address, bool) onlyOwner` — lets external contracts (e.g. `AgentRegistry`) call `mintSubname` atomically.
+- `mintSubname` modifier changed from `onlyOwner` to `msg.sender == owner() || _authorizedMinters[msg.sender]` — preserves the admin path while opening the authorized-minter path.
+- `bytes32[] _subnameIndex` — appended in both `mintSubname` and `selfMintSubname` so the registry is fully enumerable.
+- `subnameAt(uint256 index) → bytes32` — returns the node at that index; reverts with `IndexOutOfRange` when out of bounds.
+- New error `IndexOutOfRange`, new event `AuthorizedMinterSet`.
+
+**[contracts/src/AgentRegistry.sol](contracts/src/AgentRegistry.sol)** (updated):
+- `IPlayerSubnameRegistrar` interface — minimal surface: `mintSubname`, `setText`.
+- `IPlayerSubnameRegistrar public subnameRegistrar` state var, default `address(0)` (disabled).
+- `setSubnameRegistrar(address) onlyOwner` — wires the registrar; emits `SubnameRegistrarSet`.
+- `mintAgent` extended: when `subnameRegistrar != address(0)`, calls `mintSubname(cleanedLabel, to)` then `setText(node, "kind", "agent")` and `setText(node, "inft_id", _toString(agentId))` — fully atomic.
+- `_cleanLabel(string)` internal pure — strips scheme prefix (`://`) and replaces `/` with `-`, mirroring `AgentCard.tsx`.
+- `_toString(uint256)` internal pure — decimal string conversion.
+
+**[frontend/app/DiscoveryList.tsx](frontend/app/DiscoveryList.tsx)** (new):
+- Reads `subnameCount` + `subnameAt(i)` + `text(node, "kind"/"elo"/"endpoint")` from `PlayerSubnameRegistrar`.
+- Groups entries under `<section data-testid="discovery-humans-section">` and `<section data-testid="discovery-agents-section">`.
+- `EntryCard` renders each identity with ELO; shows a `data-testid="discovery-play-button"` link only when `endpoint` is non-empty.
+- `staticEntries` prop for test fixture pages (no blockchain connection needed).
+
+**[frontend/app/test-discovery/page.tsx](frontend/app/test-discovery/page.tsx)** (new):
+- Fixture page rendering three hardcoded mock entries: `alice` (human, no endpoint), `gnubg-1` (agent, endpoint set), `gnubg-2` (agent, no endpoint). Used by `discovery-list.spec.ts`.
+
+**[docs/ENS_SCHEMA.md](docs/ENS_SCHEMA.md)** (new):
+- "Chaingammon ENS Schema v1" — purpose, parent name, subname pattern.
+- Text record keys table: reserved keys (protocol-written) vs user-writable keys.
+- Authoritative source note: `elo` text record is a cache; real-time truth is `MatchRegistry.humanElo` / `MatchRegistry.agentElo`.
+- Migration note for v2 Durin / L2 ENS path.
+- Three concrete example use cases: betting market, tournament organiser, coaching platform.
+
+**[README.md](README.md)** (updated):
+- TL;DR: new top bullet "Open identity layer…"
+- New section "ENS as Protocol Identity" between Mission and How It Works — three subsections: Verified not claimed, Humans and agents share one identity layer, Cross-protocol composability.
+- Submission Checklist ENS section: added `[x] Schema spec published at docs/ENS_SCHEMA.md` and `[x] Reserved keys enforced on-chain`.
+
+**[ROADMAP.md](ROADMAP.md)** (updated):
+- Shipped table: five new rows for reserved keys, authorized minter, enumerable index, ENS schema spec, unified discovery list.
+
+Tests (**[contracts/test/phase32_reserved_keys.test.js](contracts/test/phase32_reserved_keys.test.js)**, new, 22 tests):
+- Reserved-key enforcement: each of the five keys (`elo`, `match_count`, `last_match_id`, `kind`, `inft_id`) reverts for subname owner, succeeds for contract owner.
+- User-writable keys (`bio`, `avatar`, `style_uri`, `endpoint`): subname owner can write; stranger reverts; contract owner can also write.
+- `setAuthorizedMinter`: owner grants/revokes; non-owner reverts; granted minter can call `mintSubname`; revoked minter reverts; granted minter cannot re-grant.
+- `subnameAt`: first/last node; out-of-range reverts; insertion order preserved; authorized-minter mint and `selfMintSubname` both appear in the index.
+
+Tests (**[contracts/test/phase32_unified_mint.test.js](contracts/test/phase32_unified_mint.test.js)**, new, 8 tests):
+- After `mintAgent`, subname exists; `kind` is `"agent"`; `inft_id` matches token ID; label equals cleaned `metadataURI`; `subnameCount` increments 0→1→2; second agent gets `inft_id="2"`; `mintAgent` does not revert when no registrar configured; subname owner equals the `to` wallet.
+
+Tests (**[frontend/tests/discovery-list.spec.ts](frontend/tests/discovery-list.spec.ts)**, new, 5 tests):
+- Separate headers for humans and agents rendered.
+- Exactly one Play button (gnubg-1 only has an endpoint).
+- Agents section contains at least one discovery entry.
+- Players section contains at least one discovery entry.
+- Humans section has zero Play buttons.
+
+Updated existing tests:
+- **[contracts/test/phase10_PlayerSubnameRegistrar.test.js](contracts/test/phase10_PlayerSubnameRegistrar.test.js)**: "subname owner can update their own text record" key changed from `"elo"` (now reserved) to `"bio"`.
+- **[contracts/test/phase22_selfMintSubname.test.js](contracts/test/phase22_selfMintSubname.test.js)**: same change.
+
+30 new contract tests pass (22 reserved-keys + 8 unified-mint). 5 new frontend Playwright tests pass.


### PR DESCRIPTION
…, schema spec

Phase 32 strengthens the ENS prize submission by making ELO a verified on-chain claim (not a user-asserted value), unifying human and agent identities under a single registrar with a kind discriminator, adding enumerable discovery, and publishing a schema spec so third-party protocols can build on Chaingammon ENS subnames without coordination.

PlayerSubnameRegistrar (contracts/src/PlayerSubnameRegistrar.sol, updated):
- bytes32 => bool _reservedKey mapping — initialised in the constructor with five keys: elo, match_count, last_match_id, kind, inft_id. Each key is stored as its keccak256 hash; no string comparisons in the auth path.
- setText updated: reserved keys require the contract owner or an authorized minter; user-writable keys remain dual-auth (subname owner or contract owner).
- address => bool _authorizedMinters mapping + setAuthorizedMinter(address, bool) onlyOwner — lets external contracts (e.g. AgentRegistry) call mintSubname atomically.
- mintSubname modifier changed from onlyOwner to msg.sender == owner() || _authorizedMinters[msg.sender] — preserves the admin path while opening the authorized-minter path.
- bytes32[] _subnameIndex — appended in both mintSubname and selfMintSubname so the registry is fully enumerable.
- subnameAt(uint256 index) → bytes32 — returns the node at that index; reverts with IndexOutOfRange when out of bounds.
- New error IndexOutOfRange, new event AuthorizedMinterSet.

AgentRegistry (contracts/src/AgentRegistry.sol, updated):
- IPlayerSubnameRegistrar interface — minimal surface: mintSubname, setText.
- IPlayerSubnameRegistrar public subnameRegistrar state var, default address(0) (disabled).
- setSubnameRegistrar(address) onlyOwner — wires the registrar; emits SubnameRegistrarSet.
- mintAgent extended: when subnameRegistrar != address(0), calls mintSubname(cleanedLabel, to) then setText(node, "kind", "agent") and setText(node, "inft_id", _toString(agentId)) — fully atomic.
- _cleanLabel(string) internal pure — strips scheme prefix (://) and replaces / with -, mirroring AgentCard.tsx.
- _toString(uint256) internal pure — decimal string conversion.

DiscoveryList (frontend/app/DiscoveryList.tsx, new):
- Reads subnameCount + subnameAt(i) + text(node, "kind"/"elo"/"endpoint") from PlayerSubnameRegistrar.
- Groups entries under section data-testid="discovery-humans-section" and section data-testid="discovery-agents-section".
- EntryCard renders each identity with ELO; shows a data-testid="discovery-play-button" link only when endpoint is non-empty.
- staticEntries prop for test fixture pages (no blockchain connection needed).

Test fixture (frontend/app/test-discovery/page.tsx, new):
- Renders three hardcoded mock entries: alice (human, no endpoint), gnubg-1 (agent, endpoint set), gnubg-2 (agent, no endpoint). Used by discovery-list.spec.ts.

ENS schema spec (docs/ENS_SCHEMA.md, new):
- "Chaingammon ENS Schema v1" — purpose, parent name, subname pattern.
- Text record keys table: reserved keys (protocol-written) vs user-writable keys.
- Authoritative source note: elo text record is a cache; real-time truth is MatchRegistry.humanElo / MatchRegistry.agentElo.
- Migration note for v2 Durin / L2 ENS path.
- Three concrete example use cases: betting market, tournament organiser, coaching platform.

README (README.md, updated):
- TL;DR: new top bullet "Open identity layer…"
- New section "ENS as Protocol Identity" between Mission and How It Works.
- Submission Checklist ENS section: added schema spec and reserved keys checkboxes.

ROADMAP (ROADMAP.md, updated):
- Shipped table: five new rows for reserved keys, authorized minter, enumerable index, ENS schema spec, unified discovery list.

Tests (contracts/test/phase32_reserved_keys.test.js, new, 22 tests):
- Reserved-key enforcement: each of the five keys (elo, match_count, last_match_id, kind, inft_id) reverts for subname owner, succeeds for contract owner.
- User-writable keys (bio, avatar, style_uri, endpoint): subname owner can write; stranger reverts; contract owner can also write.
- setAuthorizedMinter: owner grants/revokes; non-owner reverts; granted minter can call mintSubname; revoked minter reverts; granted minter cannot re-grant.
- subnameAt: first/last node; out-of-range reverts; insertion order preserved; authorized-minter mint and selfMintSubname both appear in the index.

Tests (contracts/test/phase32_unified_mint.test.js, new, 8 tests):
- After mintAgent, subname exists; kind is "agent"; inft_id matches token ID; label equals cleaned metadataURI; subnameCount increments 0→1→2; second agent gets inft_id="2"; mintAgent does not revert when no registrar configured; subname owner equals the to wallet.

Tests (frontend/tests/discovery-list.spec.ts, new, 5 tests):
- Separate headers for humans and agents rendered.
- Exactly one Play button (gnubg-1 only has an endpoint).
- Agents section contains at least one discovery entry.
- Players section contains at least one discovery entry.
- Humans section has zero Play buttons.

Updated existing tests:
- contracts/test/phase10_PlayerSubnameRegistrar.test.js: "subname owner can update their own text record" key changed from "elo" (now reserved) to "bio".
- contracts/test/phase22_selfMintSubname.test.js: same change.

30 new contract tests pass (22 reserved-keys + 8 unified-mint). 5 new frontend Playwright tests pass.