### PR TITLE
Phase 68: pure-Python + pure-JS backgammon rules engine for KeeperHub settlement validation

### DIFF
--- a/agent/rules_engine.py
+++ b/agent/rules_engine.py
@@ -95,6 +95,21 @@ class Board:
         return c == 1
 
 
+# Standard backgammon opening position (player 0's perspective, player 0 moves 24→1):
+#   Player 0 (+): 2 on pt 24, 5 on pt 13, 3 on pt 8, 5 on pt 6
+#   Player 1 (−): 2 on pt 1,  5 on pt 12, 3 on pt 17, 5 on pt 19
+OPENING_BOARD = Board(
+    points=(
+        -2, 0, 0, 0, 0, 5,   # points 1-6
+        0, 3, 0, 0, 0, -5,   # points 7-12
+        5, 0, 0, 0, -3, 0,   # points 13-18
+        -5, 0, 0, 0, 0, 2,   # points 19-24
+    ),
+    bar=(0, 0),
+    off=(0, 0),
+)
+
+
 # ---------------------------------------------------------------------------
 # Move parsing
 # ---------------------------------------------------------------------------
@@ -295,3 +310,51 @@ def is_legal(board: Board, dice: tuple[int, int], side: int,
                     sim_points[dst_idx] = dst_count - 1
 
     return True
+
+
+def apply_move(board: Board, side: int, move_str: str) -> Board:
+    """Apply `move_str` to `board` for `side` and return the resulting board.
+
+    Caller is responsible for calling `is_legal` first; this function
+    does not re-validate. Hits (opponent blots) send the hit checker to
+    the bar. Bear-offs increment `off[side]`.
+    """
+    pieces = parse_move(move_str, side=side)
+    sim_points = list(board.points)
+    sim_bar = list(board.bar)
+    sim_off = list(board.off)
+
+    bar_src = BAR_SRC if side == 0 else BAR_SRC_P1
+    off_dst = OFF_DST if side == 0 else OFF_DST_P1
+
+    for piece in pieces:
+        # Lift the checker from its source.
+        if piece.src == bar_src:
+            sim_bar[side] -= 1
+        else:
+            src_idx = piece.src - 1
+            sim_points[src_idx] += -1 if side == 0 else 1
+
+        # Place the checker at its destination.
+        if piece.dst == off_dst:
+            sim_off[side] += 1
+        else:
+            dst_idx = piece.dst - 1
+            if side == 0:
+                if sim_points[dst_idx] == -1:   # hit — send opponent to bar
+                    sim_bar[1] += 1
+                    sim_points[dst_idx] = 1
+                else:
+                    sim_points[dst_idx] += 1
+            else:
+                if sim_points[dst_idx] == 1:    # hit — send opponent to bar
+                    sim_bar[0] += 1
+                    sim_points[dst_idx] = -1
+                else:
+                    sim_points[dst_idx] -= 1
+
+    return Board(
+        points=tuple(sim_points),
+        bar=tuple(sim_bar),
+        off=tuple(sim_off),
+    )

--- a/agent/tests/test_rules_engine.py
+++ b/agent/tests/test_rules_engine.py
@@ -17,7 +17,9 @@ from rules_engine import (
     OFF_DST,
     Board,
     CheckerMove,
+    OPENING_BOARD,
     all_in_home,
+    apply_move,
     dice_pool,
     has_pieces_on_bar,
     is_legal,
@@ -268,3 +270,82 @@ def test_unparseable_move_returns_false():
 
 def test_empty_move_returns_false():
     assert not is_legal(_starting_board(), dice=(3, 5), side=0, move_str="")
+
+
+# ---------------------------------------------------------------------------
+# OPENING_BOARD
+# ---------------------------------------------------------------------------
+
+
+def test_opening_board_has_15_checkers_per_side():
+    p0 = OPENING_BOARD.for_side(0)
+    p1 = OPENING_BOARD.for_side(1)
+    assert sum(p0) == 15
+    assert sum(p1) == 15
+
+
+def test_opening_board_matches_starting_board():
+    """OPENING_BOARD must equal the _starting_board() helper used in the rest of
+    the test suite — they encode the same standard position."""
+    assert OPENING_BOARD == _starting_board()
+
+
+# ---------------------------------------------------------------------------
+# apply_move
+# ---------------------------------------------------------------------------
+
+
+def test_apply_move_simple_shift():
+    """13/10 on a 3-x roll: point 13 loses one checker, point 10 gains one."""
+    b = _starting_board()
+    result = apply_move(b, side=0, move_str="13/10")
+    assert result.points[12] == b.points[12] - 1   # 13-point lost one
+    assert result.points[9] == b.points[9] + 1     # 10-point gained one
+    # Total checker count unchanged.
+    assert sum(c for c in result.points if c > 0) + result.bar[0] + result.off[0] == 15
+
+
+def test_apply_move_two_checkers():
+    """8/5 6/5 (3-1 roll): both source points lose one, destination gains two."""
+    b = _starting_board()
+    result = apply_move(b, side=0, move_str="8/5 6/5")
+    assert result.points[7] == b.points[7] - 1    # 8-point
+    assert result.points[5] == b.points[5] - 1    # 6-point
+    assert result.points[4] == b.points[4] + 2    # 5-point
+
+
+def test_apply_move_hit_sends_opponent_to_bar():
+    """13/8* hits an opponent blot on the 8-point: blot goes to bar."""
+    pts = list(_starting_board().points)
+    pts[7] = -1   # lone opponent blot on 8-point
+    b = Board(points=tuple(pts))
+    result = apply_move(b, side=0, move_str="13/8*")
+    assert result.points[7] == 1        # player 0 now on the 8-point
+    assert result.bar[1] == 1           # opponent was sent to bar
+    assert result.points[12] == b.points[12] - 1  # 13-point lost one
+
+
+def test_apply_move_bar_entry():
+    """bar/22: player 0 enters from bar onto the 22-point."""
+    pts = [0] * NUM_POINTS
+    b = Board(points=tuple(pts), bar=(1, 0))
+    result = apply_move(b, side=0, move_str="bar/22")
+    assert result.bar[0] == 0           # bar cleared
+    assert result.points[21] == 1       # 22-point occupied
+
+
+def test_apply_move_bear_off():
+    """6/off: player 0 bears off from the 6-point."""
+    pts = [0] * NUM_POINTS
+    pts[5] = 15
+    b = Board(points=tuple(pts))
+    result = apply_move(b, side=0, move_str="6/off")
+    assert result.points[5] == 14
+    assert result.off[0] == 1
+
+
+def test_apply_move_preserves_immutability():
+    """apply_move must not mutate the input board (Board is frozen)."""
+    b = _starting_board()
+    _ = apply_move(b, side=0, move_str="13/10")
+    assert b.points[12] == 5   # original unchanged

--- a/frontend/lib/rules_engine.ts
+++ b/frontend/lib/rules_engine.ts
@@ -1,0 +1,264 @@
+/**
+ * rules_engine.ts — pure-TypeScript backgammon move legality.
+ *
+ * Browser-side companion to agent/rules_engine.py. Shares the same
+ * board encoding and move-notation conventions so a KeeperHub audit
+ * replayer running in the browser produces bit-identical results to
+ * the Python settlement validator.
+ *
+ * Board encoding:
+ *   - 24-element `points` array indexed 0..23 (points[0] = point 1).
+ *   - Positive counts = player 0 checkers; negative = player 1.
+ *   - Player 0 moves 24 → 1 (high-to-low index).
+ *   - Player 1 moves 1 → 24 (low-to-high index).
+ *   - BAR_SRC = 25 (player 0 entering from bar), BAR_SRC_P1 = 0 (player 1).
+ *   - OFF_DST = 0 (player 0 bearing off), OFF_DST_P1 = 25 (player 1).
+ *
+ * Scope mirrors the Python version — common cases only, no cube rules.
+ */
+
+export const NUM_POINTS = 24;
+export const BAR_SRC = 25;    // player 0 enters from bar (sentinel src)
+export const BAR_SRC_P1 = 0;  // player 1 enters from bar (sentinel src)
+export const OFF_DST = 0;     // player 0 bears off (sentinel dst)
+export const OFF_DST_P1 = 25; // player 1 bears off (sentinel dst)
+
+export interface Board {
+  /** 24 signed checker counts (positive = player 0, negative = player 1). */
+  points: number[];
+  /** [p0_on_bar, p1_on_bar] */
+  bar: [number, number];
+  /** [p0_borne_off, p1_borne_off] */
+  off: [number, number];
+}
+
+export interface CheckerMove {
+  src: number;
+  dst: number;
+  hit: boolean;
+}
+
+/** Standard backgammon opening position (player 0 perspective). */
+export const OPENING_BOARD: Board = {
+  points: [
+    -2,  0,  0,  0,  0,  5,  // points 1-6
+     0,  3,  0,  0,  0, -5,  // points 7-12
+     5,  0,  0,  0, -3,  0,  // points 13-18
+    -5,  0,  0,  0,  0,  2,  // points 19-24
+  ],
+  bar: [0, 0],
+  off: [0, 0],
+};
+
+/**
+ * Parse a gnubg-format move string into individual checker movements.
+ *
+ * @example parseMove("8/5 6/5", 0) → [{src:8,dst:5,hit:false}, {src:6,dst:5,hit:false}]
+ * @example parseMove("bar/22", 0)  → [{src:25,dst:22,hit:false}]
+ * @example parseMove("6/off", 0)   → [{src:6,dst:0,hit:false}]
+ * @example parseMove("13/8*", 0)   → [{src:13,dst:8,hit:true}]
+ */
+export function parseMove(moveStr: string, side: number): CheckerMove[] {
+  const moves: CheckerMove[] = [];
+  const re = /(\d+|bar)\/(\d+|off)(\*?)/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(moveStr)) !== null) {
+    const rawSrc = m[1].toLowerCase();
+    const rawDst = m[2].toLowerCase();
+    const hit = m[3] === "*";
+    const src =
+      rawSrc === "bar" ? (side === 0 ? BAR_SRC : BAR_SRC_P1) : parseInt(rawSrc, 10);
+    const dst =
+      rawDst === "off" ? (side === 0 ? OFF_DST : OFF_DST_P1) : parseInt(rawDst, 10);
+    moves.push({ src, dst, hit });
+  }
+  return moves;
+}
+
+/** Returns the full pip pool for a dice roll (doubles → four pips). */
+export function dicePool(dice: [number, number]): number[] {
+  const [d1, d2] = dice;
+  return d1 === d2 ? [d1, d1, d1, d1] : [d1, d2];
+}
+
+function pipConsumed(checker: CheckerMove, side: number): number {
+  if (side === 0) {
+    if (checker.src === BAR_SRC) return BAR_SRC - checker.dst;
+    if (checker.dst === OFF_DST) return checker.src;
+    return checker.src - checker.dst;
+  }
+  if (checker.src === BAR_SRC_P1) return checker.dst;
+  if (checker.dst === OFF_DST_P1) return BAR_SRC_P1 + (NUM_POINTS + 1 - checker.src);
+  return checker.dst - checker.src;
+}
+
+function allInHome(points: number[], bar: number[], side: number): boolean {
+  if (bar[side] > 0) return false;
+  if (side === 0) return points.slice(6).every((c) => c <= 0);
+  return points.slice(0, 18).every((c) => c >= 0);
+}
+
+/**
+ * Check whether `moveStr` is legal from `board` for `side` given `dice`.
+ *
+ * Returns false for malformed move strings, wrong pips, blocked destinations,
+ * source points the side doesn't own, bar-entry violations, and bear-off
+ * attempted before all checkers are in the home board.
+ */
+export function isLegal(
+  board: Board,
+  dice: [number, number],
+  side: number,
+  moveStr: string,
+): boolean {
+  const pieces = parseMove(moveStr, side);
+  if (pieces.length === 0) return false;
+
+  const pool = dicePool(dice);
+  const barSrc = side === 0 ? BAR_SRC : BAR_SRC_P1;
+
+  if (board.bar[side] > 0 && pieces[0].src !== barSrc) return false;
+
+  const simPoints = [...board.points];
+  const simBar = [...board.bar];
+  const available = [...pool];
+
+  for (const piece of pieces) {
+    const pip = pipConsumed(piece, side);
+    const pipIdx = available.indexOf(pip);
+    if (pipIdx === -1) return false;
+    available.splice(pipIdx, 1);
+
+    // Validate and lift from source.
+    if (piece.src === barSrc) {
+      if (simBar[side] <= 0) return false;
+      simBar[side]--;
+    } else {
+      const srcIdx = piece.src - 1;
+      if (srcIdx < 0 || srcIdx >= NUM_POINTS) return false;
+      if (side === 0 && simPoints[srcIdx] <= 0) return false;
+      if (side === 1 && simPoints[srcIdx] >= 0) return false;
+      simPoints[srcIdx] += side === 0 ? -1 : 1;
+    }
+
+    // Validate and place at destination.
+    const offDst = side === 0 ? OFF_DST : OFF_DST_P1;
+    if (piece.dst === offDst) {
+      if (!allInHome(simPoints, simBar, side)) return false;
+    } else {
+      const dstIdx = piece.dst - 1;
+      if (dstIdx < 0 || dstIdx >= NUM_POINTS) return false;
+      const dstCount = simPoints[dstIdx];
+      if (side === 0) {
+        if (dstCount <= -2) return false;
+        if (dstCount === -1) {
+          if (!piece.hit) return false;
+          simBar[1]++;
+          simPoints[dstIdx] = 1;
+        } else {
+          simPoints[dstIdx]++;
+        }
+      } else {
+        if (dstCount >= 2) return false;
+        if (dstCount === 1) {
+          if (!piece.hit) return false;
+          simBar[0]++;
+          simPoints[dstIdx] = -1;
+        } else {
+          simPoints[dstIdx]--;
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Apply a move (assumed valid) to `board` and return the resulting board.
+ * Does not mutate the input. Caller must call `isLegal` first.
+ */
+export function applyMove(board: Board, side: number, moveStr: string): Board {
+  const pieces = parseMove(moveStr, side);
+  const simPoints = [...board.points];
+  const simBar: [number, number] = [board.bar[0], board.bar[1]];
+  const simOff: [number, number] = [board.off[0], board.off[1]];
+
+  const barSrc = side === 0 ? BAR_SRC : BAR_SRC_P1;
+  const offDst = side === 0 ? OFF_DST : OFF_DST_P1;
+
+  for (const piece of pieces) {
+    // Lift from source.
+    if (piece.src === barSrc) {
+      simBar[side]--;
+    } else {
+      const srcIdx = piece.src - 1;
+      simPoints[srcIdx] += side === 0 ? -1 : 1;
+    }
+
+    // Place at destination.
+    if (piece.dst === offDst) {
+      simOff[side]++;
+    } else {
+      const dstIdx = piece.dst - 1;
+      if (side === 0) {
+        if (simPoints[dstIdx] === -1) {
+          simBar[1]++;
+          simPoints[dstIdx] = 1;
+        } else {
+          simPoints[dstIdx]++;
+        }
+      } else {
+        if (simPoints[dstIdx] === 1) {
+          simBar[0]++;
+          simPoints[dstIdx] = -1;
+        } else {
+          simPoints[dstIdx]--;
+        }
+      }
+    }
+  }
+
+  return { points: simPoints, bar: simBar, off: simOff };
+}
+
+export interface MoveValidationResult {
+  valid: boolean;
+  /** Index of the first invalid move, or -1 when all moves are valid. */
+  firstInvalidIndex: number;
+  /** Human-readable error for the first invalid move, or null. */
+  error: string | null;
+}
+
+/**
+ * Validate a full sequence of game-record move entries against backgammon rules.
+ *
+ * Each entry must have `turn` (0|1), `dice` ([d1, d2]), and `move` (gnubg notation).
+ * Entries with an empty or `"(auto-played)"` move string are skipped.
+ */
+export function validateGameMoves(
+  moves: Array<{ turn: number; dice: number[]; move: string }>,
+): MoveValidationResult {
+  let board = { ...OPENING_BOARD, points: [...OPENING_BOARD.points] };
+
+  for (let i = 0; i < moves.length; i++) {
+    const entry = moves[i];
+    const moveStr = entry.move ?? "";
+    if (!moveStr || moveStr === "(auto-played)") continue;
+
+    const dice = [entry.dice[0], entry.dice[1]] as [number, number];
+    const side = entry.turn as 0 | 1;
+
+    if (!isLegal(board, dice, side, moveStr)) {
+      return {
+        valid: false,
+        firstInvalidIndex: i,
+        error: `move #${i} violates backgammon rules — side ${side}, dice ${JSON.stringify(dice)}, move "${moveStr}"`,
+      };
+    }
+
+    board = applyMove(board, side, moveStr);
+  }
+
+  return { valid: true, firstInvalidIndex: -1, error: null };
+}

--- a/server/app/keeper_workflow.py
+++ b/server/app/keeper_workflow.py
@@ -67,6 +67,7 @@ STEP_IDS: tuple[str, ...] = (
     "escrow_deposit",
     "vrf_rolls",
     "og_storage_fetch",
+    "rules_check",         # Phase 68: pure-Python backgammon rules validation
     "gnubg_replay",
     "agent_move_replay",   # Phase 38: deterministic move-selection audit
     "settlement_signed",
@@ -79,6 +80,7 @@ STEP_NAMES: dict[str, str] = {
     "escrow_deposit":     "Escrow deposit confirmation",
     "vrf_rolls":          "VRF rolls (drand)",
     "og_storage_fetch":   "Game-record fetch from 0G Storage",
+    "rules_check":        "Backgammon rules validation (pure-Python)",
     "gnubg_replay":       "gnubg replay validation",
     "agent_move_replay":  "Agent move-selection replay (deterministic NN argmax)",
     "settlement_signed":  "Settlement payload signed",
@@ -301,6 +303,66 @@ def step_og_storage_fetch(ctx: WorkflowContext, step: WorkflowStep) -> None:
     step.detail = (
         f"GameRecord fetched ({len(blob)} bytes); {len(record.get('moves', []))} moves "
         f"+ final_position_id={ctx.final_position_id[:12] if ctx.final_position_id else 'unknown'}…"
+    )
+
+
+def step_rules_check(ctx: WorkflowContext, step: WorkflowStep) -> None:
+    """Validate every recorded move against the pure-Python backgammon rules engine.
+
+    Walks the game record from the canonical opening position, checks each
+    move with `rules_engine.is_legal`, then advances the board with
+    `rules_engine.apply_move`. A single illegal move fails the step and
+    halts the workflow so the match cannot settle.
+
+    This check runs independently of gnubg — it validates rule compliance
+    using the self-contained Python rules engine (agent/rules_engine.py).
+    The gnubg_replay step that follows verifies positional accuracy on top.
+    Auto-played moves (recorded as `(auto-played)`) are skipped; moves
+    without dice are rejected as malformed.
+    """
+    if not ctx.game_record:
+        raise RuntimeError("game_record not loaded (og_storage_fetch must succeed first)")
+
+    import sys
+    from pathlib import Path as _P
+
+    _agent_dir = _P(__file__).resolve().parents[2] / "agent"
+    if str(_agent_dir) not in sys.path:
+        sys.path.insert(0, str(_agent_dir))
+
+    from rules_engine import OPENING_BOARD, apply_move, is_legal  # noqa: E402
+
+    board = OPENING_BOARD
+    moves = ctx.game_record.get("moves", [])
+    validated = 0
+    skipped = 0
+
+    for i, move_entry in enumerate(moves):
+        move_str = move_entry.get("move", "")
+        if not move_str or move_str == "(auto-played)":
+            skipped += 1
+            continue
+
+        dice_list = move_entry.get("dice", [])
+        if len(dice_list) < 2:
+            raise RuntimeError(
+                f"move #{i} has no dice field: {move_entry!r}"
+            )
+        dice = (int(dice_list[0]), int(dice_list[1]))
+        side = int(move_entry.get("turn", 0))
+
+        if not is_legal(board, dice, side, move_str):
+            raise RuntimeError(
+                f"move #{i} violates backgammon rules — "
+                f"side {side}, dice {dice}, move {move_str!r}"
+            )
+
+        board = apply_move(board, side, move_str)
+        validated += 1
+
+    step.detail = (
+        f"Rules check passed: {validated} move(s) validated, "
+        f"{skipped} auto-played skip(s)."
     )
 
 
@@ -758,6 +820,7 @@ _STEP_RUNNERS: dict[str, Callable[..., None]] = {
     "escrow_deposit":    step_escrow_deposit,
     "vrf_rolls":         step_vrf_rolls,
     "og_storage_fetch":  step_og_storage_fetch,
+    "rules_check":       step_rules_check,
     "gnubg_replay":      step_gnubg_replay,
     "agent_move_replay": step_agent_move_replay,
     "settlement_signed": step_settlement_signed,

--- a/server/tests/test_keeper_workflow.py
+++ b/server/tests/test_keeper_workflow.py
@@ -52,7 +52,7 @@ def test_get_workflow_returns_all_pending_for_unrun_match():
     wf = kw.get_workflow("match-never-run")
     assert wf.match_id == "match-never-run"
     assert wf.status == "pending"
-    assert len(wf.steps) == 9   # Phase 38: +agent_move_replay
+    assert len(wf.steps) == 10   # Phase 68: +rules_check
     assert [s.id for s in wf.steps] == list(kw.STEP_IDS)
     assert all(s.status == "pending" for s in wf.steps)
     assert all(s.duration_ms is None for s in wf.steps)
@@ -326,7 +326,7 @@ def test_run_workflow_happy_path_marks_all_ok():
 
 
 def test_run_workflow_step_failure_aborts_remainder():
-    """Step 4 (gnubg_replay) raises; remaining steps stay pending."""
+    """gnubg_replay raises; remaining steps stay pending."""
     def _fail(ctx, step):
         raise RuntimeError("simulated mismatch")
 
@@ -336,11 +336,12 @@ def test_run_workflow_step_failure_aborts_remainder():
     wf = kw.run_workflow("42", runners=runners)
     assert wf.status == "failed"
     statuses = [s.status for s in wf.steps]
-    assert statuses[:3] == ["ok", "ok", "ok"]
-    assert statuses[3] == "failed"
-    assert wf.steps[3].error == "simulated mismatch"
+    gnubg_idx = list(kw.STEP_IDS).index("gnubg_replay")
+    assert all(s == "ok" for s in statuses[:gnubg_idx])
+    assert statuses[gnubg_idx] == "failed"
+    assert wf.steps[gnubg_idx].error == "simulated mismatch"
     # Remainder pending.
-    assert all(s == "pending" for s in statuses[4:])
+    assert all(s == "pending" for s in statuses[gnubg_idx + 1:])
 
 
 def test_run_workflow_persists_to_disk():
@@ -366,7 +367,7 @@ def test_run_workflow_records_step_durations():
 
 
 def test_endpoint_get_returns_canonical_shape_for_unrun_match():
-    """Phase 36 contract: 8 canonical step IDs in order, all valid statuses,
+    """Phase 36 contract: canonical step IDs in order, all valid statuses,
     every step has the required field set. Real orchestrator preserves
     this for matchIds that have never run."""
     r = client.get("/keeper-workflow/never-run-id")
@@ -403,7 +404,8 @@ def test_endpoint_run_post_triggers_workflow(monkeypatch):
     chain = _stub_chain_with_match()
     record = {
         "match_length": 1,
-        "moves": [{"move": "13/10 24/23"}],
+        # Include turn/dice so step_rules_check can validate the move.
+        "moves": [{"turn": 0, "dice": [3, 1], "move": "13/10 24/23"}],
         "final_position_id": "FINAL",
     }
     blob = json.dumps(record).encode()
@@ -428,7 +430,7 @@ def test_endpoint_run_post_triggers_workflow(monkeypatch):
 
     r = client.post("/keeper-workflow/42/run")
     assert r.status_code == 200
-    # Wait briefly for the background thread to complete (8 stubbed steps).
+    # Wait briefly for the background thread to complete (10 stubbed steps).
     deadline = time.time() + 5.0
     while time.time() < deadline:
         body = client.get("/keeper-workflow/42").json()
@@ -453,7 +455,7 @@ def test_phase36_response_shape_preserved():
     assert "matchId" in body
     assert "status" in body
     assert "steps" in body
-    assert len(body["steps"]) == 9   # Phase 38
+    assert len(body["steps"]) == 10   # Phase 68: +rules_check
     expected_fields = {"id", "name", "status", "duration_ms", "retry_count",
                        "tx_hash", "error", "detail"}
     for step in body["steps"]:
@@ -693,11 +695,11 @@ def test_step_agent_move_replay_argmax_consistent_mismatch_fails(monkeypatch):
     assert "inconclusive" in step.detail.lower() or "diverged" in step.detail.lower()
 
 
-def test_phase38_step_count_is_nine():
-    """Locked: workflow has 9 steps after Phase 38."""
+def test_phase68_step_count_is_ten():
+    """Locked: workflow has 10 steps after Phase 68 (+rules_check)."""
     r = client.get("/keeper-workflow/test-id")
     body = r.json()
-    assert len(body["steps"]) == 9
+    assert len(body["steps"]) == 10
 
 
 def test_phase38_includes_agent_move_replay_step():
@@ -709,3 +711,13 @@ def test_phase38_includes_agent_move_replay_step():
     i = step_ids.index("agent_move_replay")
     assert step_ids[i - 1] == "gnubg_replay"
     assert step_ids[i + 1] == "settlement_signed"
+
+
+def test_phase68_includes_rules_check_step():
+    """Locked: rules_check is in the canonical step list, between og_storage_fetch and gnubg_replay."""
+    r = client.get("/keeper-workflow/test-id")
+    step_ids = [s["id"] for s in r.json()["steps"]]
+    assert "rules_check" in step_ids
+    i = step_ids.index("rules_check")
+    assert step_ids[i - 1] == "og_storage_fetch"
+    assert step_ids[i + 1] == "gnubg_replay"

--- a/server/tests/test_phase68_rules_check.py
+++ b/server/tests/test_phase68_rules_check.py
@@ -1,0 +1,214 @@
+"""
+Phase 68 tests: pure-Python backgammon rules validation step in the
+KeeperHub settlement workflow.
+
+Run with:  cd server && uv run pytest tests/test_phase68_rules_check.py -v
+
+Covers:
+  - Happy path: valid game record passes rules check
+  - Illegal move detection: step fails and names the offending move
+  - Auto-played moves are skipped without error
+  - Missing dice field raises RuntimeError (malformed record)
+  - Empty move list succeeds (nothing to validate)
+  - No game_record in context raises RuntimeError
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from app import keeper_workflow as kw  # noqa: E402
+
+
+# ─── fixtures ───────────────────────────────────────────────────────────────
+
+
+def _ctx_with_record(moves: list[dict]) -> kw.WorkflowContext:
+    record = {
+        "match_length": 1,
+        "moves": moves,
+        "final_position_id": "FINAL",
+    }
+    return kw.WorkflowContext(match_id="42", game_record=record)
+
+
+def _step() -> kw.WorkflowStep:
+    return kw.WorkflowStep(id="rules_check", name="Backgammon rules validation (pure-Python)")
+
+
+# ─── happy path ─────────────────────────────────────────────────────────────
+
+
+def test_rules_check_valid_opening_move():
+    """Classic opening 3-1: 8/5 6/5 is legal from the starting position."""
+    ctx = _ctx_with_record([
+        {"turn": 0, "dice": [3, 1], "move": "8/5 6/5"},
+    ])
+    step = _step()
+    kw.step_rules_check(ctx, step)
+    assert "validated" in step.detail
+    assert "1 move" in step.detail
+
+
+def test_rules_check_two_valid_moves():
+    """Two moves in sequence both pass; board state advances correctly.
+    Player 1 (side=1) moves 1→24 so src < dst in gnubg notation."""
+    ctx = _ctx_with_record([
+        {"turn": 0, "dice": [3, 1], "move": "8/5 6/5"},
+        {"turn": 1, "dice": [4, 2], "move": "12/16 12/14"},
+    ])
+    step = _step()
+    kw.step_rules_check(ctx, step)
+    assert "2 move" in step.detail
+
+
+def test_rules_check_empty_move_list_passes():
+    """A game record with no moves is trivially valid."""
+    ctx = _ctx_with_record([])
+    step = _step()
+    kw.step_rules_check(ctx, step)
+    assert "0 move" in step.detail
+
+
+# ─── auto-played skips ───────────────────────────────────────────────────────
+
+
+def test_rules_check_skips_auto_played():
+    """(auto-played) entries are skipped, not validated."""
+    ctx = _ctx_with_record([
+        {"turn": 0, "dice": [3, 1], "move": "(auto-played)"},
+        # Player 1 (side=1) moves 1→24 so valid notation has src < dst.
+        {"turn": 1, "dice": [4, 2], "move": "12/16 12/14"},
+    ])
+    step = _step()
+    kw.step_rules_check(ctx, step)
+    assert "1 auto-played skip" in step.detail
+    assert "1 move" in step.detail
+
+
+def test_rules_check_skips_empty_move_string():
+    """Entries with an empty move string are also skipped."""
+    ctx = _ctx_with_record([
+        {"turn": 0, "dice": [3, 1], "move": ""},
+        {"turn": 1, "dice": [4, 2], "move": "12/16 12/14"},
+    ])
+    step = _step()
+    kw.step_rules_check(ctx, step)
+    assert "1 auto-played skip" in step.detail
+
+
+# ─── illegal move detection ──────────────────────────────────────────────────
+
+
+def test_rules_check_illegal_move_fails():
+    """A move that uses a pip not in the dice fails the step."""
+    ctx = _ctx_with_record([
+        # 8/3 requires 5 pips; dice are (3, 1) — illegal.
+        {"turn": 0, "dice": [3, 1], "move": "8/3"},
+    ])
+    step = _step()
+    with pytest.raises(RuntimeError, match="violates backgammon rules"):
+        kw.step_rules_check(ctx, step)
+
+
+def test_rules_check_blocked_destination_fails():
+    """Player 0 cannot land on a point held by 2+ opponent checkers."""
+    ctx = _ctx_with_record([
+        # From opening, point 19 has 5 player-1 checkers — blocked for player 0.
+        {"turn": 0, "dice": [5, 5], "move": "24/19 24/19"},
+    ])
+    step = _step()
+    with pytest.raises(RuntimeError, match="violates backgammon rules"):
+        kw.step_rules_check(ctx, step)
+
+
+def test_rules_check_names_the_offending_move():
+    """Error message includes the move index and notation."""
+    ctx = _ctx_with_record([
+        {"turn": 0, "dice": [3, 1], "move": "8/5 6/5"},  # ok
+        {"turn": 1, "dice": [4, 2], "move": "8/1"},       # illegal (wrong pip)
+    ])
+    step = _step()
+    with pytest.raises(RuntimeError) as exc_info:
+        kw.step_rules_check(ctx, step)
+    assert "move #1" in str(exc_info.value)
+    assert "8/1" in str(exc_info.value)
+
+
+# ─── malformed record ────────────────────────────────────────────────────────
+
+
+def test_rules_check_missing_dice_raises():
+    """A move entry without a dice field is malformed — fail the step."""
+    ctx = _ctx_with_record([
+        {"turn": 0, "move": "8/5 6/5"},   # no 'dice' key
+    ])
+    step = _step()
+    with pytest.raises(RuntimeError, match="no dice"):
+        kw.step_rules_check(ctx, step)
+
+
+def test_rules_check_no_game_record_raises():
+    """step_rules_check requires ctx.game_record to be populated."""
+    ctx = kw.WorkflowContext(match_id="42")   # game_record not set
+    step = _step()
+    with pytest.raises(RuntimeError, match="game_record not loaded"):
+        kw.step_rules_check(ctx, step)
+
+
+# ─── workflow integration ────────────────────────────────────────────────────
+
+
+def test_rules_check_step_in_workflow_happy_path():
+    """End-to-end: rules_check step passes in a run_workflow call where all
+    other steps are stubbed out."""
+    runners = {sid: lambda ctx, step: None for sid in kw.STEP_IDS}
+    runners["audit_append"] = lambda ctx, step, *, workflow: None
+
+    # Inject a game_record so rules_check has something to validate.
+    def _inject_record(ctx, step):
+        ctx.game_record = {
+            "match_length": 1,
+            "moves": [{"turn": 0, "dice": [3, 1], "move": "8/5 6/5"}],
+            "final_position_id": "FINAL",
+        }
+
+    runners["og_storage_fetch"] = _inject_record
+    # Use the real rules_check runner.
+    del runners["rules_check"]
+
+    wf = kw.run_workflow("99", runners=runners)
+    rules_step = next(s for s in wf.steps if s.id == "rules_check")
+    assert rules_step.status == "ok"
+    assert "validated" in rules_step.detail
+
+
+def test_rules_check_step_fails_workflow_on_illegal_move():
+    """If rules_check detects an illegal move, the workflow status is 'failed'
+    and steps after rules_check stay pending."""
+    runners = {sid: lambda ctx, step: None for sid in kw.STEP_IDS}
+    runners["audit_append"] = lambda ctx, step, *, workflow: None
+
+    def _inject_bad_record(ctx, step):
+        ctx.game_record = {
+            "match_length": 1,
+            # 8/3 is not legal on dice (3, 1).
+            "moves": [{"turn": 0, "dice": [3, 1], "move": "8/3"}],
+            "final_position_id": "FINAL",
+        }
+
+    runners["og_storage_fetch"] = _inject_bad_record
+    del runners["rules_check"]
+
+    wf = kw.run_workflow("99", runners=runners)
+    assert wf.status == "failed"
+    rules_step = next(s for s in wf.steps if s.id == "rules_check")
+    assert rules_step.status == "failed"
+    assert "violates backgammon rules" in (rules_step.error or "")
+    # gnubg_replay and later steps must still be pending.
+    subsequent = [s for s in wf.steps
+                  if list(kw.STEP_IDS).index(s.id) > list(kw.STEP_IDS).index("rules_check")]
+    assert all(s.status == "pending" for s in subsequent)


### PR DESCRIPTION
Adds a self-contained rules-validation layer to the KeeperHub settlement workflow. Every move in a GameRecord is checked against standard backgammon rules before the match settles. Also adds a pure-TypeScript port for browser-side pre-validation.

Closes #68

Generated with [Claude Code](https://claude.ai/code)