### PR TITLE
Phase 36: settlement-visualization routes — 0G log, ENS, KeeperHub steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,60 @@ cd agent && uv run pytest tests/ -v      # same as agent:test, run directly
 
 ---
 
+## Frontend Routes
+
+The Next.js app is a fully static export. All routes are client-side; the sidebar provides navigation between them.
+
+| Route | Page | Data source |
+| --- | --- | --- |
+| `/` | Agent discovery + matchmaking | On-chain reads via wagmi |
+| `/match?agentId=N` | Live match against agent N | AXL gnubg service (`:8001`) |
+| `/expenses` | 0G token spending ledger | localStorage |
+| `/log/[matchId]` | 0G Storage log for the current match | FastAPI server `/game-records/{rootHash}` (live) |
+| `/ens/[matchId]` | ENS text records before/after keeper settlement | `PlayerSubnameRegistrar.text()` on-chain (live) |
+| `/keeper/[matchId]` | KeeperHub workflow step view | FastAPI server `/keeper-workflow/{matchId}` (mock in Phase 36) |
+
+**`matchId` deep-linking:** the match page writes a UUID to `localStorage.currentMatchId` on game start. The sidebar reads this UUID and links the three new routes to the current match. If no match has been started, all three links use the `/no-match` sentinel, which renders "No active match — start one from Play with agent."
+
+### KeeperHub mock endpoint (Phase 36)
+
+`GET /keeper-workflow/{matchId}` on the FastAPI server (`server/app/main.py`) returns a deterministic mock of the KeeperHub workflow run for the given matchId. The response shape is the real API contract for Phase 37.
+
+```bash
+# Start the server (port 8000 by default)
+cd server && uv run uvicorn app.main:app --port 8000
+
+# Fetch workflow status for a match
+curl http://localhost:8000/keeper-workflow/my-match-id
+```
+
+Response shape:
+```json
+{
+  "matchId": "my-match-id",
+  "status": "pending",
+  "steps": [
+    {
+      "id": "escrow_deposit",
+      "name": "Escrow deposit confirmation",
+      "status": "ok",
+      "duration_ms": 1842,
+      "retry_count": 0,
+      "tx_hash": "0x...",
+      "error": null,
+      "detail": "Both players' deposits confirmed on 0G testnet."
+    }
+    // ... 7 more steps
+  ]
+}
+```
+
+The eight canonical step IDs: `escrow_deposit`, `vrf_rolls`, `og_storage_fetch`, `gnubg_replay`, `settlement_signed`, `relay_tx`, `ens_update`, `audit_append`.
+
+Set `NEXT_PUBLIC_SERVER_URL=http://localhost:8000` in `frontend/.env.local` so the `/keeper/[matchId]` and `/log/[matchId]` pages reach the FastAPI server.
+
+---
+
 ## 0G Testnet
 
 |          |                                 |

--- a/frontend/app/Sidebar.tsx
+++ b/frontend/app/Sidebar.tsx
@@ -1,4 +1,5 @@
 // Phase 28: global sidebar navigation. Phase 35: hidden on mobile (md:flex).
+// Phase 36: adds three settlement-visualization entries below "Expenses".
 //
 // Navigation entries:
 //   1. "Play with agent" — links to /match with the most recently played
@@ -10,6 +11,13 @@
 //      appears immediately in AgentsList.
 //   3. "Expenses" (Phase 30) — links to /expenses, the 0G token spending
 //      ledger. Shows coach-hint and game-settlement charges.
+//   4. "0G Storage log" (Phase 36) — links to /log/{currentMatchId}, the live
+//      match record on 0G Storage. currentMatchId is written to localStorage
+//      by the match page on game start. Falls back to /log/no-match.
+//   5. "ENS updates" (Phase 36) — links to /ens/{currentMatchId}, showing
+//      both players' ENS text records before/after keeper settlement.
+//   6. "KeeperHub steps" (Phase 36) — links to /keeper/{currentMatchId}, the
+//      KeeperHub workflow step view (escrow, VRF, replay, settlement, ENS).
 //
 // The component is SSR-safe: localStorage is read inside useEffect after
 // hydration so the server-rendered HTML never diverges from the initial
@@ -43,6 +51,7 @@ export function Sidebar() {
   // Defer localStorage access until after hydration to avoid SSR mismatch.
   const [mounted, setMounted] = useState(false);
   const [lastAgentId, setLastAgentId] = useState<number | null>(null);
+  const [currentMatchId, setCurrentMatchId] = useState<string | null>(null);
   const [showCreateForm, setShowCreateForm] = useState(false);
 
   // Create-agent form state.
@@ -64,11 +73,13 @@ export function Sidebar() {
     hash: txHash,
   });
 
-  // Read last active agentId from localStorage after hydration.
+  // Read last active agentId and current match ID from localStorage after hydration.
   useEffect(() => {
     setMounted(true);
     const stored = window.localStorage.getItem("lastAgentId");
     if (stored) setLastAgentId(Number(stored));
+    const matchId = window.localStorage.getItem("currentMatchId");
+    if (matchId) setCurrentMatchId(matchId);
   }, []);
 
   // Redirect to home after agent creation so the new agent appears in AgentsList.
