### PR TITLE
Phase 35: mobile & desktop responsive layout

### DIFF
--- a/frontend/app/MobileNav.tsx
+++ b/frontend/app/MobileNav.tsx
@@ -1,0 +1,42 @@
+// Phase 35: fixed bottom navigation bar for mobile screens.
+// Hidden on md+ breakpoints (>= 768px) where the sidebar is visible.
+// Reads lastAgentId from localStorage (same key the match page writes)
+// so the Play link targets the most recently used agent.
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+export function MobileNav() {
+  const [lastAgentId, setLastAgentId] = useState<number | null>(null);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("lastAgentId");
+    if (stored) setLastAgentId(Number(stored));
+  }, []);
+
+  const playHref = lastAgentId
+    ? `/match?agentId=${lastAgentId}`
+    : "/match?agentId=1";
+
+  const linkClass =
+    "flex flex-1 items-center justify-center py-3 text-sm font-medium text-zinc-600 hover:bg-zinc-50 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-900 dark:hover:text-zinc-50";
+
+  return (
+    <nav
+      data-testid="mobile-nav"
+      aria-label="Mobile navigation"
+      className="fixed bottom-0 left-0 right-0 z-50 flex border-t border-zinc-200 bg-white md:hidden dark:border-zinc-800 dark:bg-zinc-950"
+    >
+      <Link href="/" data-testid="mobile-nav-home" className={linkClass}>
+        Home
+      </Link>
+      <Link href={playHref} data-testid="mobile-nav-play" className={linkClass}>
+        Play
+      </Link>
+      <Link href="/expenses" data-testid="mobile-nav-expenses" className={linkClass}>
+        Expenses
+      </Link>
+    </nav>
+  );
+}

--- a/frontend/app/Sidebar.tsx
+++ b/frontend/app/Sidebar.tsx
@@ -1,4 +1,4 @@
-// Phase 28: global sidebar navigation.
+// Phase 28: global sidebar navigation. Phase 35: hidden on mobile (md:flex).
 //
 // Navigation entries:
 //   1. "Play with agent" — links to /match with the most recently played
