### PR TITLE
Add KeeperHub workflow and one-command setup script

### DIFF
--- a/keeperhub/.env.example
+++ b/keeperhub/.env.example
@@ -1,0 +1,56 @@
+# KeeperHub secrets for the chaingammon-match-settle workflow.
+#
+# Copy this file to keeperhub/.env (gitignored), fill in the values,
+# then run:
+#
+#   ./scripts/setup-keeper.sh
+#
+# This registers the workflow and pushes all secrets to KeeperHub.
+# You only need to run it once (or again when values change).
+
+# ── Authentication ─────────────────────────────────────────────────────────────
+
+# Your KeeperHub API key.  Get it from https://app.keeperhub.com → Settings →
+# API Keys.  Keep it secret — treat it like a password.
+KH_API_KEY=
+
+# ── Keeper identity ─────────────────────────────────────────────────────────────
+
+# The Ethereum private key the keeper uses to sign settlement payloads.
+# Generate a fresh wallet (never use your personal wallet):
+#   cast wallet new      # requires foundry (https://getfoundry.sh)
+# The matching PUBLIC key must be set as KEEPER_PUBKEY in MatchEscrow.sol
+# at deploy time (see contracts/src/MatchEscrow.sol constructor).
+KEEPER_PRIVKEY=
+
+# ── Service URLs ───────────────────────────────────────────────────────────────
+
+# Public URL of the Chaingammon FastAPI server.
+# Example (local tunnel): https://chaingammon.ngrok.app
+# Example (production):   https://api.chaingammon.xyz
+SERVER_URL=
+
+# Public URL of the relayer service (relayer/relayer.py).
+# Example: https://relayer.chaingammon.xyz
+RELAYER_URL=
+
+# gnubg replay service endpoint.
+# If you are running it locally: http://localhost:8001
+GNUBG_REPLAY_URL=
+
+# ── 0G testnet ─────────────────────────────────────────────────────────────────
+
+# 0G testnet EVM RPC endpoint.
+OG_RPC_URL=https://evmrpc-testnet.0g.ai
+
+# 0G Storage indexer (for fetching match records by archive URI).
+OG_STORAGE_INDEXER=https://indexer-storage-testnet-turbo.0g.ai
+
+# ── Contract addresses ─────────────────────────────────────────────────────────
+
+# MatchRegistry address (already deployed — read from contracts/deployments/0g-testnet.json).
+MATCH_REGISTRY_ADDRESS=0x60E52e2d9Ea7b4A851Dd63365222c7d102A11eaE
+
+# MatchEscrow address (deployed via: pnpm contracts:deploy after adding MatchEscrow.sol).
+# Fill this in after running the deploy script.
+MATCH_ESCROW_ADDRESS=