@@ -151,6 +162,48 @@ export function Sidebar() {
           </span>
           <span className="text-xs text-zinc-500 dark:text-zinc-400">
             0G token ledger
+          </span>
+        </Link>
+
+        {/* Entry 4: 0G Storage log — live match record on 0G Storage */}
+        <Link
+          href={mounted && currentMatchId ? `/log/${currentMatchId}` : "/log/no-match"}
+          data-testid="sidebar-log"
+          className="flex flex-col gap-0.5 rounded-md px-3 py-3 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800"
+        >
+          <span className="font-semibold text-zinc-900 dark:text-zinc-50">
+            0G Storage log
+          </span>
+          <span className="text-xs text-zinc-500 dark:text-zinc-400">
+            Live match record
+          </span>
+        </Link>
+
+        {/* Entry 5: ENS text records before/after keeper settlement */}
+        <Link
+          href={mounted && currentMatchId ? `/ens/${currentMatchId}` : "/ens/no-match"}
+          data-testid="sidebar-ens"
+          className="flex flex-col gap-0.5 rounded-md px-3 py-3 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800"
+        >
+          <span className="font-semibold text-zinc-900 dark:text-zinc-50">
+            ENS updates
+          </span>
+          <span className="text-xs text-zinc-500 dark:text-zinc-400">
+            Reputation writes
+          </span>
+        </Link>
+
+        {/* Entry 6: KeeperHub workflow step view — escrow, VRF, replay, settlement */}
+        <Link
+          href={mounted && currentMatchId ? `/keeper/${currentMatchId}` : "/keeper/no-match"}
+          data-testid="sidebar-keeper"
+          className="flex flex-col gap-0.5 rounded-md px-3 py-3 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800"
+        >
+          <span className="font-semibold text-zinc-900 dark:text-zinc-50">
+            KeeperHub steps
+          </span>
+          <span className="text-xs text-zinc-500 dark:text-zinc-400">
+            Workflow + escrow
           </span>
         </Link>
 

--- a/frontend/app/ens/[matchId]/page.tsx
+++ b/frontend/app/ens/[matchId]/page.tsx
@@ -1,0 +1,231 @@
+// Phase 36: /ens/[matchId] — ENS text record viewer for the current match.
+//
+// Architecture:
+//   - matchId is read from the URL segment via useParams (SSR-safe mounted pattern).
+//   - The connected player's ENS label is read from localStorage ("ensLabel",
+//     set by the profile page when the player claims a subname).
+//   - Text records are fetched live from the FastAPI server's /ens-records/{label}
+//     endpoint, which reads directly from the PlayerSubnameRegistrar contract.
+//   - A "before ELO" snapshot is read from localStorage ("matchStartElo") set
+//     at game start in match/page.tsx so the before/after comparison renders.
+//   - Pre-settlement: shows a pending banner noting the keeper has not run yet.
+//   - The sentinel matchId "no-match" renders the "no active match" state.
+//
+// Five text record keys are surfaced: elo, match_count, last_match_id,
+// style_uri, archive_uri. KeeperHub writes elo, last_match_id, and archive_uri
+// at settlement — these are highlighted with a "keeper" badge.
+//
+// Data source: live on-chain reads via server/app/main.py `/ens-records/`.
+// Static export: generateStaticParams pre-builds placeholder shells.
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+
+const SERVER = process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:8000";
+const NO_MATCH_SENTINEL = "no-match";
+
+// Text record keys the PlayerSubnameRegistrar stores per player.
+const TEXT_KEYS = ["elo", "match_count", "last_match_id", "style_uri", "archive_uri"] as const;
+type TextKey = (typeof TEXT_KEYS)[number];
+
+// Keys that the KeeperHub workflow writes at settlement — highlighted in the UI.
+const KEEPER_WRITTEN_KEYS: readonly TextKey[] = ["elo", "last_match_id", "archive_uri"];
+
+// Shape returned by GET /ens-records/{label}.
+interface EnsRecordsResponse {
+  label: string;
+  records: Record<string, string>;
+}
+
+export function generateStaticParams() {
+  return [{ matchId: "placeholder" }, { matchId: NO_MATCH_SENTINEL }];
+}
+
+export default function EnsPage() {
+  const params = useParams();
+  const [mounted, setMounted] = useState(false);
+  const [ensLabel, setEnsLabel] = useState<string | null>(null);
+  const [matchStartElo, setMatchStartElo] = useState<string | null>(null);
+  const [records, setRecords] = useState<Record<string, string> | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+    setEnsLabel(window.localStorage.getItem("ensLabel"));
+    setMatchStartElo(window.localStorage.getItem("matchStartElo"));
+  }, []);
+
+  const matchId = mounted ? (params?.matchId as string) : null;
+  const isNoMatch = matchId === NO_MATCH_SENTINEL || matchId === "placeholder";
+
+  // Fetch live text records from the server once the player's ENS label is known.
+  useEffect(() => {
+    if (!ensLabel || isNoMatch) return;
+    setLoading(true);
+    setFetchError(null);
+    fetch(`${SERVER}/ens-records/${encodeURIComponent(ensLabel)}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`Server responded ${res.status}`);
+        return res.json() as Promise<EnsRecordsResponse>;
+      })
+      .then((data) => setRecords(data.records))
+      .catch((e: unknown) => setFetchError(String(e)))
+      .finally(() => setLoading(false));
+  }, [ensLabel, isNoMatch]);
+
+  // Settlement has run if the on-chain elo differs from the pre-match snapshot.
+  const currentElo = records?.["elo"] ?? "";
+  const settled = !!currentElo && matchStartElo !== null && currentElo !== matchStartElo;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-zinc-50 dark:bg-black">
+      <header className="flex items-center justify-between border-b border-zinc-200 px-8 py-4 dark:border-zinc-800">
+        <Link
+          href="/"
+          className="text-sm text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
+        >
+          ← Home
+        </Link>
+        <h1 className="text-lg font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+          ENS updates
+        </h1>
+        <div className="w-20" />
+      </header>
+
+      <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-6 px-4 py-8 sm:px-8">
+        {mounted && matchId && !isNoMatch && (
+          <p className="font-mono text-xs text-zinc-400 dark:text-zinc-600">
+            Match: {matchId}
+          </p>
+        )}
+
+        {/* No active match sentinel */}
+        {mounted && isNoMatch && (
+          <div
+            data-testid="ens-no-match"
+            className="rounded-lg border border-zinc-200 bg-white px-6 py-10 text-center dark:border-zinc-800 dark:bg-zinc-950"
+          >
+            <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+              No active match
+            </p>
+            <p className="mt-1 text-sm text-zinc-400 dark:text-zinc-500">
+              Start one from{" "}
+              <Link
+                href="/match?agentId=1"
+                className="text-indigo-600 underline dark:text-indigo-400"
+              >
+                Play with agent
+              </Link>
+              .
+            </p>
+          </div>
+        )}
+
+        {!isNoMatch && (
+          <div data-testid="ens-records" className="flex flex-col gap-4">
+            {/* ENS label header */}
+            <div className="rounded-lg border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950">
+              <p className="text-xs font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+                Player subname
+              </p>
+              <p className="mt-1 font-mono text-sm text-zinc-900 dark:text-zinc-50">
+                {mounted && ensLabel
+                  ? `${ensLabel}.chaingammon.eth`
+                  : "No ENS label — claim one from your profile"}
+              </p>
+            </div>
+
+            {/* Pre-settlement pending banner */}
+            {!settled && mounted && (
+              <div
+                data-testid="ens-pending"
+                className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-700/40 dark:bg-amber-900/10"
+              >
+                <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+                  Pending — keeper has not run settlement yet
+                </p>
+                <p className="mt-0.5 text-xs text-amber-600 dark:text-amber-500">
+                  Text records update after the KeeperHub workflow completes (
+                  <Link
+                    href={`/keeper/${matchId ?? "no-match"}`}
+                    className="underline"
+                  >
+                    watch progress
+                  </Link>
+                  ).
+                </p>
+              </div>
+            )}
+
+            {/* Fetch error */}
+            {fetchError && (
+              <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+                Could not fetch ENS records: {fetchError}
+              </p>
+            )}
+
+            {/* Loading */}
+            {loading && (
+              <p className="animate-pulse text-sm text-zinc-500 dark:text-zinc-400">
+                Reading from chain…
+              </p>
+            )}
+
+            {/* Text records table — shown when an ENS label is available */}
+            {mounted && ensLabel && (
+              <div className="overflow-hidden rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
+                <table className="w-full text-sm">
+                  <thead className="border-b border-zinc-200 dark:border-zinc-800">
+                    <tr className="text-left text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+                      <th className="px-4 py-3">Key</th>
+                      <th className="px-4 py-3">Before match</th>
+                      <th className="px-4 py-3">Current (on-chain)</th>
+                      <th className="px-4 py-3">Keeper</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800/60">
+                    {TEXT_KEYS.map((key) => {
+                      const current = loading ? "…" : (records?.[key] ?? "—");
+                      const before = key === "elo" && matchStartElo ? matchStartElo : "—";
+                      const changed = key === "elo" && matchStartElo && records?.["elo"] && records["elo"] !== matchStartElo;
+                      const keeperWritten = KEEPER_WRITTEN_KEYS.includes(key);
+                      return (
+                        <tr key={key} data-testid={`ens-row-${key}`}>
+                          <td className="px-4 py-3 font-mono text-xs text-zinc-700 dark:text-zinc-300">
+                            {key}
+                          </td>
+                          <td className="px-4 py-3 font-mono text-xs text-zinc-500 dark:text-zinc-400">
+                            {before}
+                          </td>
+                          <td
+                            className={`px-4 py-3 font-mono text-xs ${
+                              changed
+                                ? "font-semibold text-green-700 dark:text-green-400"
+                                : "text-zinc-700 dark:text-zinc-300"
+                            }`}
+                          >
+                            {current}
+                          </td>
+                          <td className="px-4 py-3 text-center">
+                            {keeperWritten && (
+                              <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300">
+                                ✓
+                              </span>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/app/keeper/[matchId]/page.tsx
+++ b/frontend/app/keeper/[matchId]/page.tsx
@@ -1,0 +1,278 @@
+// Phase 36: /keeper/[matchId] — KeeperHub workflow steps for the current match.
+//
+// Architecture:
+//   - matchId is read from the URL segment via useParams (SSR-safe mounted pattern).
+//   - Calls GET /keeper-workflow/{matchId} on the FastAPI server
+//     (server/app/main.py) which currently returns a deterministic mock keyed
+//     by matchId. The shape is the real KeeperHub API contract so the page
+//     needs no changes when Phase 37 replaces the mock with live data.
+//   - Each of the eight workflow steps is rendered as a row with status badge,
+//     duration, retry count, and tx hash link where applicable.
+//   - Failed steps surface the error/log field — this page is the primary
+//     debugging surface when keeper settlement breaks.
+//   - The sentinel matchId "no-match" renders the "no active match" state.
+//
+// TODO(phase-37): Remove the mock from server/app/main.py and replace the
+// /keeper-workflow/{matchId} implementation with `kh run status --json` output
+// piped through the FastAPI server once the KeeperHub workflow is wired.
+//
+// Data source: deterministic mock from server/app/main.py (Phase 36).
+// Static export: generateStaticParams pre-builds placeholder shells.
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+
+const SERVER = process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:8000";
+const NO_MATCH_SENTINEL = "no-match";
+
+// Status values for workflow steps and the overall run.
+type StepStatus = "pending" | "running" | "ok" | "failed";
+
+// Shape of a single KeeperHub workflow step — mirrors the server's response.
+interface WorkflowStep {
+  id: string;
+  name: string;
+  status: StepStatus;
+  duration_ms: number | null;
+  retry_count: number;
+  tx_hash: string | null;
+  error: string | null;
+  detail: string | null;
+}
+
+// Top-level response shape from /keeper-workflow/{matchId}.
+interface WorkflowRun {
+  matchId: string;
+  status: StepStatus;
+  steps: WorkflowStep[];
+}
+
+export function generateStaticParams() {
+  return [{ matchId: "placeholder" }, { matchId: NO_MATCH_SENTINEL }];
+}
+
+export default function KeeperPage() {
+  const params = useParams();
+  const [mounted, setMounted] = useState(false);
+  const [run, setRun] = useState<WorkflowRun | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const matchId = mounted ? (params?.matchId as string) : null;
+  const isNoMatch = matchId === NO_MATCH_SENTINEL || matchId === "placeholder";
+
+  useEffect(() => {
+    if (!matchId || isNoMatch) return;
+    setLoading(true);
+    setFetchError(null);
+    fetch(`${SERVER}/keeper-workflow/${encodeURIComponent(matchId)}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`Server responded ${res.status}`);
+        return res.json() as Promise<WorkflowRun>;
+      })
+      .then((data) => setRun(data))
+      .catch((e: unknown) => setFetchError(String(e)))
+      .finally(() => setLoading(false));
+  }, [matchId, isNoMatch]);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-zinc-50 dark:bg-black">
+      <header className="flex items-center justify-between border-b border-zinc-200 px-8 py-4 dark:border-zinc-800">
+        <Link
+          href="/"
+          className="text-sm text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
+        >
+          ← Home
+        </Link>
+        <h1 className="text-lg font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+          KeeperHub steps
+        </h1>
+        <div className="w-20" />
+      </header>
+
+      <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-6 px-4 py-8 sm:px-8">
+        {mounted && matchId && !isNoMatch && (
+          <p className="font-mono text-xs text-zinc-400 dark:text-zinc-600">
+            Match: {matchId}
+          </p>
+        )}
+
+        {/* No active match sentinel */}
+        {mounted && isNoMatch && (
+          <div
+            data-testid="keeper-no-match"
+            className="rounded-lg border border-zinc-200 bg-white px-6 py-10 text-center dark:border-zinc-800 dark:bg-zinc-950"
+          >
+            <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+              No active match
+            </p>
+            <p className="mt-1 text-sm text-zinc-400 dark:text-zinc-500">
+              Start one from{" "}
+              <Link
+                href="/match?agentId=1"
+                className="text-indigo-600 underline dark:text-indigo-400"
+              >
+                Play with agent
+              </Link>
+              .
+            </p>
+          </div>
+        )}
+
+        {/* Mock notice */}
+        {mounted && !isNoMatch && (
+          <div className="rounded-lg border border-indigo-100 bg-indigo-50 px-4 py-2 dark:border-indigo-900/40 dark:bg-indigo-900/10">
+            <p className="text-xs text-indigo-600 dark:text-indigo-400">
+              <span className="font-semibold">Mock data (Phase 36)</span> — KeeperHub
+              workflow integration lands in Phase 37. This view shows the real
+              API shape with deterministic placeholder values keyed by matchId.
+            </p>
+          </div>
+        )}
+
+        {/* Fetch error */}
+        {fetchError && (
+          <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+            Could not reach server: {fetchError}
+          </p>
+        )}
+
+        {/* Loading state */}
+        {loading && (
+          <p className="animate-pulse text-sm text-zinc-500 dark:text-zinc-400">
+            Fetching workflow status…
+          </p>
+        )}
+
+        {/* Step list */}
+        {!isNoMatch && (
+          <div data-testid="keeper-steps" className="flex flex-col gap-2">
+            {run && (
+              <>
+                {/* Overall run status */}
+                <div className="mb-2 flex items-center gap-2">
+                  <StatusBadge status={run.status} />
+                  <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+                    Workflow{" "}
+                    {run.status === "ok"
+                      ? "complete"
+                      : run.status === "failed"
+                      ? "failed"
+                      : run.status === "running"
+                      ? "in progress"
+                      : "pending"}
+                  </span>
+                </div>
+
+                {run.steps.map((step, i) => (
+                  <StepRow key={step.id} step={step} index={i} explorerUrl="https://chainscan-galileo.0g.ai" />
+                ))}
+              </>
+            )}
+
+            {/* Empty state when server is unreachable but no error yet */}
+            {!run && !loading && !fetchError && mounted && !isNoMatch && (
+              <div className="rounded-lg border border-zinc-200 bg-white px-6 py-10 text-center dark:border-zinc-800 dark:bg-zinc-950">
+                <p className="text-sm text-zinc-400 dark:text-zinc-500">
+                  Waiting for server response…
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+/** Colour-coded status badge matching the four workflow step states. */
+function StatusBadge({ status }: { status: StepStatus }) {
+  const classes: Record<StepStatus, string> = {
+    ok: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
+    failed: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+    running: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+    pending: "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400",
+  };
+  return (
+    <span
+      className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${classes[status]}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+/** One workflow step rendered as a card row. */
+function StepRow({
+  step,
+  index,
+  explorerUrl,
+}: {
+  step: WorkflowStep;
+  index: number;
+  explorerUrl: string;
+}) {
+  return (
+    <div
+      data-testid={`keeper-step-${step.id}`}
+      className="rounded-lg border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950"
+    >
+      <div className="flex flex-wrap items-start gap-2">
+        {/* Step number */}
+        <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-zinc-100 text-xs font-semibold text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+          {index + 1}
+        </span>
+
+        {/* Step name + status */}
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
+              {step.name}
+            </span>
+            <StatusBadge status={step.status} />
+          </div>
+
+          {/* Detail text */}
+          {step.detail && (
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">
+              {step.detail}
+            </p>
+          )}
+
+          {/* Error — visible only on failed steps */}
+          {step.error && (
+            <p className="rounded bg-red-50 px-2 py-1 font-mono text-xs text-red-700 dark:bg-red-900/20 dark:text-red-400">
+              {step.error}
+            </p>
+          )}
+
+          {/* Metadata row: duration, retries, tx link */}
+          <div className="flex flex-wrap gap-3 text-xs text-zinc-400 dark:text-zinc-600">
+            {step.duration_ms !== null && (
+              <span>{(step.duration_ms / 1000).toFixed(2)}s</span>
+            )}
+            {step.retry_count > 0 && (
+              <span>{step.retry_count} retries</span>
+            )}
+            {step.tx_hash && (
+              <a
+                href={`${explorerUrl}/tx/${step.tx_hash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-indigo-500 underline hover:text-indigo-400 dark:text-indigo-400"
+              >
+                tx ↗
+              </a>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/log/[matchId]/page.tsx
+++ b/frontend/app/log/[matchId]/page.tsx
@@ -1,0 +1,220 @@
+// Phase 36: /log/[matchId] — 0G Storage log viewer for the current match.
+//
+// Architecture:
+//   - matchId is read from the URL segment via useParams (SSR-safe mounted
+//     pattern to avoid hydration mismatches in the static export).
+//   - The page reads `currentMatchArchiveUri` from localStorage (set by the
+//     match flow when the keeper writes the archive after settlement). If the
+//     key is present, the game record is fetched from the FastAPI server's
+//     /game-records/{rootHash} endpoint and rendered as a chronological feed.
+//   - If no archive URI is stored (match still in progress or pre-settlement)
+//     the page renders an empty/pending state explaining what will appear.
+//   - The sentinel matchId "no-match" triggers the "no active match" state.
+//
+// TODO(phase-37): Add drand fields (round, randomness, signature) to each
+// move entry once the KeeperHub VRF workflow is active. The "Verify" button
+// for each entry will then call the drand verification API for roll entries
+// and ECDSA-recover for move entries.
+//
+// Data source: live 0G Storage data via server/app/main.py `/game-records/`.
+// Static export: generateStaticParams pre-builds placeholder shells;
+// arbitrary matchIds work in dev mode.
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+
+// FastAPI server URL — distinct from the AXL gnubg service (port 8001).
+const SERVER = process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:8000";
+
+// Sentinel value written to the URL when no match is active in localStorage.
+const NO_MATCH_SENTINEL = "no-match";
+
+// Shape of a move state returned by /game-records/{rootHash}.states[].
+interface MoveState {
+  turn: number;
+  dice: number[];
+  move: string;
+  board: number[];
+  bar: number[];
+  off: number[];
+}
+
+// Pre-build static shells for the placeholder and no-match sentinels.
+// In dev mode, Next.js serves any matchId dynamically.
+export function generateStaticParams() {
+  return [{ matchId: "placeholder" }, { matchId: NO_MATCH_SENTINEL }];
+}
+
+export default function LogPage() {
+  const params = useParams();
+
+  // SSR-safe: useParams() is available but matchId must be read after mount
+  // to prevent hydration mismatches in the static export (the HTML shell is
+  // built for the placeholder param, not the runtime matchId from localStorage).
+  const [mounted, setMounted] = useState(false);
+  const [archiveUri, setArchiveUri] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [moves, setMoves] = useState<MoveState[]>([]);
+
+  useEffect(() => {
+    setMounted(true);
+    const uri = window.localStorage.getItem("currentMatchArchiveUri");
+    setArchiveUri(uri);
+  }, []);
+
+  const matchId = mounted ? (params?.matchId as string) : null;
+  const isNoMatch = matchId === NO_MATCH_SENTINEL || matchId === "placeholder";
+
+  // Fetch game record from 0G Storage via the server when archive URI is available.
+  useEffect(() => {
+    if (!archiveUri || isNoMatch) return;
+    // Format: "0g://<rootHash>" — strip the scheme prefix before the request.
+    const rootHash = archiveUri.startsWith("0g://")
+      ? archiveUri.slice(5)
+      : archiveUri;
+    setLoading(true);
+    setFetchError(null);
+    fetch(`${SERVER}/game-records/${rootHash}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`Server responded ${res.status}`);
+        return res.json() as Promise<{ record: unknown; states: MoveState[] }>;
+      })
+      .then((data) => setMoves(data.states ?? []))
+      .catch((e: unknown) => setFetchError(String(e)))
+      .finally(() => setLoading(false));
+  }, [archiveUri, isNoMatch]);
+
+  const hasData = moves.length > 0;
+  const isEmpty = !archiveUri && mounted && !isNoMatch;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-zinc-50 dark:bg-black">
+      <header className="flex items-center justify-between border-b border-zinc-200 px-8 py-4 dark:border-zinc-800">
+        <Link
+          href="/"
+          className="text-sm text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
+        >
+          ← Home
+        </Link>
+        <h1 className="text-lg font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+          0G Storage log
+        </h1>
+        <div className="w-20" />
+      </header>
+
+      <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-6 px-4 py-8 sm:px-8">
+        {/* Match identifier */}
+        {mounted && matchId && !isNoMatch && (
+          <p className="font-mono text-xs text-zinc-400 dark:text-zinc-600">
+            Match: {matchId}
+          </p>
+        )}
+
+        {/* No active match sentinel */}
+        {mounted && isNoMatch && (
+          <div
+            data-testid="log-no-match"
+            className="rounded-lg border border-zinc-200 bg-white px-6 py-10 text-center dark:border-zinc-800 dark:bg-zinc-950"
+          >
+            <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+              No active match
+            </p>
+            <p className="mt-1 text-sm text-zinc-400 dark:text-zinc-500">
+              Start one from{" "}
+              <Link
+                href="/match?agentId=1"
+                className="text-indigo-600 underline dark:text-indigo-400"
+              >
+                Play with agent
+              </Link>
+              .
+            </p>
+          </div>
+        )}
+
+        {/* Fetch error */}
+        {fetchError && (
+          <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+            Could not fetch log from 0G Storage: {fetchError}
+          </p>
+        )}
+
+        {/* Chronological feed */}
+        {!isNoMatch && (
+          <div data-testid="log-feed" className="flex flex-col gap-3">
+            {loading && (
+              <p className="animate-pulse text-sm text-zinc-500 dark:text-zinc-400">
+                Fetching log from 0G Storage…
+              </p>
+            )}
+
+            {/* Empty / pending state — no archive yet */}
+            {isEmpty && !loading && (
+              <div
+                data-testid="log-empty"
+                className="rounded-lg border border-zinc-200 bg-white px-6 py-10 text-center dark:border-zinc-800 dark:bg-zinc-950"
+              >
+                <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                  No archive yet
+                </p>
+                <p className="mt-1 text-sm text-zinc-400 dark:text-zinc-500">
+                  Match in progress — 0G Storage log entries appear here after
+                  the KeeperHub workflow completes settlement.
+                </p>
+              </div>
+            )}
+
+            {/* Move entries */}
+            {hasData &&
+              moves.map((move, i) => (
+                <MoveRow key={i} move={move} index={i} />
+              ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+/** Renders one move entry in the chronological feed. */
+function MoveRow({ move, index }: { move: MoveState; index: number }) {
+  const sideLabel = move.turn === 0 ? "Human" : "Agent";
+  return (
+    <div
+      data-testid={`log-entry-${index}`}
+      className="rounded-lg border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950"
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span
+            className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+              move.turn === 0
+                ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+                : "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+            }`}
+          >
+            {sideLabel}
+          </span>
+          <span className="font-mono text-xs text-zinc-400 dark:text-zinc-500">
+            Move {index + 1}
+          </span>
+        </div>
+        {/* Verify affordance — active once drand VRF is wired in Phase 37. */}
+        <button
+          type="button"
+          disabled
+          title="Verification requires drand VRF integration (Phase 37)"
+          className="rounded border border-zinc-200 px-2 py-0.5 text-xs text-zinc-300 dark:border-zinc-700 dark:text-zinc-600"
+        >
+          Verify
+        </button>
+      </div>
+      <div className="mt-2 font-mono text-xs text-zinc-600 dark:text-zinc-400">
+        Dice {move.dice.join(",")} · {move.move || "—"}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/match/page.tsx
+++ b/frontend/app/match/page.tsx
@@ -236,6 +236,19 @@ function MatchInner() {
     window.localStorage.setItem("lastAgentId", String(agentId));
   }, [agentId]);
 
+  // Phase 36: write a stable UUID for this match session so the sidebar's
+  // 0G Storage log / ENS / KeeperHub entries deep-link to the current match.
+  // A new UUID is generated on each page load (= each new game session).
+  // The archive URI (set after keeper settlement) is stored separately under
+  // "currentMatchArchiveUri" and keyed by this UUID.
+  useEffect(() => {
+    const matchSessionId = crypto.randomUUID();
+    window.localStorage.setItem("currentMatchId", matchSessionId);
+    // Clear any archive URI from a previous match so the log page correctly
+    // shows "in progress" until this match is settled.
+    window.localStorage.removeItem("currentMatchArchiveUri");
+  }, []);
+
   const [game, setGame] = useState<MatchState | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);

--- a/frontend/tests/ens-page.spec.ts
+++ b/frontend/tests/ens-page.spec.ts
@@ -1,0 +1,60 @@
+// Phase 36: Playwright tests for /ens/[matchId] — ENS text record viewer.
+//
+// Verifies:
+//   1. The sidebar "ENS updates" entry is visible and links to the ENS route.
+//   2. The ENS page renders the text-records shell container.
+//   3. The pre-settlement pending banner is visible when no wallet is connected.
+//   4. "No active match" message appears when the route uses the no-match sentinel.
+//
+// No wallet or backend connection is required — the pending state renders
+// client-side without RPC calls when no wallet is connected.
+
+import { test, expect } from "@playwright/test";
+
+const TEST_MATCH_ID = "test-match-deadbeef-36";
+
+test.describe("ENS page (/ens/[matchId])", () => {
+  test("sidebar has 'ENS updates' entry with correct text and href", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const ensLink = page.locator('[data-testid="sidebar-ens"]');
+    await expect(ensLink).toBeVisible({ timeout: 5000 });
+    await expect(ensLink).toContainText("ENS updates");
+    await expect(ensLink).toContainText("Reputation writes");
+
+    const href = await ensLink.getAttribute("href");
+    expect(href).toMatch(/^\/ens\//);
+  });
+
+  test("ENS page renders the records shell container", async ({ page }) => {
+    await page.goto(`/ens/${TEST_MATCH_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.locator('[data-testid="ens-records"]'),
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test("shows pending banner when no wallet is connected", async ({ page }) => {
+    await page.goto(`/ens/${TEST_MATCH_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.locator('[data-testid="ens-pending"]'),
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test("shows 'No active match' when matchId is the no-match sentinel", async ({
+    page,
+  }) => {
+    await page.goto("/ens/no-match");
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.locator('[data-testid="ens-no-match"]'),
+    ).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/frontend/tests/keeper-page.spec.ts
+++ b/frontend/tests/keeper-page.spec.ts
@@ -1,0 +1,79 @@
+// Phase 36: Playwright tests for /keeper/[matchId] — KeeperHub workflow steps.
+//
+// Verifies:
+//   1. The sidebar "KeeperHub steps" entry is visible and links to the keeper route.
+//   2. The keeper page renders a step-list container with the expected testid.
+//   3. At least one step row renders with a testid following the keeper-step-* pattern.
+//   4. "No active match" message appears when the route uses the no-match sentinel.
+//
+// The keeper page calls the server's /keeper-workflow/{matchId} mock endpoint.
+// When the server is not running, the page shows an error state — the step list
+// container is still present so the DOM shape assertion passes.
+
+import { test, expect } from "@playwright/test";
+
+const TEST_MATCH_ID = "test-match-deadbeef-36";
+
+test.describe("Keeper page (/keeper/[matchId])", () => {
+  test("sidebar has 'KeeperHub steps' entry with correct text and href", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const keeperLink = page.locator('[data-testid="sidebar-keeper"]');
+    await expect(keeperLink).toBeVisible({ timeout: 5000 });
+    await expect(keeperLink).toContainText("KeeperHub steps");
+    await expect(keeperLink).toContainText("Workflow + escrow");
+
+    const href = await keeperLink.getAttribute("href");
+    expect(href).toMatch(/^\/keeper\//);
+  });
+
+  test("keeper page renders the steps container", async ({ page }) => {
+    await page.goto(`/keeper/${TEST_MATCH_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.locator('[data-testid="keeper-steps"]'),
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test("keeper page renders at least one step row when server responds", async ({
+    page,
+  }) => {
+    // The mock endpoint at /keeper-workflow/{matchId} is expected to run during
+    // the test suite (the dev server starts the Next.js app; the FastAPI server
+    // must be up separately for this assertion to pass). If the server is not
+    // running, the page falls back to an error state and this test is skipped.
+    const serverUrl = process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:8000";
+    let serverUp = false;
+    try {
+      const res = await page.request.get(`${serverUrl}/keeper-workflow/${TEST_MATCH_ID}`);
+      serverUp = res.ok();
+    } catch {
+      // server not running — skip the step-row check
+    }
+    if (!serverUp) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/keeper/${TEST_MATCH_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    const firstStep = page.locator('[data-testid^="keeper-step-"]').first();
+    await expect(firstStep).toBeVisible({ timeout: 8000 });
+  });
+
+  test("shows 'No active match' when matchId is the no-match sentinel", async ({
+    page,
+  }) => {
+    await page.goto("/keeper/no-match");
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.locator('[data-testid="keeper-no-match"]'),
+    ).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/frontend/tests/log-page.spec.ts
+++ b/frontend/tests/log-page.spec.ts
@@ -1,0 +1,68 @@
+// Phase 36: Playwright tests for /log/[matchId] — 0G Storage log viewer.
+//
+// Verifies:
+//   1. The sidebar "0G Storage log" entry is visible and links to the log route.
+//   2. The log page renders its shell with the chronological-feed testid.
+//   3. The empty/pending state is shown when no archive URI is in localStorage.
+//   4. "No active match" message appears when the route uses the no-match sentinel.
+//
+// No wallet or backend connection is required — the page reads only from
+// localStorage. When no archive URI is stored, the empty state renders
+// without making any network requests.
+
+import { test, expect } from "@playwright/test";
+
+const TEST_MATCH_ID = "test-match-deadbeef-36";
+
+test.describe("Log page (/log/[matchId])", () => {
+  test("sidebar has '0G Storage log' entry with correct text and href", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const logLink = page.locator('[data-testid="sidebar-log"]');
+    await expect(logLink).toBeVisible({ timeout: 5000 });
+    await expect(logLink).toContainText("0G Storage log");
+    await expect(logLink).toContainText("Live match record");
+
+    const href = await logLink.getAttribute("href");
+    expect(href).toMatch(/^\/log\//);
+  });
+
+  test("log page renders the feed container", async ({ page }) => {
+    await page.goto(`/log/${TEST_MATCH_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.locator('[data-testid="log-feed"]'),
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test("shows pending empty state when no archive URI is in localStorage", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.evaluate(() =>
+      window.localStorage.removeItem("currentMatchArchiveUri"),
+    );
+
+    await page.goto(`/log/${TEST_MATCH_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.locator('[data-testid="log-empty"]'),
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test("shows 'No active match' when matchId is the no-match sentinel", async ({
+    page,
+  }) => {
+    await page.goto("/log/no-match");
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.locator('[data-testid="log-no-match"]'),
+    ).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import Dict, Optional
+import hashlib
 import json
 import os
 import re
@@ -257,6 +258,47 @@ def resign(game_id: str):
     state = _build_game_state(game_id, res["position_id"], res["match_id"])
     games[game_id] = state
     return state
+
+
+# ---------------------------------------------------------------------------
+# Phase 36 — ENS text records read endpoint
+#
+# Thin wrapper around EnsClient so the frontend can read live text records
+# without needing a wagmi connection or on-chain RPC key in the browser.
+# Returns the five text record keys for a given subname label. Returns empty
+# strings for unset keys rather than errors so the UI renders cleanly.
+# ---------------------------------------------------------------------------
+
+
+@app.get("/ens-records/{label}")
+def ens_records(label: str):
+    """Return all five reputation text records for `<label>.chaingammon.eth`.
+
+    The five keys (elo, match_count, last_match_id, style_uri, archive_uri)
+    are the canonical set written by the protocol. Unset keys return "".
+
+    Requires RPC_URL, PLAYER_SUBNAME_REGISTRAR_ADDRESS, and DEPLOYER_PRIVATE_KEY
+    in the server environment. Returns a 503 when those are missing or the RPC
+    is unreachable, so the /ens/[matchId] frontend page can show a graceful
+    error rather than a crash.
+    """
+    TEXT_KEYS = ["elo", "match_count", "last_match_id", "style_uri", "archive_uri"]
+    try:
+        ens = EnsClient.from_env()
+    except EnsError as e:
+        raise HTTPException(
+            status_code=503,
+            detail=f"ENS client not configured: {e} — set RPC_URL, "
+            "PLAYER_SUBNAME_REGISTRAR_ADDRESS, and DEPLOYER_PRIVATE_KEY",
+        ) from e
+    node = ens.subname_node(label)
+    records: dict[str, str] = {}
+    for key in TEXT_KEYS:
+        try:
+            records[key] = ens.text(node=node, key=key)
+        except EnsError:
+            records[key] = ""
+    return {"label": label, "records": records}
 
 
 # ---------------------------------------------------------------------------
@@ -604,3 +646,146 @@ def finalize_game(game_id: str, req: FinalizeRequest):
         overlay_updates=overlay_updates,
         ens_updates=ens_updates,
     )
+
+
+# ---------------------------------------------------------------------------
+# Phase 36 — KeeperHub workflow status mock
+#
+# TODO(phase-37): Replace this endpoint's body with a real `kh run status --json`
+# call once the KeeperHub workflow is wired. The response shape below is the
+# canonical contract the frontend develops against — field names, step IDs, and
+# status values must remain stable when the real implementation lands.
+#
+# The eight steps correspond 1-to-1 with the workflow stages described in
+# docs/keeperhub-feedback.md and the Phase 36 issue specification.
+# ---------------------------------------------------------------------------
+
+
+def _keeper_step_statuses(seed: int) -> list[str]:
+    """Return a deterministic list of 8 step statuses based on a numeric seed.
+
+    The first `n` steps are "ok" and the remainder are "pending", where n is
+    seed % 9 (range 0–8). This gives different matchIds visually distinct
+    progress states without requiring any real workflow state.
+    """
+    n_ok = seed % 9
+    return ["ok"] * n_ok + ["pending"] * (8 - n_ok)
+
+
+@app.get("/keeper-workflow/{match_id}")
+def keeper_workflow_status(match_id: str):
+    """Return a deterministic mock of the KeeperHub workflow run for matchId.
+
+    Shape mirrors what `kh run status --json` will return in Phase 37. Each
+    of the eight steps is populated with realistic placeholder data so the
+    frontend can develop the full UI without a live KeeperHub connection.
+
+    The step statuses are seeded by sha256(matchId) so the same matchId always
+    returns the same response — useful for Playwright snapshot tests and demos.
+    """
+    seed = int(hashlib.sha256(match_id.encode()).hexdigest(), 16)
+    statuses = _keeper_step_statuses(seed)
+
+    # Placeholder tx hashes derived from the matchId seed for display purposes.
+    def _tx(index: int) -> Optional[str]:
+        if statuses[index] != "ok":
+            return None
+        h = hashlib.sha256(f"{match_id}-step-{index}".encode()).hexdigest()
+        return "0x" + h
+
+    steps = [
+        {
+            "id": "escrow_deposit",
+            "name": "Escrow deposit confirmation",
+            "status": statuses[0],
+            "duration_ms": 1842 if statuses[0] == "ok" else None,
+            "retry_count": 0,
+            "tx_hash": _tx(0),
+            "error": None,
+            "detail": "Both players' deposits confirmed on 0G testnet." if statuses[0] == "ok" else None,
+        },
+        {
+            "id": "vrf_rolls",
+            "name": "VRF rolls (drand)",
+            "status": statuses[1],
+            "duration_ms": 312 if statuses[1] == "ok" else None,
+            "retry_count": 0,
+            "tx_hash": None,
+            "error": None,
+            "detail": "Drand rounds fetched and signed for each turn." if statuses[1] == "ok" else None,
+        },
+        {
+            "id": "og_storage_fetch",
+            "name": "Game-record fetch from 0G Storage",
+            "status": statuses[2],
+            "duration_ms": 780 if statuses[2] == "ok" else None,
+            "retry_count": 0,
+            "tx_hash": None,
+            "error": None,
+            "detail": "archive_uri resolved; game record downloaded." if statuses[2] == "ok" else None,
+        },
+        {
+            "id": "gnubg_replay",
+            "name": "gnubg replay validation",
+            "status": statuses[3],
+            "duration_ms": 2341 if statuses[3] == "ok" else None,
+            "retry_count": 0,
+            "tx_hash": None,
+            "error": None,
+            "detail": "All moves legal given their drand-signed dice." if statuses[3] == "ok" else None,
+        },
+        {
+            "id": "settlement_signed",
+            "name": "Settlement payload signed",
+            "status": statuses[4],
+            "duration_ms": 54 if statuses[4] == "ok" else None,
+            "retry_count": 0,
+            "tx_hash": None,
+            "error": None,
+            "detail": "Keeper signed result payload for on-chain relay." if statuses[4] == "ok" else None,
+        },
+        {
+            "id": "relay_tx",
+            "name": "Relay tx submitted to 0G testnet",
+            "status": statuses[5],
+            "duration_ms": 3200 if statuses[5] == "ok" else None,
+            "retry_count": 0,
+            "tx_hash": _tx(5),
+            "error": None,
+            "detail": "settleWithSessionKeys confirmed on-chain." if statuses[5] == "ok" else None,
+        },
+        {
+            "id": "ens_update",
+            "name": "ENS text records updated",
+            "status": statuses[6],
+            "duration_ms": 2100 if statuses[6] == "ok" else None,
+            "retry_count": 0,
+            "tx_hash": _tx(6),
+            "error": None,
+            "detail": "elo, last_match_id, archive_uri written for both players." if statuses[6] == "ok" else None,
+        },
+        {
+            "id": "audit_append",
+            "name": "Audit JSON appended to 0G Storage",
+            "status": statuses[7],
+            "duration_ms": 950 if statuses[7] == "ok" else None,
+            "retry_count": 0,
+            "tx_hash": _tx(7),
+            "error": None,
+            "detail": "Full audit trail written to the match's 0G Storage log." if statuses[7] == "ok" else None,
+        },
+    ]
+
+    # Overall run status: "ok" if all steps done, "failed" if any failed,
+    # "running" if any are running, otherwise "pending".
+    all_statuses = {s["status"] for s in steps}
+    if "failed" in all_statuses:
+        run_status = "failed"
+    elif "running" in all_statuses:
+        run_status = "running"
+    elif all(s == "ok" for s in statuses):
+        run_status = "ok"
+    else:
+        run_status = "pending"
+
+    return {"matchId": match_id, "status": run_status, "steps": steps}

--- a/server/tests/test_phase36_keeper_mock.py
+++ b/server/tests/test_phase36_keeper_mock.py
@@ -1,0 +1,130 @@
+"""
+Phase 36 — KeeperHub mock and ENS records endpoint tests.
+
+Fast, no-network unit tests that verify:
+
+  A. GET /keeper-workflow/{matchId} — mock endpoint for KeeperHub workflow status.
+     The endpoint is a stub for the real `kh run status --json` output that
+     Phase 37 will wire once the KeeperHub workflow is live.
+     Tests: response shape, 8 steps, canonical step IDs, determinism, isolation.
+
+  B. GET /ens-records/{label} — thin wrapper around EnsClient.text().
+     Returns a 503 when PLAYER_SUBNAME_REGISTRAR_ADDRESS is unset. Tests
+     the 503 behavior without an RPC connection (fast, no network required).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.main import app
+
+client = TestClient(app)
+
+EXPECTED_STEP_IDS = [
+    "escrow_deposit",
+    "vrf_rolls",
+    "og_storage_fetch",
+    "gnubg_replay",
+    "settlement_signed",
+    "relay_tx",
+    "ens_update",
+    "audit_append",
+]
+
+EXPECTED_STEP_FIELDS = {"id", "name", "status", "duration_ms", "retry_count", "tx_hash", "error", "detail"}
+VALID_STATUSES = {"pending", "running", "ok", "failed"}
+
+
+def test_response_shape():
+    """Top-level fields matchId, status, and steps must be present."""
+    resp = client.get("/keeper-workflow/test-match-abc123")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "matchId" in data
+    assert "status" in data
+    assert "steps" in data
+    assert data["matchId"] == "test-match-abc123"
+    assert data["status"] in VALID_STATUSES
+
+
+def test_exactly_eight_steps():
+    """The workflow must surface exactly the 8 canonical KeeperHub steps."""
+    resp = client.get("/keeper-workflow/test-match-abc123")
+    assert resp.status_code == 200
+    steps = resp.json()["steps"]
+    assert len(steps) == 8, f"Expected 8 steps, got {len(steps)}"
+
+
+def test_all_eight_step_ids_present():
+    """Every canonical step ID must appear exactly once."""
+    resp = client.get("/keeper-workflow/test-match-abc123")
+    step_ids = [s["id"] for s in resp.json()["steps"]]
+    for expected_id in EXPECTED_STEP_IDS:
+        assert expected_id in step_ids, f"Missing step id: {expected_id}"
+
+
+def test_each_step_has_required_fields():
+    """Every step must carry the fields the frontend depends on."""
+    resp = client.get("/keeper-workflow/test-match-abc123")
+    for step in resp.json()["steps"]:
+        missing = EXPECTED_STEP_FIELDS - set(step.keys())
+        assert not missing, f"Step {step.get('id')} missing fields: {missing}"
+
+
+def test_step_status_is_valid():
+    """status on every step must be one of the four valid values."""
+    resp = client.get("/keeper-workflow/test-match-abc123")
+    for step in resp.json()["steps"]:
+        assert step["status"] in VALID_STATUSES, (
+            f"Step {step['id']} has invalid status: {step['status']!r}"
+        )
+
+
+def test_deterministic_same_match_id():
+    """Two calls with the same matchId must return identical step statuses."""
+    r1 = client.get("/keeper-workflow/stable-id-xyz")
+    r2 = client.get("/keeper-workflow/stable-id-xyz")
+    s1 = [s["status"] for s in r1.json()["steps"]]
+    s2 = [s["status"] for s in r2.json()["steps"]]
+    assert s1 == s2, "Responses for the same matchId are not deterministic"
+
+
+def test_different_match_ids_may_differ():
+    """Two different matchIds are allowed (not required) to return different step
+    statuses — this just checks the endpoint accepts multiple IDs without error."""
+    r1 = client.get("/keeper-workflow/id-alpha")
+    r2 = client.get("/keeper-workflow/id-beta")
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+
+
+# ── ENS records endpoint ───────────────────────────────────────────────────
+
+
+def test_ens_records_returns_503_without_env(monkeypatch):
+    """When PLAYER_SUBNAME_REGISTRAR_ADDRESS is unset, the endpoint must return
+    503 with a human-readable detail string. This keeps the frontend's error
+    banner meaningful (it shows the detail field) without requiring a live RPC."""
+    monkeypatch.delenv("PLAYER_SUBNAME_REGISTRAR_ADDRESS", raising=False)
+    monkeypatch.delenv("RPC_URL", raising=False)
+    resp = client.get("/ens-records/alice")
+    assert resp.status_code == 503
+    data = resp.json()
+    assert "detail" in data
+    # The detail message must explain what env vars are missing.
+    assert "RPC_URL" in data["detail"] or "ENS client" in data["detail"]
+
+
+def test_ens_records_label_in_path():
+    """The endpoint must handle URL-encoded labels without error (returns 503
+    when not configured, but must not raise a 500 or routing error)."""
+    resp = client.get("/ens-records/chaingammon-player")
+    # Either 200 (configured env) or 503 (not configured) — never 404 or 500.
+    assert resp.status_code in (200, 503)


### PR DESCRIPTION
Adds three sidebar entries and three detail-only routes for the keeper-driven settlement architecture: `/log/[matchId]`, `/ens/[matchId]`, `/keeper/[matchId]`. Includes server mock endpoint for KeeperHub workflow status and live ENS records endpoint.

Closes #46

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/oslinin/chaingammon/actions/runs/25187044790