### PR TITLE
Phase 37: add WalletConnect integration

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,10 @@
+# WalletConnect Project ID — required for WalletConnect modal / mobile deeplink.
+# Create a free project at https://cloud.walletconnect.com and copy the Project ID.
+# Without this, only browser-injected wallets (MetaMask, Coinbase Wallet browser
+# extension) are offered. With it, any WalletConnect-compatible mobile wallet
+# (MetaMask Mobile, Rainbow, etc.) can connect by scanning a QR code or deeplink.
+NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
+
 # AXL gnubg agent node URL (the local gnubg_service from agent/).
 # Used by the match flow page (frontend/app/match/page.tsx) for
 # /new, /apply, /move, /resign, /evaluate. Defaults to localhost:8001 if unset.

--- a/frontend/app/ConnectButton.tsx
+++ b/frontend/app/ConnectButton.tsx
@@ -1,20 +1,17 @@
 "use client";
 
-// Phase 12: connect / disconnect button + network dropdown.
+// Connect / disconnect button with injected-wallet and WalletConnect support.
 //
-// Three states:
-//   1. No wallet detected (no injected connector)  → "Install MetaMask"
-//   2. Wallet detected, not connected              → "Connect wallet"
-//   3. Connected                                   → network dropdown
-//      (replaces the old amber "Switch to X" nudge), profile badge,
-//      disconnect button.
+// Four states:
+//   1. Not mounted (SSR)          → null (avoids hydration mismatch)
+//   2. No wallet / no WC config   → "Install MetaMask" link
+//   3. Not connected, wallet(s) available → injected button + WalletConnect
+//      button (if projectId is configured)
+//   4. Connected                  → network dropdown, profile badge, disconnect
 //
-// SSR note: wagmi is configured with ssr:true, which means the server has no
-// access to window.ethereum and renders connectors as []. Without a mounted
-// guard the server emits "Install MetaMask" while the client wants "Connect
-// wallet" — a structural mismatch that causes React hydration to silently
-// drop the click handler. The `mounted` state defers the real render until
-// after hydration so both trees agree.
+// SSR note: wagmi is configured with ssr:true so the server renders connectors
+// as []. The `mounted` guard defers the real render until after hydration so
+// both trees agree and the click handler is never silently dropped.
 
 import { useAccount, useConnect, useDisconnect } from "wagmi";
 import type { Connector } from "wagmi";