--- a/keeperhub/match-settle.yaml
+++ b/keeperhub/match-settle.yaml
@@ -1,0 +1,167 @@
+name: chaingammon-match-settle
+description: >
+  End-to-end match settlement workflow: drand VRF dice delivery, forfeit
+  detection, gnubg move-replay validation, keeper-signed settlement, and
+  relayer broadcast to 0G testnet.
+
+# Trigger: fires when the on-deposit step detects both players have deposited
+trigger:
+  type: evm-log
+  network: og-testnet
+  rpc: "{{ secret.OG_RPC_URL }}"
+  address: "{{ secret.MATCH_ESCROW_ADDRESS }}"
+  event: "Deposited(bytes32 indexed matchId, address indexed player, uint256 amount)"
+  filter:
+    # The workflow starts when the SECOND Deposited event for a matchId arrives.
+    # KeeperHub deduplicates by matchId across two firings before proceeding.
+    count: 2
+    group_by: matchId
+
+steps:
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Step 1 – on-deposit
+  # Confirm both deposits arrived and log the matchId.
+  # ─────────────────────────────────────────────────────────────────────────────
+  - id: on-deposit
+    name: Confirm both deposits
+    action: log
+    params:
+      message: "Both deposits received for match {{ trigger.matchId }}. Starting settlement workflow."
+    outputs:
+      match_id: "{{ trigger.matchId }}"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Step 2 – per-turn-drand
+  # Poll the server every 5 s to deliver the next drand round's dice.
+  # Runs until the game ends (on-game-end) or forfeit is triggered.
+  # ─────────────────────────────────────────────────────────────────────────────
+  - id: per-turn-drand
+    name: Deliver drand dice each turn
+    action: http-poll
+    params:
+      method: GET
+      url: "{{ secret.SERVER_URL }}/games/{{ steps.on-deposit.match_id }}/dice"
+      interval_seconds: 5
+      # Stop polling when the game has ended or a forfeit is detected.
+      stop_condition: "{{ steps.on-game-end.done || steps.forfeit-poll.forfeited }}"
+      headers:
+        Content-Type: application/json
+    outputs:
+      last_dice_round: "{{ response.body.round }}"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Step 3 – forfeit-poll
+  # Check every 30 s whether a player has exceeded the move clock.
+  # ─────────────────────────────────────────────────────────────────────────────
+  - id: forfeit-poll
+    name: Poll for move-clock expiry
+    action: http-poll
+    params:
+      method: POST
+      url: "{{ secret.SERVER_URL }}/matches/{{ steps.on-deposit.match_id }}/forfeit-check"
+      interval_seconds: 30
+      stop_condition: "{{ response.body.forfeit == true || steps.on-game-end.done }}"
+      headers:
+        Content-Type: application/json
+    outputs:
+      forfeited: "{{ response.body.forfeit }}"
+      expired_player: "{{ response.body.expired_player }}"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Step 4 – on-game-end
+  # Wait for the server to POST a game-end webhook (match result + archive_uri).
+  # ─────────────────────────────────────────────────────────────────────────────
+  - id: on-game-end
+    name: Wait for game-end webhook
+    action: webhook
+    params:
+      path: "/webhooks/match/{{ steps.on-deposit.match_id }}/end"
+      timeout_seconds: 7200  # 2-hour hard cap; forfeit-poll handles earlier exits
+    outputs:
+      done: true
+      winner: "{{ request.body.winner }}"
+      archive_uri: "{{ request.body.archive_uri }}"
+      elo_delta: "{{ request.body.elo_delta }}"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Step 5 – fetch-and-replay
+  # Pull the match record from 0G Storage and replay every move through gnubg.
+  # If any move is illegal the step fails → workflow halts → escrow stays locked.
+  # ─────────────────────────────────────────────────────────────────────────────
+  - id: fetch-and-replay
+    name: Fetch match record and replay via gnubg
+    action: http
+    params:
+      method: POST
+      url: "{{ secret.GNUBG_REPLAY_URL }}/replay"
+      headers:
+        Content-Type: application/json
+      body:
+        archive_uri: >-
+          {{
+            steps.forfeit-poll.forfeited
+              ? null
+              : steps.on-game-end.archive_uri
+          }}
+        match_id: "{{ steps.on-deposit.match_id }}"
+        storage_indexer: "{{ secret.OG_STORAGE_INDEXER }}"
+    # Halt the workflow if gnubg reports any invalid move.
+    assert: "{{ response.body.valid == true }}"
+    outputs:
+      confirmed_winner: >-
+        {{
+          steps.forfeit-poll.forfeited
+            ? (steps.forfeit-poll.expired_player == steps.on-game-end.winner
+                ? 'opponent'
+                : steps.on-game-end.winner)
+            : response.body.winner
+        }}
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Step 6 – sign-settlement
+  # Build and ECDSA-sign the settlement payload with the keeper private key.
+  # ─────────────────────────────────────────────────────────────────────────────
+  - id: sign-settlement
+    name: Sign settlement payload
+    action: ecdsa-sign
+    params:
+      private_key: "{{ secret.KEEPER_PRIVKEY }}"
+      payload:
+        matchId: "{{ steps.on-deposit.match_id }}"
+        winner: >-
+          {{
+            steps.forfeit-poll.forfeited
+              ? steps.fetch-and-replay.confirmed_winner
+              : steps.on-game-end.winner
+          }}
+        forfeit: "{{ steps.forfeit-poll.forfeited }}"
+        forfeitingPlayer: "{{ steps.forfeit-poll.expired_player }}"
+        eloDelta: "{{ steps.on-game-end.elo_delta }}"
+        archiveUri: "{{ steps.on-game-end.archive_uri }}"
+    outputs:
+      signature: "{{ signature }}"
+      payload: "{{ payload }}"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Step 7 – relay-settlement
+  # POST the signed payload to the relayer service, which broadcasts to 0G.
+  # ─────────────────────────────────────────────────────────────────────────────
+  - id: relay-settlement
+    name: Broadcast settlement via relayer
+    action: http
+    params:
+      method: POST
+      url: "{{ secret.RELAYER_URL }}/settle"
+      headers:
+        Content-Type: application/json
+      body:
+        matchId: "{{ steps.sign-settlement.payload.matchId }}"
+        winner: "{{ steps.sign-settlement.payload.winner }}"
+        forfeit: "{{ steps.sign-settlement.payload.forfeit }}"
+        forfeitingPlayer: "{{ steps.sign-settlement.payload.forfeitingPlayer }}"
+        eloDelta: "{{ steps.sign-settlement.payload.eloDelta }}"
+        archiveUri: "{{ steps.sign-settlement.payload.archiveUri }}"
+        keeperSig: "{{ steps.sign-settlement.signature }}"
+    assert: "{{ response.status == 200 }}"
+    outputs:
+      tx_hash: "{{ response.body.tx_hash }}"

