### PR TITLE
Track all gas transactions in Expenses ledger

### DIFF
--- a/frontend/app/ProfileBadge.tsx
+++ b/frontend/app/ProfileBadge.tsx
@@ -13,12 +13,13 @@
 // the contract to be redeployed with `selfMintSubname` (added in Phase 22).
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useWriteContract, useWaitForTransactionReceipt } from "wagmi";
 
 import { useChaingammonName } from "./useChaingammonName";
 import { useChaingammonProfile } from "./useChaingammonProfile";
 import { useChainContracts } from "./contracts";
+import { recordExpense } from "./expenses";
 
 // Inline ABI fragment for selfMintSubname. Kept here instead of relying
 // on the artifact so the component builds independently of the compile
@@ -79,6 +80,9 @@ function isSubnameAlreadyTaken(error: Error | null): boolean {
 export function ClaimForm({ address: _address }: { address: `0x${string}` }) {
   const [claimInput, setClaimInput] = useState("");
   const [suggestion, setSuggestion] = useState<string | null>(null);
+  // Track the label actually submitted so the expense description is accurate
+  // even when the suggestion button changes `claimInput` before confirming.
+  const submittedLabelRef = useRef<string>("");
 
   const { playerSubnameRegistrar } = useChainContracts();
 
@@ -94,9 +98,16 @@ export function ClaimForm({ address: _address }: { address: `0x${string}` }) {
     hash: txHash,
   });
 
-  // Reload so every component re-runs its subname lookup after the tx confirms.
+  // Record the gas expense and reload after the tx confirms so every component
+  // re-runs its subname lookup with the newly registered name.
   useEffect(() => {
-    if (isSuccess) window.location.reload();
+    if (isSuccess) {
+      recordExpense({
+        type: "ens_subname",
+        description: `ENS subname registered: ${submittedLabelRef.current}.chaingammon.eth`,
+      });
+      window.location.reload();
+    }
   }, [isSuccess]);
 
   // Show fallback suggestion when the name is already taken.
@@ -121,6 +132,7 @@ export function ClaimForm({ address: _address }: { address: `0x${string}` }) {
   const submit = (labelToUse?: string) => {
     const trimmed = (labelToUse ?? claimInput).trim();
     if (!trimmed || !isValidLabel(trimmed)) return;
+    submittedLabelRef.current = trimmed;
     resetWrite();
     setSuggestion(null);
     writeContract({

--- a/frontend/app/Sidebar.tsx
+++ b/frontend/app/Sidebar.tsx
@@ -29,6 +29,7 @@ import Link from "next/link";
 import { useAccount, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
 
 import { useChainContracts } from "./contracts";
+import { recordExpense } from "./expenses";
 
 // Inline ABI fragment for mintAgent. Kept here so the sidebar builds
 // independently of the Hardhat compile step (same pattern as ClaimForm
@@ -82,12 +83,17 @@ export function Sidebar() {
     if (matchId) setCurrentMatchId(matchId);
   }, []);
 
-  // Redirect to home after agent creation so the new agent appears in AgentsList.
+  // Record the gas expense then redirect to home after agent creation so the
+  // new agent appears in AgentsList immediately.
   useEffect(() => {
     if (isSuccess) {
+      recordExpense({
+        type: "agent_mint",
+        description: `Agent minted: "${agentLabel}" (Tier ${agentTier})`,
+      });
       window.location.href = "/";
     }
-  }, [isSuccess]);
+  }, [isSuccess, agentLabel, agentTier]);
 
   const creating = signing || confirming;
 

--- a/frontend/app/expenses.ts
+++ b/frontend/app/expenses.ts
@@ -1,21 +1,24 @@
-// Lightweight 0G-token expense ledger stored in localStorage.
+// Gas expense ledger stored in localStorage.
 //
-// Records one entry per event that charges 0G tokens:
-//   - coach_hint  — hint served by 0G Compute (Qwen 2.5 7B Instruct)
+// Records one entry per on-chain or paid-compute event that costs the user gas
+// or 0G tokens:
+//   - coach_hint      — hint served by 0G Compute (Qwen 2.5 7B Instruct)
 //   - game_settlement — on-chain match settlement via KeeperHub + 0G Chain
+//   - ens_subname     — ENS subname claimed via selfMintSubname on-chain
+//   - agent_mint      — iNFT agent minted via mintAgent on-chain
 //
 // The ledger is append-only and client-local; it is not synced anywhere.
 // Entries are stored newest-first so the Expenses page can render them in
 // insertion order without sorting.
 
-/** A single 0G-token spending event. */
+/** A single gas/token spending event. */
 export interface ExpenseEntry {
   /** Collision-resistant id: `${Date.now()}-${random}`. */
   id: string;
   /** ISO 8601 UTC timestamp of when the charge was incurred. */
   timestamp: string;
   /** Category of the spending event. */
-  type: "coach_hint" | "game_settlement";
+  type: "coach_hint" | "game_settlement" | "ens_subname" | "agent_mint";
   /** Human-readable summary shown in the Expenses ledger. */
   description: string;
 }

--- a/frontend/app/expenses/page.tsx
+++ b/frontend/app/expenses/page.tsx
@@ -1,13 +1,14 @@
-// Phase 30: Expenses page — ledger of 0G token–spending events.
+// Phase 30: Expenses page — ledger of gas and 0G token–spending events.
 //
 // Shows one row per charge:
 //   - Coach hint via 0G Compute (Qwen 2.5 7B Instruct)
 //   - On-chain game settlement via KeeperHub + 0G Chain
+//   - ENS subname registered via selfMintSubname (gas)
+//   - Agent iNFT minted via mintAgent (gas)
 //
-// The table is populated from localStorage (written by the match page whenever
-// the paid coach serves a hint, or when a game is settled on-chain). The empty
-// state is shown when no entries exist — i.e. the user has only ever used the
-// free local coach and has not settled any games.
+// The table is populated from localStorage (written whenever an on-chain or
+// paid-compute event completes). The empty state is shown when no entries
+// exist.
 //
 // SSR note: `getExpenses()` returns [] on the server, so the empty-state card
 // is always the server-rendered HTML. The client replaces it after hydration if
@@ -18,21 +19,29 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { getExpenses, type ExpenseEntry } from "../expenses";
 
-/**
- * Renders a badge for the expense type.
- * Coach hints use an amber palette; settlement charges use indigo.
- */
+const TYPE_LABELS: Record<ExpenseEntry["type"], string> = {
+  coach_hint: "Coach hint",
+  game_settlement: "Settlement",
+  ens_subname: "ENS claim",
+  agent_mint: "Agent mint",
+};
+
+const TYPE_CLASSES: Record<ExpenseEntry["type"], string> = {
+  coach_hint:
+    "inline-flex rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+  game_settlement:
+    "inline-flex rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300",
+  ens_subname:
+    "inline-flex rounded-full bg-teal-100 px-2 py-0.5 text-xs font-medium text-teal-800 dark:bg-teal-900/30 dark:text-teal-300",
+  agent_mint:
+    "inline-flex rounded-full bg-violet-100 px-2 py-0.5 text-xs font-medium text-violet-800 dark:bg-violet-900/30 dark:text-violet-300",
+};
+
+/** Renders a colour-coded badge for the expense type. */
 function TypeBadge({ type }: { type: ExpenseEntry["type"] }) {
-  const isHint = type === "coach_hint";
   return (
-    <span
-      className={
-        isHint
-          ? "inline-flex rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300"
-          : "inline-flex rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300"
-      }
-    >
-      {isHint ? "Coach hint" : "Settlement"}
+    <span className={TYPE_CLASSES[type] ?? TYPE_CLASSES.game_settlement}>
+      {TYPE_LABELS[type] ?? type}
     </span>
   );
 }
@@ -67,9 +76,9 @@ export default function ExpensesPage() {
 
       <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-6 px-4 py-8 sm:px-8">
         <p className="text-sm text-zinc-500 dark:text-zinc-400">
-          One row per 0G token–spending event. Entries appear only when the
-          paid coach (0G Compute · Qwen 2.5 7B) is active or a game is settled
-          on-chain.
+          One row per gas or 0G token–spending event: ENS subname registration,
+          agent minting, game settlement, and paid coach hints (0G Compute ·
+          Qwen 2.5 7B).
         </p>
 
         {isEmpty ? (
@@ -78,8 +87,9 @@ export default function ExpensesPage() {
             className="rounded-lg border border-zinc-200 bg-white px-6 py-10 text-center dark:border-zinc-800 dark:bg-zinc-950"
           >
             <p className="text-sm text-zinc-400 dark:text-zinc-500">
-              No expenses yet. Enable the paid coach or settle a game to see
-              charges here.
+              No expenses yet. Gas charges appear here after registering an ENS
+              subname, minting an agent, settling a game, or using the paid
+              coach.
             </p>
           </div>
         ) : (

--- a/frontend/app/match/page.tsx
+++ b/frontend/app/match/page.tsx
@@ -812,6 +812,10 @@ function MatchInner() {
         ],
       });
       setSettleTxHash(txHash);
+      recordExpense({
+        type: "game_settlement",
+        description: `Match settled on-chain · Agent #${agentId} · tx ${txHash.slice(0, 10)}…`,
+      });
     } catch (e: unknown) {
       setSettleError(e instanceof Error ? e.message : String(e));
     } finally {

--- a/frontend/tests/expenses.spec.ts
+++ b/frontend/tests/expenses.spec.ts
@@ -70,4 +70,55 @@ test.describe("Expenses page", () => {
       "Coach hint · Agent #1 · Qwen 2.5 7B via 0G Compute",
     );
   });
+
+  test("shows ENS subname and agent mint entries with correct badges", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.evaluate(() => {
+      const entries = [
+        {
+          id: "test-ens-1",
+          timestamp: new Date().toISOString(),
+          type: "ens_subname",
+          description: "ENS subname registered: alice.chaingammon.eth",
+        },
+        {
+          id: "test-agent-1",
+          timestamp: new Date().toISOString(),
+          type: "agent_mint",
+          description: 'Agent minted: "my-agent" (Tier 0)',
+        },
+        {
+          id: "test-settle-1",
+          timestamp: new Date().toISOString(),
+          type: "game_settlement",
+          description: "Match settled on-chain · Agent #1 · tx 0xabcdef1234…",
+        },
+      ];
+      window.localStorage.setItem(
+        "chaingammon_expenses",
+        JSON.stringify(entries),
+      );
+    });
+
+    await page.goto("/expenses");
+    await page.waitForLoadState("networkidle");
+
+    const table = page.locator('[data-testid="expenses-table"]');
+    await expect(table).toBeVisible({ timeout: 5000 });
+
+    await expect(page.locator("table")).toContainText("ENS claim");
+    await expect(page.locator("table")).toContainText(
+      "ENS subname registered: alice.chaingammon.eth",
+    );
+    await expect(page.locator("table")).toContainText("Agent mint");
+    await expect(page.locator("table")).toContainText(
+      'Agent minted: "my-agent" (Tier 0)',
+    );
+    await expect(page.locator("table")).toContainText("Settlement");
+    await expect(page.locator("table")).toContainText(
+      "Match settled on-chain · Agent #1 · tx 0xabcdef1234…",
+    );
+  });
 });


### PR DESCRIPTION
Fixes #52

Extends the Expenses ledger to record gas fees from all on-chain transactions, not just 0G Compute coach hints.

## Changes
- `expenses.ts`: adds `ens_subname` and `agent_mint` to the `ExpenseEntry` type
- `ProfileBadge.tsx`: records expense after ENS subname registration confirms
- `Sidebar.tsx`: records expense after agent mint confirms
- `match/page.tsx`: records expense after game settlement confirms
- `expenses/page.tsx`: colour-coded badges for all four types; updated copy
- `expenses.spec.ts`: Playwright coverage for new entry types

Generated with [Claude Code](https://claude.ai/code)