### PR TITLE
feat: show owner's ENS in agent card hover popover

### DIFF
--- a/frontend/app/AgentCard.tsx
+++ b/frontend/app/AgentCard.tsx
@@ -32,6 +32,7 @@ interface AgentProfile {
   kind: "model" | "overlay" | "null";
   match_count: number;
   summary: string;
+  owner_ens?: string | null;
 }
 
 interface AgentCardProps {
@@ -139,6 +140,14 @@ export function AgentCard({ agentId }: AgentCardProps) {
           <p className="text-red-600">Profile unavailable.</p>
         ) : profileQuery.data ? (
           <>
+            {profileQuery.data.owner_ens && (
+              <p className="mb-1.5 font-mono text-[10px] text-zinc-500 dark:text-zinc-400 truncate">
+                <span className="uppercase tracking-wide">Owner</span>{" "}
+                <span className="text-zinc-700 dark:text-zinc-300">
+                  {profileQuery.data.owner_ens}
+                </span>
+              </p>
+            )}
             <p className="mb-1 text-zinc-700 dark:text-zinc-300">
               <span className="font-mono">
                 Matches: {profileQuery.data.match_count}

--- a/server/app/chain_client.py
+++ b/server/app/chain_client.py
@@ -46,6 +46,13 @@ _AGENT_REGISTRY_ABI = [
     },
     {
         "type": "function",
+        "name": "ownerOf",
+        "stateMutability": "view",
+        "inputs": [{"name": "tokenId", "type": "uint256"}],
+        "outputs": [{"name": "", "type": "address"}],
+    },
+    {
+        "type": "function",
         "name": "tier",
         "stateMutability": "view",
         "inputs": [{"name": "agentId", "type": "uint256"}],
@@ -419,6 +426,11 @@ class ChainClient:
     def agent_match_count(self, agent_id: int) -> int:
         contract = self._require_agent_registry()
         return int(contract.functions.matchCount(agent_id).call())
+
+    def agent_owner(self, agent_id: int) -> str:
+        """Return the ERC-721 owner address of the agent NFT."""
+        contract = self._require_agent_registry()
+        return str(contract.functions.ownerOf(agent_id).call())
 
     def agent_experience_version(self, agent_id: int) -> int:
         contract = self._require_agent_registry()

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1442,12 +1442,16 @@ def list_agents():
 @app.get("/agents/{agent_id}/profile")
 def get_agent_profile(agent_id: int):
     """Resolve `agent_id`'s on-chain `dataHashes[1]` → 0G storage blob
-    → `load_profile` content-sniff → `{match_count, summary, kind}`.
+    → `load_profile` content-sniff → `{match_count, summary, kind, owner_ens}`.
 
     Mirrors the resolver path /games/{id}/agent-move (overlay) and
     /agents/{id}/recommend-teammate (model) already use. Returns the
     NullProfile shape for cold-start agents (frontend renders a
-    'no measurable style yet' chip)."""
+    'no measurable style yet' chip).
+
+    `owner_ens` is the ENS name of the agent's ERC-721 owner, resolved
+    via web3 reverse lookup on Sepolia. Falls back to a truncated address
+    when ENS resolution is unavailable (e.g. on 0G testnet)."""
     from agent_profile import (
         ModelProfile,
         NullProfile,
@@ -1476,9 +1480,33 @@ def get_agent_profile(agent_id: int):
         kind = "overlay"
     else:
         kind = "null"
+
+    # Resolve the agent's ERC-721 owner and their ENS name.
+    # Best-effort: missing env vars or chain errors return None gracefully.
+    owner_ens: Optional[str] = None
+    try:
+        owner_addr = chain.agent_owner(agent_id)
+        # Try ENS reverse lookup on the connected network (works on Sepolia).
+        # Returns None if the address has no reverse record set.
+        try:
+            resolved = chain.w3.ens.name(owner_addr)
+            owner_ens = resolved if resolved else _truncate_address(owner_addr)
+        except Exception:
+            owner_ens = _truncate_address(owner_addr)
+    except ChainError:
+        pass
+
     return {
         "agent_id": agent_id,
         "kind": kind,
         "match_count": int(metrics.get("match_count", 0)),
         "summary": profile.summarize(),
+        "owner_ens": owner_ens,
     }
+
+
+def _truncate_address(addr: str) -> str:
+    """Return a short display form like `0x1234…abcd` for a hex address."""
+    if not addr or len(addr) < 10:
+        return addr
+    return f"{addr[:6]}…{addr[-4:]}"


### PR DESCRIPTION
Show the agent NFT owner's ENS name (or truncated address) in the AgentCard hover popover.

Changes:
- Added ERC-721 `ownerOf` to AgentRegistry ABI in `chain_client.py`
- New `agent_owner(agent_id)` method on `ChainClient`
- `/agents/{id}/profile` now returns `owner_ens` (ENS reverse lookup on Sepolia, falls back to truncated address)
- AgentCard hover popover shows "Owner" row with the resolved ENS or address

Closes #60

Generated with [Claude Code](https://claude.ai/code)