### PR TITLE
Phase 69: wire 0G weight upload through training API

### DIFF
--- a/agent/round_robin_trainer.py
+++ b/agent/round_robin_trainer.py
@@ -21,7 +21,8 @@ Status JSONL events (one event per line):
     {"event":"match",         "epoch":i, "agent_a":a, "agent_b":b,
                               "winner":a|b, "plies":n, "ts":...}
     {"event":"epoch_end",     "epoch":i, "ts":...}
-    {"event":"agent_saved",   "agent_id":a, "path":..., "root_hash":..., "ts":...}
+    {"event":"agent_saved",      "agent_id":a, "path":..., "root_hash":..., "ts":...}
+    {"event":"agent_save_error", "agent_id":a, "detail":..., "ts":...}
     {"event":"done"|"aborted","ts":...}
 
 Pairing is `itertools.combinations(agent_ids, 2)` — each unordered pair
@@ -385,17 +386,27 @@ def run_round_robin(
         # for the on-chain match_count.
         matches_per_agent = max(1, epochs * (n - 1) // 2)
         for aid, state in agents.items():
-            local_path, root_hash = save_and_upload_checkpoint(
-                state,
-                checkpoint_dir=Path(checkpoint_dir),
-                upload=upload,
-                encrypt=encrypt,
-                matches_played=matches_per_agent,
-            )
-            _emit(
-                status_fh, "agent_saved",
-                agent_id=aid, path=str(local_path), root_hash=root_hash,
-            )
+            try:
+                local_path, root_hash = save_and_upload_checkpoint(
+                    state,
+                    checkpoint_dir=Path(checkpoint_dir),
+                    upload=upload,
+                    encrypt=encrypt,
+                    matches_played=matches_per_agent,
+                )
+                _emit(
+                    status_fh, "agent_saved",
+                    agent_id=aid, path=str(local_path), root_hash=root_hash,
+                )
+            except Exception as exc:
+                # Upload failure (e.g. missing OG_STORAGE_* env vars or
+                # network timeout) must not abort the run — the local
+                # checkpoint may still have been written. Surface the
+                # error in the status JSONL so the frontend can render it.
+                _emit(
+                    status_fh, "agent_save_error",
+                    agent_id=aid, detail=str(exc),
+                )
 
     return agents
 

--- a/frontend/app/training/page.tsx
+++ b/frontend/app/training/page.tsx
@@ -83,6 +83,13 @@ interface EstimateResponse {
   note?: string;
 }
 
+interface CheckpointEntry {
+  agent_id: number;
+  path: string | null;
+  root_hash: string | null;
+  error: string | null;
+}
+
 interface StatusResponse {
   running: boolean;
   completed_games: number;
@@ -93,6 +100,7 @@ interface StatusResponse {
   per_agent: Record<string, { games: number; wins: number; losses: number }>;
   use_0g_inference: boolean;
   use_0g_coaching: boolean;
+  upload_to_0g: boolean;
   ended: "done" | "aborted" | null;
   last_update_ts: number;
   // Phase L.2: TensorBoard sidecar metadata. Frontend uses this to
@@ -100,6 +108,9 @@ interface StatusResponse {
   // tensorboard binary not on PATH on the operator's host).
   tensorboard_url?: string | null;
   logdir?: string | null;
+  // Per-agent checkpoint save/upload results. Populated after training
+  // completes; root_hash is the 0G Storage Merkle root when uploaded.
+  checkpoints?: CheckpointEntry[];
 }
 
 export default function TrainingPage() {
@@ -182,6 +193,9 @@ export default function TrainingPage() {
           agent_ids: selectedIds,
           use_0g_inference: use0gInference,
           use_0g_coaching: use0gCoaching,
+          // Auto-upload weights to 0G when any 0G backend is active so
+          // the iNFT's dataHashes[1] stays current after training.
+          upload_to_0g: use0gInference || use0gCoaching,
         }),
       });
       if (!r.ok) {
@@ -287,6 +301,8 @@ export default function TrainingPage() {
       </div>
 
       <StatusPanel status={statusQuery.data} />
+
+      <CheckpointsPanel status={statusQuery.data} />
 
       <TensorBoardPanel status={statusQuery.data} agentIds={selectedIds} />
     </main>
@@ -625,6 +641,62 @@ function formatBig(n: number): string {
   if (n >= 1_000_000) return `${n / 1_000_000}M`;
   if (n >= 1_000) return `${n / 1_000}k`;
   return String(n);
+}
+
+// CheckpointsPanel — shows per-agent checkpoint save/upload results
+// after the training run ends. Each entry shows the agent ID, the local
+// .pt path, and the 0G Storage Merkle root (root_hash) if uploaded. An
+// error field is shown instead when the upload failed (e.g. missing env
+// vars) but the local save may still have succeeded.
+function CheckpointsPanel({ status }: { status: StatusResponse | undefined }) {
+  const entries = status?.checkpoints;
+  if (!entries || entries.length === 0) return null;
+
+  return (
+    <section className="rounded-md border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-zinc-500">
+        Checkpoints
+      </h2>
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="border-b border-zinc-200 dark:border-zinc-800">
+            <th className="py-1 text-left font-mono uppercase text-zinc-500">Agent</th>
+            <th className="text-left font-mono uppercase text-zinc-500">0G root hash</th>
+            <th className="text-left font-mono uppercase text-zinc-500">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((ck, i) => (
+            <tr key={i} className="border-b border-zinc-100 dark:border-zinc-800">
+              <td className="py-1 font-mono">#{ck.agent_id}</td>
+              <td className="py-1 font-mono text-[10px] text-zinc-500 break-all">
+                {ck.root_hash ? (
+                  <span className="text-emerald-700 dark:text-emerald-400">
+                    {ck.root_hash.slice(0, 10)}…{ck.root_hash.slice(-8)}
+                  </span>
+                ) : ck.error ? (
+                  <span className="text-red-600 dark:text-red-400">upload failed</span>
+                ) : (
+                  <span className="text-zinc-400">local only</span>
+                )}
+              </td>
+              <td className="py-1 text-[10px]">
+                {ck.error ? (
+                  <span className="text-red-600 dark:text-red-400" title={ck.error}>
+                    ✗ {ck.error.slice(0, 60)}{ck.error.length > 60 ? "…" : ""}
+                  </span>
+                ) : ck.root_hash ? (
+                  <span className="text-emerald-700 dark:text-emerald-400">✓ saved to 0G</span>
+                ) : (
+                  <span className="text-zinc-500">✓ saved locally</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
 }
 
 // Phase L.3: TensorBoard panel — embeds the live tb dashboard so a

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1890,12 +1890,26 @@ class StartTrainingRequest(BaseModel):
     use_0g_coaching: bool = False
     extras_dim: int = 16
     seed: int = 42
+    # When True, save a checkpoint per agent at end of run and upload to
+    # 0G Storage. Auto-derived as True when any 0G backend is selected
+    # (inference or coaching), because the user has signalled 0G intent.
+    # Requires OG_STORAGE_{RPC,INDEXER,PRIVATE_KEY} env vars in the
+    # server process; upload failure surfaces as an agent_save_error
+    # event in /training/status rather than aborting the whole run.
+    upload_to_0g: bool = False
+    # Skip AES-256-GCM encryption — demo path so a server with no key
+    # file can fetch the checkpoint via load_profile. Leave False for
+    # production agents; the uploaded blob will be publicly readable.
+    no_encrypt: bool = False
 
 
 @app.post("/training/start")
 def post_training_start(req: StartTrainingRequest):
     """Spawn a round-robin training subprocess. 409 if one is already
     running. Returns `{job_id, started_at, epochs, agent_ids}`."""
+    # Auto-derive: if any 0G backend is selected, default to uploading
+    # trained weights to 0G so the iNFT's dataHashes stay current.
+    upload_to_0g = req.upload_to_0g or req.use_0g_inference or req.use_0g_coaching
     try:
         job = start_job(
             epochs=req.epochs,
@@ -1904,6 +1918,8 @@ def post_training_start(req: StartTrainingRequest):
             use_0g_coaching=req.use_0g_coaching,
             extras_dim=req.extras_dim,
             seed=req.seed,
+            upload_to_0g=upload_to_0g,
+            no_encrypt=req.no_encrypt,
         )
     except RuntimeError as e:
         # Already running.
@@ -1917,6 +1933,7 @@ def post_training_start(req: StartTrainingRequest):
         "agent_ids": job.agent_ids,
         "use_0g_inference": job.use_0g_inference,
         "use_0g_coaching": job.use_0g_coaching,
+        "upload_to_0g": job.upload_to_0g,
         "status_file": str(job.status_file_path),
     }
 

--- a/server/app/training_service.py
+++ b/server/app/training_service.py
@@ -74,6 +74,8 @@ class TrainingJob:
     log_path: Path
     use_0g_inference: bool
     use_0g_coaching: bool
+    upload_to_0g: bool = False
+    checkpoint_dir: Optional[Path] = None
     process: Optional[subprocess.Popen] = field(default=None, repr=False)
     # Phase L.2: TensorBoard sidecar — written when the trainer's
     # --logdir is set (the default for every job started via
@@ -167,6 +169,14 @@ def start_job(
     # the directory unique per run.
     tb_logdir = Path(tempfile.mkdtemp(prefix="chaingammon-training-tb-"))
 
+    # When 0G upload is requested and no explicit checkpoint dir is
+    # given, create a persistent temp dir so the trainer has somewhere
+    # to write the .pt files before uploading them to 0G Storage. The
+    # dir survives after the run so the key files (alongside .pt) are
+    # available for the next resume-from-0G cycle.
+    if upload_to_0g and checkpoint_dir is None:
+        checkpoint_dir = Path(tempfile.mkdtemp(prefix="chaingammon-training-ckpt-"))
+
     cmd = [
         sys.executable,
         str(_TRAINER),
@@ -220,6 +230,8 @@ def start_job(
         log_path=log_file,
         use_0g_inference=use_0g_inference,
         use_0g_coaching=use_0g_coaching,
+        upload_to_0g=upload_to_0g,
+        checkpoint_dir=checkpoint_dir,
         process=process,
         logdir=tb_logdir,
         tensorboard_pid=tb_proc.pid if tb_proc is not None else None,
@@ -378,6 +390,7 @@ def _empty_status() -> dict[str, Any]:
         "per_agent": {},
         "use_0g_inference": False,
         "use_0g_coaching": False,
+        "upload_to_0g": False,
         "ended": None,
         "last_update_ts": 0.0,
         # Phase L.2: TensorBoard sidecar metadata. Frontend reads these
@@ -386,6 +399,11 @@ def _empty_status() -> dict[str, Any]:
         # pointing at a dead URL.
         "tensorboard_url": None,
         "logdir": None,
+        # Per-agent checkpoint save/upload results. Each entry is
+        # {agent_id, path, root_hash, error} where root_hash is the
+        # 0G Storage Merkle root (None for local-only saves) and error
+        # is set when the upload failed but the local save succeeded.
+        "checkpoints": [],
     }
 
 
@@ -414,6 +432,7 @@ def _aggregate(events: list[dict], *, job: Optional[TrainingJob],
     last_epoch_completed = -1
     ended: Optional[str] = None
     last_ts = 0.0
+    checkpoints: list[dict] = []
 
     for e in events:
         kind = e.get("event")
@@ -431,6 +450,20 @@ def _aggregate(events: list[dict], *, job: Optional[TrainingJob],
             ended = "done"
         elif kind == "aborted":
             ended = "aborted"
+        elif kind == "agent_saved":
+            checkpoints.append({
+                "agent_id": int(e.get("agent_id", 0)),
+                "path": str(e.get("path", "")),
+                "root_hash": e.get("root_hash"),
+                "error": None,
+            })
+        elif kind == "agent_save_error":
+            checkpoints.append({
+                "agent_id": int(e.get("agent_id", 0)),
+                "path": None,
+                "root_hash": None,
+                "error": str(e.get("detail", "unknown error")),
+            })
 
     per_agent: dict[int, dict] = {}
     for m in matches:
@@ -451,6 +484,8 @@ def _aggregate(events: list[dict], *, job: Optional[TrainingJob],
             "last_update_ts": last_ts,
             "use_0g_inference": bool(job.use_0g_inference) if job else False,
             "use_0g_coaching": bool(job.use_0g_coaching) if job else False,
+            "upload_to_0g": bool(job.upload_to_0g) if job else False,
+            "checkpoints": checkpoints,
         }
 
     total_games = int(started.get("total_games", 0))
@@ -481,12 +516,16 @@ def _aggregate(events: list[dict], *, job: Optional[TrainingJob],
         },
         "use_0g_inference": bool(started.get("use_0g_inference", False)),
         "use_0g_coaching": bool(job.use_0g_coaching) if job else False,
+        "upload_to_0g": bool(job.upload_to_0g) if job else False,
         "ended": ended,
         "last_update_ts": last_ts,
         # Phase L.2: tensorboard sidecar — null when launch failed
         # (e.g. binary not on PATH) so the frontend can disclose state.
         "tensorboard_url": job.tensorboard_url if job else None,
         "logdir": str(job.logdir) if job and job.logdir else None,
+        # Per-agent checkpoint save/upload events. Populated by
+        # agent_saved and agent_save_error events from the trainer.
+        "checkpoints": checkpoints,
     }
 
 

--- a/server/tests/test_training_endpoints.py
+++ b/server/tests/test_training_endpoints.py
@@ -243,6 +243,50 @@ def test_start_422_too_few_agents(monkeypatch):
     assert r.status_code == 422
 
 
+def test_start_upload_to_0g_passes_checkpoint_flags(monkeypatch):
+    """When upload_to_0g=True is requested, the trainer subprocess
+    receives --checkpoint-dir and --upload-to-0g. The response also
+    surfaces upload_to_0g=True."""
+    _install_fake_popen(monkeypatch)
+    r = client.post("/training/start", json={
+        "epochs": 1, "agent_ids": [1, 2], "upload_to_0g": True,
+    })
+    assert r.status_code == 200, r.text
+    assert r.json()["upload_to_0g"] is True
+    trainer = next(i for i in _FakePopen.instances if not i.is_tensorboard)
+    assert "--checkpoint-dir" in trainer.cmd
+    assert "--upload-to-0g" in trainer.cmd
+
+
+def test_start_use_0g_inference_auto_derives_upload(monkeypatch):
+    """When use_0g_inference=True is set (but upload_to_0g not explicitly
+    sent), the endpoint auto-derives upload_to_0g=True so trained weights
+    are persisted to 0G after the run."""
+    _install_fake_popen(monkeypatch)
+    r = client.post("/training/start", json={
+        "epochs": 1, "agent_ids": [1, 2], "use_0g_inference": True,
+    })
+    assert r.status_code == 200, r.text
+    assert r.json()["upload_to_0g"] is True
+    trainer = next(i for i in _FakePopen.instances if not i.is_tensorboard)
+    assert "--checkpoint-dir" in trainer.cmd
+    assert "--upload-to-0g" in trainer.cmd
+
+
+def test_start_local_only_no_checkpoint_flags(monkeypatch):
+    """When all backends are local and upload_to_0g is False (the default),
+    --checkpoint-dir and --upload-to-0g are NOT passed to the trainer."""
+    _install_fake_popen(monkeypatch)
+    r = client.post("/training/start", json={
+        "epochs": 1, "agent_ids": [1, 2],
+        "use_0g_inference": False, "use_0g_coaching": False,
+    })
+    assert r.status_code == 200, r.text
+    assert r.json()["upload_to_0g"] is False
+    trainer = next(i for i in _FakePopen.instances if not i.is_tensorboard)
+    assert "--upload-to-0g" not in trainer.cmd
+
+
 # ─── /training/status ───────────────────────────────────────────────────────
 
 
@@ -288,6 +332,50 @@ def test_status_done_event_marks_ended(monkeypatch):
     body = r.json()
     assert body["running"] is False
     assert body["ended"] == "done"
+
+
+def test_status_agent_saved_surfaced_in_checkpoints(monkeypatch):
+    """agent_saved events emitted by the trainer appear in the
+    checkpoints list with agent_id, path, and root_hash."""
+    _install_fake_popen(monkeypatch)
+    client.post("/training/start", json={"epochs": 1, "agent_ids": [1, 2]})
+    fake = next(i for i in reversed(_FakePopen.instances) if not i.is_tensorboard)
+    fake.emit_match(epoch=0, agent_a=1, agent_b=2, winner=1)
+    fake._emit("agent_saved", agent_id=1, path="/tmp/ckpt/agent-1.pt",
+               root_hash="0x" + "aa" * 32)
+    fake._emit("agent_saved", agent_id=2, path="/tmp/ckpt/agent-2.pt",
+               root_hash="0x" + "bb" * 32)
+    fake.emit_done()
+
+    r = client.get("/training/status")
+    body = r.json()
+    ckpts = body["checkpoints"]
+    assert len(ckpts) == 2
+    assert ckpts[0]["agent_id"] == 1
+    assert ckpts[0]["root_hash"] == "0x" + "aa" * 32
+    assert ckpts[0]["error"] is None
+    assert ckpts[1]["agent_id"] == 2
+    assert ckpts[1]["root_hash"] == "0x" + "bb" * 32
+
+
+def test_status_agent_save_error_surfaces_in_checkpoints(monkeypatch):
+    """agent_save_error events (upload failed, e.g. missing env vars)
+    appear in the checkpoints list with the error string."""
+    _install_fake_popen(monkeypatch)
+    client.post("/training/start", json={"epochs": 1, "agent_ids": [1, 2]})
+    fake = next(i for i in reversed(_FakePopen.instances) if not i.is_tensorboard)
+    fake.emit_match(epoch=0, agent_a=1, agent_b=2, winner=1)
+    fake._emit("agent_save_error", agent_id=1,
+               detail="Missing env vars for 0G Storage upload: ['OG_STORAGE_RPC']")
+    fake.emit_done()
+
+    r = client.get("/training/status")
+    body = r.json()
+    ckpts = body["checkpoints"]
+    assert len(ckpts) == 1
+    assert ckpts[0]["agent_id"] == 1
+    assert ckpts[0]["root_hash"] is None
+    assert "OG_STORAGE_RPC" in ckpts[0]["error"]
 
 
 def test_status_dead_process_no_done_marks_aborted(monkeypatch):


### PR DESCRIPTION
Fixes #71

The `/training/start` endpoint never passed `--checkpoint-dir` or `--upload-to-0g` to the trainer subprocess, so trained weights were always discarded. This PR wires the full pipeline: auto-creates a checkpoint dir, enables 0G upload when any 0G backend is active, surfaces upload results in the training status response, and adds graceful error handling so upload failures don't crash the trainer.

Generated with [Claude Code](https://claude.ai/code)