### PR TITLE
feat: move create-agent form from sidebar to dedicated page

### DIFF
--- a/frontend/app/Sidebar.tsx
+++ b/frontend/app/Sidebar.tsx
@@ -5,10 +5,8 @@
 //   1. "Play with agent" — links to /match with the most recently played
 //      agentId (read from localStorage, set by the match page on mount).
 //      Falls back to agentId=1 when no prior game exists.
-//   2. "Create new agent" — reveals an inline form that calls
-//      AgentRegistry.mintAgent via the connected wallet (onlyOwner on the
-//      contract). On success the page redirects to "/" so the new agent
-//      appears immediately in AgentsList.
+//   2. "Create new agent" — links to /create-agent, a dedicated page with
+//      the mint form (AgentRegistry.mintAgent).
 //   3. "Expenses" (Phase 30) — links to /expenses, the 0G token spending
 //      ledger. Shows coach-hint and game-settlement charges.
 //   4. "0G Storage log" (Phase 36) — links to /log/{currentMatchId}, the live
@@ -26,53 +24,12 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { useAccount, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
-
-import { useChainContracts } from "./contracts";
-import { recordExpense } from "./expenses";
-
-// Inline ABI fragment for mintAgent. Kept here so the sidebar builds
-// independently of the Hardhat compile step (same pattern as ClaimForm
-// using SELF_MINT_ABI). The full artifact ABI covers all other reads.
-const MINT_AGENT_ABI = [
-  {
-    type: "function",
-    name: "mintAgent",
-    inputs: [
-      { name: "to", type: "address", internalType: "address" },
-      { name: "metadataURI", type: "string", internalType: "string" },
-      { name: "tier_", type: "uint8", internalType: "uint8" },
-    ],
-    outputs: [{ name: "agentId", type: "uint256", internalType: "uint256" }],
-    stateMutability: "nonpayable",
-  },
-] as const;
 
 export function Sidebar() {
   // Defer localStorage access until after hydration to avoid SSR mismatch.
   const [mounted, setMounted] = useState(false);
   const [lastAgentId, setLastAgentId] = useState<number | null>(null);
   const [currentMatchId, setCurrentMatchId] = useState<string | null>(null);
-  const [showCreateForm, setShowCreateForm] = useState(false);
-
-  // Create-agent form state.
-  const [agentLabel, setAgentLabel] = useState("");
-  const [agentTier, setAgentTier] = useState<number>(0);
-
-  const { address } = useAccount();
-  const { agentRegistry } = useChainContracts();
-
-  const {
-    writeContract,
-    data: txHash,
-    error: writeError,
-    isPending: signing,
-    reset,
-  } = useWriteContract();
-
-  const { isLoading: confirming, isSuccess } = useWaitForTransactionReceipt({
-    hash: txHash,
-  });
 
   // Read last active agentId and current match ID from localStorage after hydration.
   useEffect(() => {
@@ -82,31 +39,6 @@ export function Sidebar() {
     const matchId = window.localStorage.getItem("currentMatchId");
     if (matchId) setCurrentMatchId(matchId);
   }, []);
-
-  // Record the gas expense then redirect to home after agent creation so the
-  // new agent appears in AgentsList immediately.
-  useEffect(() => {
-    if (isSuccess) {
-      recordExpense({
-        type: "agent_mint",
-        description: `Agent minted: "${agentLabel}" (Tier ${agentTier})`,
-      });
-      window.location.href = "/";
-    }
-  }, [isSuccess, agentLabel, agentTier]);
-
-  const creating = signing || confirming;
-
-  const submit = () => {
-    if (!address || !agentLabel.trim()) return;
-    reset();
-    writeContract({
-      address: agentRegistry,
-      abi: MINT_AGENT_ABI,
-      functionName: "mintAgent",
-      args: [address, agentLabel.trim(), agentTier],
-    });
-  };
 
   // Before hydration, render only the structural shell so the server HTML
   // matches the initial client render.
@@ -156,12 +88,11 @@ export function Sidebar() {
           </span>
         </Link>
 
-        {/* Entry 2: create a new agent */}
-        <button
-          type="button"
+        {/* Entry 2: create a new agent — navigates to dedicated /create-agent page */}
+        <Link
+          href="/create-agent"
           data-testid="sidebar-create-agent"
-          onClick={() => setShowCreateForm((v) => !v)}
-          className="flex flex-col gap-0.5 rounded-md px-3 py-3 text-left text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800"
+          className="flex flex-col gap-0.5 rounded-md px-3 py-3 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800"
         >
           <span className="font-semibold text-zinc-900 dark:text-zinc-50">
             Create new agent
@@ -169,7 +100,7 @@ export function Sidebar() {
           <span className="text-xs text-zinc-500 dark:text-zinc-400">
             Mint an iNFT agent
           </span>
-        </button>
+        </Link>
 
         {/* Entry 3: 0G token expense ledger */}
         <Link
@@ -255,60 +186,7 @@ export function Sidebar() {
           </span>
         </Link>
 
-        {/* Inline create-agent form — shown when the entry above is clicked */}
-        {showCreateForm && (
-          <div
-            data-testid="create-agent-form"
-            className="flex flex-col gap-2 rounded-md border border-zinc-200 p-3 dark:border-zinc-700"
-          >
-            <input
-              data-testid="agent-label-input"
-              type="text"
-              value={agentLabel}
-              onChange={(e) => {
-                setAgentLabel(e.target.value);
-                reset();
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") submit();
-              }}
-              placeholder="agent-label"
-              className="h-8 rounded border border-zinc-300 bg-white px-2 font-mono text-xs text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-50"
-              disabled={creating}
-            />
-            <select
-              data-testid="agent-tier-select"
-              value={agentTier}
-              onChange={(e) => setAgentTier(Number(e.target.value))}
-              className="h-8 rounded border border-zinc-300 bg-white px-2 text-xs text-zinc-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-50"
-              disabled={creating}
-            >
-              <option value={0}>Tier 0</option>
-              <option value={1}>Tier 1</option>
-              <option value={2}>Tier 2</option>
-              <option value={3}>Tier 3</option>
-            </select>
-            <button
-              data-testid="create-agent-submit"
-              type="button"
-              onClick={submit}
-              disabled={creating || !agentLabel.trim() || !address}
-              className="rounded bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
-            >
-              {signing ? "Signing…" : confirming ? "Confirming…" : "Create"}
-            </button>
-            {!address && (
-              <p className="text-xs text-amber-600 dark:text-amber-400">
-                Connect wallet to create an agent.
-              </p>
-            )}
-            {writeError && (
-              <p className="text-xs text-red-600 dark:text-red-400">
-                {writeError.message.split("\n")[0]}
-              </p>
-            )}
-          </div>
-        )}
+
       </nav>
     </aside>
   );

--- a/frontend/app/create-agent/page.tsx
+++ b/frontend/app/create-agent/page.tsx
@@ -1,0 +1,157 @@
+// Create-agent page. The sidebar "Create new agent" link navigates here;
+// this page owns the mint form that was previously inlined in the sidebar.
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAccount, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
+
+import { useChainContracts } from "../contracts";
+import { recordExpense } from "../expenses";
+
+// Inline ABI fragment — same as the one that was in Sidebar.tsx.
+const MINT_AGENT_ABI = [
+  {
+    type: "function",
+    name: "mintAgent",
+    inputs: [
+      { name: "to", type: "address", internalType: "address" },
+      { name: "metadataURI", type: "string", internalType: "string" },
+      { name: "tier_", type: "uint8", internalType: "uint8" },
+    ],
+    outputs: [{ name: "agentId", type: "uint256", internalType: "uint256" }],
+    stateMutability: "nonpayable",
+  },
+] as const;
+
+export default function CreateAgentPage() {
+  const router = useRouter();
+  const { address } = useAccount();
+  const { agentRegistry } = useChainContracts();
+
+  const [agentLabel, setAgentLabel] = useState("");
+  const [agentTier, setAgentTier] = useState<number>(0);
+
+  const {
+    writeContract,
+    data: txHash,
+    error: writeError,
+    isPending: signing,
+    reset,
+  } = useWriteContract();
+
+  const { isLoading: confirming, isSuccess } = useWaitForTransactionReceipt({
+    hash: txHash,
+  });
+
+  // Record expense and navigate home once the tx is confirmed.
+  useEffect(() => {
+    if (isSuccess) {
+      recordExpense({
+        type: "agent_mint",
+        description: `Agent minted: "${agentLabel}" (Tier ${agentTier})`,
+      });
+      router.push("/");
+    }
+  }, [isSuccess, agentLabel, agentTier, router]);
+
+  const creating = signing || confirming;
+
+  const submit = () => {
+    if (!address || !agentLabel.trim()) return;
+    reset();
+    writeContract({
+      address: agentRegistry,
+      abi: MINT_AGENT_ABI,
+      functionName: "mintAgent",
+      args: [address, agentLabel.trim(), agentTier],
+    });
+  };
+
+  return (
+    <main className="flex flex-1 flex-col gap-6 p-6 max-w-md">
+      <div>
+        <h1 className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">
+          Create new agent
+        </h1>
+        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+          Mint an iNFT agent on-chain. You must be the contract owner.
+        </p>
+      </div>
+
+      <div
+        data-testid="create-agent-form"
+        className="flex flex-col gap-4"
+      >
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="agent-label"
+            className="text-sm font-medium text-zinc-700 dark:text-zinc-300"
+          >
+            Agent label
+          </label>
+          <input
+            id="agent-label"
+            data-testid="agent-label-input"
+            type="text"
+            value={agentLabel}
+            onChange={(e) => {
+              setAgentLabel(e.target.value);
+              reset();
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") submit();
+            }}
+            placeholder="agent-label"
+            className="h-9 rounded border border-zinc-300 bg-white px-3 font-mono text-sm text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-50"
+            disabled={creating}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="agent-tier"
+            className="text-sm font-medium text-zinc-700 dark:text-zinc-300"
+          >
+            Tier
+          </label>
+          <select
+            id="agent-tier"
+            data-testid="agent-tier-select"
+            value={agentTier}
+            onChange={(e) => setAgentTier(Number(e.target.value))}
+            className="h-9 rounded border border-zinc-300 bg-white px-3 text-sm text-zinc-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-50"
+            disabled={creating}
+          >
+            <option value={0}>Tier 0</option>
+            <option value={1}>Tier 1</option>
+            <option value={2}>Tier 2</option>
+            <option value={3}>Tier 3</option>
+          </select>
+        </div>
+
+        {!address && (
+          <p className="text-sm text-amber-600 dark:text-amber-400">
+            Connect your wallet to create an agent.
+          </p>
+        )}
+
+        {writeError && (
+          <p className="text-sm text-red-600 dark:text-red-400">
+            {writeError.message.split("\n")[0]}
+          </p>
+        )}
+
+        <button
+          data-testid="create-agent-submit"
+          type="button"
+          onClick={submit}
+          disabled={creating || !agentLabel.trim() || !address}
+          className="rounded bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+        >
+          {signing ? "Signing…" : confirming ? "Confirming…" : "Create agent"}
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/frontend/tests/sidebar.spec.ts
+++ b/frontend/tests/sidebar.spec.ts
@@ -2,7 +2,8 @@
 //
 // Asserts that the global sidebar renders on the home page with both
 // required navigation entries, and that clicking "Create new agent"
-// reveals the inline creation form.
+// navigates to the dedicated /create-agent page (form no longer inlined
+// in the sidebar).
 //
 // The sidebar is a client component that uses wagmi hooks — all reads
 // degrade gracefully when no wallet is connected, so these tests run
@@ -24,24 +25,27 @@ test.describe("Sidebar", () => {
     await expect(playLink).toContainText("Play with agent");
 
     // Entry 2: "Create new agent"
-    const createButton = page.locator('[data-testid="sidebar-create-agent"]');
-    await expect(createButton).toBeVisible({ timeout: 5000 });
-    await expect(createButton).toContainText("Create new agent");
+    const createLink = page.locator('[data-testid="sidebar-create-agent"]');
+    await expect(createLink).toBeVisible({ timeout: 5000 });
+    await expect(createLink).toContainText("Create new agent");
   });
 
-  test("clicking Create new agent reveals the inline form", async ({ page }) => {
+  test("Create new agent link points to /create-agent", async ({ page }) => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
-    // Form must not be visible before the toggle.
-    const form = page.locator('[data-testid="create-agent-form"]');
-    await expect(form).not.toBeVisible();
+    const createLink = page.locator('[data-testid="sidebar-create-agent"]');
+    await expect(createLink).toBeVisible({ timeout: 5000 });
 
-    // Click the toggle button.
-    await page.locator('[data-testid="sidebar-create-agent"]').click();
+    const href = await createLink.getAttribute("href");
+    expect(href).toBe("/create-agent");
+  });
 
-    // Form should now be visible with label input, tier select, and submit.
-    await expect(form).toBeVisible({ timeout: 3000 });
+  test("create-agent page shows the mint form", async ({ page }) => {
+    await page.goto("/create-agent");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.locator('[data-testid="create-agent-form"]')).toBeVisible({ timeout: 5000 });
     await expect(page.locator('[data-testid="agent-label-input"]')).toBeVisible();
     await expect(page.locator('[data-testid="agent-tier-select"]')).toBeVisible();
     await expect(page.locator('[data-testid="create-agent-submit"]')).toBeVisible();


### PR DESCRIPTION
Moves the "Create new agent" mint form out of the sidebar and into a dedicated /create-agent page. Sidebar entry is now a link that navigates to that page.

Closes #58

Generated with [Claude Code](https://claude.ai/code)