@@ -31,13 +28,13 @@ export function ConnectButton() {
   useEffect(() => setMounted(true), []);
 
   const injectedConnector = connectors.find((c: Connector) => c.type === "injected");
+  const wcConnector = connectors.find((c: Connector) => c.type === "walletConnect");
 
-  // Render nothing until hydration is complete — avoids a structural mismatch
-  // between the SSR output (no window.ethereum) and the client tree.
   if (!mounted) return null;
 
   if (!isConnected) {
-    if (!injectedConnector) {
+    const hasAnyConnector = injectedConnector || wcConnector;
+    if (!hasAnyConnector) {
       return (
         <a
           href="https://metamask.io/download/"
@@ -51,14 +48,28 @@ export function ConnectButton() {
     }
     return (
       <div className="flex flex-col items-end gap-1">
-        <button
-          type="button"
-          onClick={() => connect({ connector: injectedConnector })}
-          disabled={connectPending}
-          className="inline-flex h-10 items-center rounded-full bg-zinc-900 px-4 text-sm font-medium text-zinc-50 hover:bg-zinc-700 disabled:opacity-60 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300"
-        >
-          {connectPending ? "Connecting…" : "Connect wallet"}
-        </button>
+        <div className="flex flex-wrap justify-end gap-2">
+          {injectedConnector && (
+            <button
+              type="button"
+              onClick={() => connect({ connector: injectedConnector })}
+              disabled={connectPending}
+              className="inline-flex h-10 items-center rounded-full bg-zinc-900 px-4 text-sm font-medium text-zinc-50 hover:bg-zinc-700 disabled:opacity-60 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300"
+            >
+              {connectPending ? "Connecting…" : "Browser wallet"}
+            </button>
+          )}
+          {wcConnector && (
+            <button
+              type="button"
+              onClick={() => connect({ connector: wcConnector })}
+              disabled={connectPending}
+              className="inline-flex h-10 items-center rounded-full border border-zinc-300 px-4 text-sm font-medium text-zinc-900 hover:bg-zinc-50 disabled:opacity-60 dark:border-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-900"
+            >
+              WalletConnect
+            </button>
+          )}
+        </div>
         {connectError ? (
           <span className="text-xs text-red-600 dark:text-red-400">
             {connectError.message}

--- a/frontend/app/wagmi.ts
+++ b/frontend/app/wagmi.ts
@@ -9,16 +9,44 @@ import { createConfig } from "wagmi";
 // avoid the latter's umbrella export, which transitively pulls in
 // `@wagmi/core/tempo` — that file imports a missing `accounts` package
 // and crashes Webpack at build time. Turbopack happens to skip the dead
-// branch; Webpack does not.
+// branch; Webpack does not. `walletConnect` is NOT in @wagmi/core so it
+// comes from `@wagmi/connectors` directly (same avoidance of
+// `wagmi/connectors` umbrella). next.config.ts aliases `accounts → false`
+// so Webpack resolves the optional peer without crashing.
 import { injected } from "@wagmi/core";
+import { walletConnect } from "@wagmi/connectors";
 
 import { ALL_CHAINS, CHAIN_REGISTRY } from "./chains";
 
 const transports = Object.fromEntries(ALL_CHAINS.map((c) => [c.id, http()]));
 
+// WalletConnect requires a Project ID from cloud.walletconnect.com.
+// Set NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID in your .env (or GitHub secrets
+// for CI). If it is missing we skip the connector so the app still boots.
+const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID;
+
+const connectors = projectId
+  ? [
+      injected({ shimDisconnect: true }),
+      walletConnect({
+        projectId,
+        metadata: {
+          name: "Chaingammon",
+          description: "Open protocol for portable backgammon reputation",
+          url:
+            typeof window !== "undefined"
+              ? window.location.origin
+              : "https://oslinin.github.io/chaingammon",
+          icons: ["https://oslinin.github.io/chaingammon/favicon.ico"],
+        },
+        showQrModal: true,
+      }),
+    ]
+  : [injected({ shimDisconnect: true })];
+
 export const config = createConfig({
   chains: ALL_CHAINS,
-  connectors: [injected({ shimDisconnect: true })],
+  connectors,
   transports,
   ssr: true,
 });

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -6,6 +6,17 @@ import type { NextConfig } from "next";
 const basePath = process.env.BASE_PATH ?? "";
 
 const nextConfig: NextConfig = {
+  // `accounts` is an optional peer dep of @wagmi/core and @wagmi/connectors that
+  // is not published to npm. @wagmi/core/tempo references it but the feature is
+  // unused. Without this alias Webpack chokes trying to resolve the import.
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      accounts: false,
+    };
+    return config;
+  },
+
   // Static export — produces the `out/` directory which can be hosted on
   // GitHub Pages or any static file server. No Node.js server required.
   output: "export",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,9 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.100.5",
+    "@wagmi/connectors": "^8.0.4",
     "@wagmi/core": "3.4.6",
+    "@walletconnect/ethereum-provider": "^2.21.1",
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.100.5
         version: 5.100.5(react@19.2.4)
+      '@wagmi/connectors':
+        specifier: ^8.0.4
+        version: 8.0.4(@wagmi/core@3.4.5(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.48.4(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(viem@2.48.4(typescript@5.9.3)(zod@4.3.6))
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
Adds WalletConnect support so any WalletConnect-compatible mobile wallet can connect by QR code or deeplink, in addition to the existing injected-provider flow.

- `wagmi.ts`: adds `walletConnect` connector from `@wagmi/connectors` (Webpack-safe import, not the umbrella)
- `ConnectButton.tsx`: renders "Browser wallet" + "WalletConnect" buttons when both connectors present
- `next.config.ts`: webpack alias `accounts → false` to stub missing optional peer
- `package.json`: adds `@wagmi/connectors` and `@walletconnect/ethereum-provider` as direct deps

> After merging, run `pnpm install` from `frontend/` to update the lockfile before building.

Closes #37

Generated with [Claude Code](https://claude.ai/code)