--- a/scripts/setup-keeper.sh
+++ b/scripts/setup-keeper.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# setup-keeper.sh — register the Chaingammon settlement workflow on KeeperHub
+#                   and push all required secrets.
+#
+# Usage (local):
+#   cp keeperhub/.env.example keeperhub/.env   # fill in values
+#   ./scripts/setup-keeper.sh
+#
+# Usage (CI — add each variable as a GitHub Secret, then run this script
+#   in a workflow step):
+#   ./scripts/setup-keeper.sh
+#
+# Prereqs:
+#   kh CLI — install with:  brew install keeperhub/tap/kh
+#   All variables below set in keeperhub/.env OR as environment variables.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_FILE="$REPO_ROOT/keeperhub/.env"
+
+# ── Load .env file if present (allows local usage without exporting vars) ────
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck source=/dev/null
+  set -a
+  source "$ENV_FILE"
+  set +a
+fi
+
+# ── Validate required variables ──────────────────────────────────────────────
+REQUIRED_VARS=(
+  KH_API_KEY
+  KEEPER_PRIVKEY
+  SERVER_URL
+  RELAYER_URL
+  GNUBG_REPLAY_URL
+  OG_RPC_URL
+  OG_STORAGE_INDEXER
+  MATCH_REGISTRY_ADDRESS
+  MATCH_ESCROW_ADDRESS
+)
+
+missing=()
+for var in "${REQUIRED_VARS[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    missing+=("$var")
+  fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "ERROR: The following variables are not set:"
+  for v in "${missing[@]}"; do
+    echo "  $v"
+  done
+  echo ""
+  echo "Copy keeperhub/.env.example to keeperhub/.env and fill in the values,"
+  echo "or export them as environment variables before running this script."
+  exit 1
+fi
+
+# ── Authenticate ─────────────────────────────────────────────────────────────
+export KH_API_KEY
+echo "✓ Using KH_API_KEY"
+
+# ── Push workflow YAML to KeeperHub ──────────────────────────────────────────
+echo "→ Pushing workflow to KeeperHub..."
+kh workflow push "$REPO_ROOT/keeperhub/match-settle.yaml"
+echo "✓ Workflow registered"
+
+# ── Push secrets ─────────────────────────────────────────────────────────────
+echo "→ Setting secrets..."
+
+kh secret set KEEPER_PRIVKEY          "$KEEPER_PRIVKEY"
+kh secret set SERVER_URL              "$SERVER_URL"
+kh secret set RELAYER_URL             "$RELAYER_URL"
+kh secret set GNUBG_REPLAY_URL        "$GNUBG_REPLAY_URL"
+kh secret set OG_RPC_URL              "$OG_RPC_URL"
+kh secret set OG_STORAGE_INDEXER      "$OG_STORAGE_INDEXER"
+kh secret set MATCH_REGISTRY_ADDRESS  "$MATCH_REGISTRY_ADDRESS"
+kh secret set MATCH_ESCROW_ADDRESS    "$MATCH_ESCROW_ADDRESS"
+
+echo "✓ All secrets set"
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+echo ""
+echo "KeeperHub setup complete."
+echo "The chaingammon-match-settle workflow will fire automatically when"
+echo "both players deposit into MatchEscrow on 0G testnet."


### PR DESCRIPTION
Adds the keeperhub/match-settle.yaml workflow definition (7-step settlement pipeline: drand dice delivery, forfeit polling, gnubg replay, keeper signing, relayer broadcast), a keeperhub/.env.example that documents every required secret with plain-English explanations, and a scripts/setup-keeper.sh script that runs all kh commands in one step.

Closes #47

Generated with [Claude Code](https://claude.ai/code)