### PR TITLE
Phase 57: show ELO and matches played in top navbar; consolidate to one global navbar

### DIFF
--- a/frontend/app/ProfileBadge.tsx
+++ b/frontend/app/ProfileBadge.tsx
@@ -218,7 +218,7 @@ export function ClaimForm({ address: _address }: { address: `0x${string}` }) {
 
 export function ProfileBadge({ address }: { address: `0x${string}` }) {
   const { label, name, isLoading: nameLoading } = useChaingammonName(address);
-  const { elo } = useChaingammonProfile(label);
+  const { elo, matchCount } = useChaingammonProfile(label);
 
   if (nameLoading) {
     return (
@@ -235,11 +235,24 @@ export function ProfileBadge({ address }: { address: `0x${string}` }) {
     return (
       <span
         data-testid="profile-badge"
-        className="font-mono text-sm text-zinc-700 dark:text-zinc-300"
+        className="flex items-center gap-2 font-mono text-sm text-zinc-700 dark:text-zinc-300"
       >
         {name}
         {elo ? (
-          <span className="ml-1 text-zinc-500 dark:text-zinc-400">({elo})</span>
+          <span
+            title="ELO rating"
+            className="rounded bg-indigo-100 px-1.5 py-0.5 text-xs font-semibold text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300"
+          >
+            ELO {elo}
+          </span>
+        ) : null}
+        {matchCount ? (
+          <span
+            title="Matches played"
+            className="rounded bg-zinc-100 px-1.5 py-0.5 text-xs font-semibold text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+          >
+            {matchCount}M
+          </span>
         ) : null}
       </span>
     );

--- a/frontend/app/Sidebar.tsx
+++ b/frontend/app/Sidebar.tsx
@@ -128,6 +128,20 @@ export function Sidebar() {
       </div>
 
       <nav className="flex flex-col gap-1 p-3">
+        {/* Entry 0: home page */}
+        <Link
+          href="/"
+          data-testid="sidebar-home"
+          className="flex flex-col gap-0.5 rounded-md px-3 py-3 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800"
+        >
+          <span className="font-semibold text-zinc-900 dark:text-zinc-50">
+            Home
+          </span>
+          <span className="text-xs text-zinc-500 dark:text-zinc-400">
+            Agents &amp; lobby
+          </span>
+        </Link>
+
         {/* Entry 1: current play with agent */}
         <Link
           href={playHref}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,10 +1,13 @@
 // Phase 28: root layout updated to include global sidebar.
 // Phase 35: responsive layout — viewport meta tag, sidebar hidden on mobile,
 // MobileNav fixed bottom bar for small screens.
+// Phase 57: consolidated top navbar — brand, compute-backends, and wallet
+// connect (with ELO + match count from ENS) in a single global header.
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ComputeBackendsPill } from "./ComputeBackendsPill";
+import { ConnectButton } from "./ConnectButton";
 import { Providers } from "./providers";
 import { Sidebar } from "./Sidebar";
 import { MobileNav } from "./MobileNav";
@@ -48,11 +51,18 @@ export default function RootLayout({
             <Sidebar />
             {/* pb-16 md:pb-0 reserves space for the fixed mobile bottom nav */}
             <div className="flex flex-1 flex-col min-w-0 pb-16 md:pb-0">
-              {/* Compute-backends pill: pinned at the top so the three
-                  operations × two backends story is visible on every page. */}
-              <div className="flex justify-end border-b border-zinc-200 px-4 py-2 dark:border-zinc-800">
-                <ComputeBackendsPill />
-              </div>
+              {/* Global top navbar: brand on the left, compute backends
+                  + wallet connect (ELO, matches played) on the right.
+                  Visible on every page so users always see their stats. */}
+              <header className="flex items-center justify-between gap-4 border-b border-zinc-200 px-4 py-2 dark:border-zinc-800">
+                <span className="text-sm font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+                  Chaingammon
+                </span>
+                <div className="flex flex-wrap items-center justify-end gap-3">
+                  <ComputeBackendsPill />
+                  <ConnectButton />
+                </div>
+              </header>
               {children}
             </div>
           </div>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,20 +1,14 @@
 // Phase 13: landing page extended with live on-chain agents list.
 // Phase 35: responsive padding for mobile screens.
+// Phase 57: page-level header removed — brand + ConnectButton now live in the
+// global layout navbar so they render on every page, not just the home page.
 // The page shell is a server component; <AgentsList> is a client component
 // that performs the wagmi reads.
-import { ConnectButton } from "./ConnectButton";
 import { AgentsList } from "./AgentsList";
 
 export default function Home() {
   return (
     <div className="flex flex-1 flex-col bg-zinc-50 dark:bg-black">
-      <header className="flex items-center justify-between border-b border-zinc-200 px-4 py-4 sm:px-8 dark:border-zinc-800">
-        <h1 className="text-lg font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
-          Chaingammon
-        </h1>
-        <ConnectButton />
-      </header>
-
       <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-8 px-4 py-8 sm:px-8 sm:py-16">
         <div className="flex flex-col gap-3">
           <h2 className="text-3xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">

--- a/frontend/app/useChaingammonProfile.ts
+++ b/frontend/app/useChaingammonProfile.ts
@@ -50,6 +50,17 @@ export function useChaingammonProfile(label: string | null) {
     query: { enabled: !!node },
   });
 
+  const { data: matchCount } = useReadContract({
+    address: playerSubnameRegistrar,
+    abi: PlayerSubnameRegistrarABI,
+    functionName: "text",
+    args: node ? [node, "match_count"] : undefined,
+    chainId,
+    query: { enabled: !!node },
+  });
+
   const eloValue = typeof elo === "string" && elo !== "" ? elo : undefined;
-  return { elo: eloValue, node, isLoading };
+  const matchCountValue =
+    typeof matchCount === "string" && matchCount !== "" ? matchCount : undefined;
+  return { elo: eloValue, matchCount: matchCountValue, node, isLoading };
 }


### PR DESCRIPTION
Fixes #57

Consolidates to a single global top navbar showing the brand, compute backends, and wallet connect with ELO rating + matches played read from ENS text records. Adds Home to sidebar.

Generated with [Claude Code](https://claude.ai/code)