@@ -102,7 +102,7 @@ export function Sidebar() {
   return (
     <aside
       data-testid="sidebar"
-      className="flex w-56 shrink-0 flex-col border-r border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950"
+      className="hidden md:flex w-56 shrink-0 flex-col border-r border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950"
     >
       <div className="border-b border-zinc-200 px-4 py-4 dark:border-zinc-800">
         <span className="text-xs font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,12 +1,12 @@
 // Phase 28: root layout updated to include global sidebar.
-// The sidebar (client component) appears on every page via the flex
-// wrapper inside <Providers>. Both the sidebar and page content share
-// the wagmi + react-query context provided by <Providers>.
-import type { Metadata } from "next";
+// Phase 35: responsive layout — viewport meta tag, sidebar hidden on mobile,
+// MobileNav fixed bottom bar for small screens.
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
 import { Sidebar } from "./Sidebar";
+import { MobileNav } from "./MobileNav";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -23,6 +23,14 @@ export const metadata: Metadata = {
   description: "Open backgammon protocol with portable on-chain reputation",
 };
 
+// Ensures mobile browsers render at device width instead of zooming out
+// to a desktop-width viewport. Without this meta tag the page appears
+// tiny on phones because browsers default to ~980px virtual width.
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -37,8 +45,10 @@ export default function RootLayout({
         <Providers>
           <div className="flex flex-1">
             <Sidebar />
-            <div className="flex flex-1 flex-col min-w-0">{children}</div>
+            {/* pb-16 md:pb-0 reserves space for the fixed mobile bottom nav */}
+            <div className="flex flex-1 flex-col min-w-0 pb-16 md:pb-0">{children}</div>
           </div>
+          <MobileNav />
         </Providers>
       </body>
     </html>

--- a/frontend/app/match/page.tsx
+++ b/frontend/app/match/page.tsx
@@ -713,18 +713,18 @@ function MatchInner() {
   return (
     <div className="flex min-h-screen flex-col bg-zinc-50 dark:bg-black">
       {/* Header */}
-      <header className="flex items-center justify-between gap-4 border-b border-zinc-200 px-8 py-4 dark:border-zinc-800">
+      <header className="flex flex-wrap items-center justify-between gap-2 border-b border-zinc-200 px-4 py-3 sm:gap-4 sm:px-8 sm:py-4 dark:border-zinc-800">
         <Link
           href="/"
-          className="text-sm text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
+          className="shrink-0 text-sm text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
         >
           ← Agents
         </Link>
-        <div className="flex flex-1 items-center justify-center gap-4">
-          <span className="font-mono text-sm text-zinc-500 dark:text-zinc-400">
+        <div className="flex min-w-0 flex-1 items-center justify-center gap-2 sm:gap-4">
+          <span className="truncate font-mono text-xs text-zinc-500 sm:text-sm dark:text-zinc-400">
             Agent #{agentId} · {game.match_length}-pt match
           </span>
-          <span className="font-mono text-sm text-zinc-900 dark:text-zinc-50">
+          <span className="shrink-0 font-mono text-xs text-zinc-900 sm:text-sm dark:text-zinc-50">
             {game.score[0]} – {game.score[1]}
           </span>
         </div>
@@ -732,7 +732,7 @@ function MatchInner() {
       </header>
 
       {/* Main */}
-      <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-6 px-4 py-8 sm:px-8">
+      <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-6 px-3 py-6 sm:px-8 sm:py-8">
         {game.game_over && (
           <div
             className={`rounded-lg border p-4 ${

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,4 +1,5 @@
 // Phase 13: landing page extended with live on-chain agents list.
+// Phase 35: responsive padding for mobile screens.
 // The page shell is a server component; <AgentsList> is a client component
 // that performs the wagmi reads.
 import { ConnectButton } from "./ConnectButton";
@@ -7,14 +8,14 @@ import { AgentsList } from "./AgentsList";
 export default function Home() {
   return (
     <div className="flex flex-1 flex-col bg-zinc-50 dark:bg-black">
-      <header className="flex items-center justify-between border-b border-zinc-200 px-8 py-4 dark:border-zinc-800">
+      <header className="flex items-center justify-between border-b border-zinc-200 px-4 py-4 sm:px-8 dark:border-zinc-800">
         <h1 className="text-lg font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
           Chaingammon
         </h1>
         <ConnectButton />
       </header>
 
-      <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-8 px-8 py-16">
+      <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-8 px-4 py-8 sm:px-8 sm:py-16">
         <div className="flex flex-col gap-3">
           <h2 className="text-3xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
             Open backgammon protocol

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -38,6 +38,7 @@ const nextConfig: NextConfig = {
   // host (phone / another laptop on the LAN) causes the JS bundles and
   // HMR to be refused, React never hydrates, and the navbar / agents
   // list show their pre-hydration shell forever.
+  // To test on a phone: add your machine's LAN IP here (e.g. "192.168.1.5").
   allowedDevOrigins: ["192.168.2.9"],
 };
 

--- a/frontend/tests/mobile-responsive.spec.ts
+++ b/frontend/tests/mobile-responsive.spec.ts
@@ -1,0 +1,58 @@
+// Phase 35: mobile responsiveness regression tests.
+//
+// Verifies that the app renders correctly at a typical phone viewport
+// (375×667 — iPhone SE) without horizontal overflow. Also checks that
+// the desktop sidebar is hidden and the mobile bottom nav is shown at
+// small widths, with the reverse holding at desktop width.
+
+import { test, expect } from "@playwright/test";
+
+const PHONE = { width: 375, height: 667 };
+const DESKTOP = { width: 1280, height: 800 };
+
+test.describe("Mobile responsiveness — home page", () => {
+  test("no horizontal scroll at 375px viewport", async ({ page }) => {
+    await page.setViewportSize(PHONE);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const scrollWidth = await page.evaluate(() => document.body.scrollWidth);
+    const clientWidth = await page.evaluate(() => document.body.clientWidth);
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth + 1); // 1px tolerance
+  });
+
+  test("sidebar hidden on mobile viewport", async ({ page }) => {
+    await page.setViewportSize(PHONE);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const sidebar = page.locator('[data-testid="sidebar"]');
+    await expect(sidebar).toBeHidden();
+  });
+
+  test("mobile nav visible on mobile viewport", async ({ page }) => {
+    await page.setViewportSize(PHONE);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const mobileNav = page.locator('[data-testid="mobile-nav"]');
+    await expect(mobileNav).toBeVisible({ timeout: 5000 });
+
+    // All three links must be present.
+    await expect(page.locator('[data-testid="mobile-nav-home"]')).toBeVisible();
+    await expect(page.locator('[data-testid="mobile-nav-play"]')).toBeVisible();
+    await expect(page.locator('[data-testid="mobile-nav-expenses"]')).toBeVisible();
+  });
+
+  test("sidebar visible and mobile nav hidden at desktop viewport", async ({ page }) => {
+    await page.setViewportSize(DESKTOP);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const sidebar = page.locator('[data-testid="sidebar"]');
+    await expect(sidebar).toBeVisible({ timeout: 5000 });
+
+    const mobileNav = page.locator('[data-testid="mobile-nav"]');
+    await expect(mobileNav).toBeHidden();
+  });
+});


### PR DESCRIPTION
Fixes #43 — makes the dApp work on cell phone browsers and desktop.

Changes:
- Viewport meta tag so mobile browsers render at device width
- Sidebar hidden on mobile (`hidden md:flex`)
- New MobileNav fixed bottom bar with Home, Play, Expenses links
- Responsive padding on home & match page headers
- Match header flex-wrap so it doesn't overflow on narrow screens

Generated with [Claude Code](https://claude.ai/code)