### PR TITLE
Phase 80: Migrate game engine from gnubg to ONNX BackgammonNet

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,12 +36,13 @@ Sponsor mix per ETHGlobal Open Agents (the three Chaingammon targets): **0G** (S
                                     │ HTTP fetch (no central server)
         ┌───────────────────────────┼────────────────────────────┐
         ▼                           ▼                            ▼
- ┌───────────────┐       ┌───────────────────┐         ┌───────────────────┐
- │ Browser-side  │       │  0G Compute       │         │ Local agent       │
- │ value-net     │       │  TEE-attested     │         │ process (dev):    │
- │ forward pass  │       │  coach LLM +      │         │ gnubg :8001       │
- │ (per-agent NN)│       │  offline NN       │         │                   │
- └───────────────┘       └───────────────────┘         └───────────────────┘
+ ┌───────────────┐       ┌───────────────────┐
+ │ Browser-side  │       │  0G Compute       │
+ │ value-net     │       │  TEE-attested     │
+ │ forward pass  │       │  coach LLM +      │
+ │ (per-agent NN)│       │  offline NN       │
+ │ ONNX Runtime  │       │                   │
+ └───────────────┘       └───────────────────┘
                                     │
                                     │ KeeperHub workflow
                                     ▼
@@ -64,7 +65,7 @@ Sponsor mix per ETHGlobal Open Agents (the three Chaingammon targets): **0G** (S
 
 - Player connects wallet → frontend resolves their `<name>.chaingammon.eth` on Sepolia (issues new subname if missing).
 - Player picks an agent → frontend reads agent iNFT data hashes → fetches encrypted weights from 0G Storage, decrypts, runs inference (browser by default; 0G Compute for offline play).
-- Each turn → KeeperHub pulls a drand round; dice = `keccak256(drand_round_digest, turn_index) mod 36` → active side runs a value-net forward pass → records move.
+- Each turn → KeeperHub pulls a drand round; dice = `keccak256(drand_round_digest, turn_index) mod 36` → active side runs a BackgammonNet ONNX forward pass in the browser → records move.
 - Game over → frontend serializes the full game record to 0G Storage Log → triggers KeeperHub workflow with the resulting hash.
 - Workflow runs: validate moves via WASM rules engine → `MatchRegistry.settleWithSessionKeys(...)` on Sepolia → ENS text records updated (`elo`, `last_match_id`, `style_uri`, `archive_uri`) → audit JSON mirrored to 0G Storage.
 - Frontend match-details page reads game record + audit from 0G Storage and renders both.
@@ -106,20 +107,14 @@ Or run sub-project commands directly from within each directory:
 ### agent/ (Python 3.12, uv)
 
 ```bash
-# Start gnubg agent node (port 8001)
-uv run uvicorn gnubg_service:app --port 8001
-
-# Start it via the helper script (recommended)
-bash start.sh
-
-# Run all tests (includes sample_trainer + agent_profile + service tests)
+# Run all tests (includes sample_trainer + agent_profile tests)
 uv run pytest
 
 # Run the sample value-network trainer (TD(λ) self-play with TensorBoard)
 uv run python sample_trainer.py --matches 200 --launch-tensorboard
 
-# Run a single test file
-uv run pytest tests/test_gnubg_service.py -v
+# Export the trained BackgammonNet to ONNX (places backgammon_net.onnx in frontend/public/)
+uv run python sample_trainer.py --export-onnx
 
 # Add a dependency
 uv add <package>
@@ -162,9 +157,10 @@ See `## Frontend Policies` below for the three rules every frontend change must 
 | `log.md` | Frozen archive of Phases 0–33 (no longer maintained) |
 | `CHANGELOG.md` | Keep-a-Changelog summary; the active per-release record |
 | `MISSION.md` | Product vision and principles |
-| `agent/gnubg_service.py` | Local FastAPI service (port 8001): gnubg move evaluation via External Player interface |
+| `agent/gnubg_service.py` | Legacy gnubg FastAPI service — no longer used. Game engine now runs client-side via ONNX (see `frontend/lib/match_engine.ts`). |
 | `agent/coach_service.py` | Legacy Python coaching service — no longer started locally. The active coach LLM runs on 0G Compute, called from `frontend/app/api/coach/hint/route.ts`. |
-| `agent/start.sh` | Start script: launches the gnubg FastAPI service (coach now runs on 0G Compute) |
+| `frontend/lib/match_engine.ts` | Client-side game engine: replaces gnubg_service. Uses rules_engine.ts (legality) + onnx_eval.ts (BackgammonNet inference). |
+| `frontend/lib/move_tagger.ts` | Heuristic strategy labels (Safe/Aggressive/Priming/Anchor/Blitz). TypeScript port of agent/move_tagger.py. |
 | `scripts/upload_gnubg_docs.py` | One-time script: upload gnubg strategy docs to 0G Storage for coach RAG |
 | `contracts/src/PlayerSubnameRegistrar.sol` | ENS-shaped subname registrar. Issues `<label>.chaingammon.eth` subnames with text records (`elo`, `match_count`, `last_match_id`, `style_uri`, `archive_uri`). |
 | `contracts/src/EloMath.sol` | Fixed-point ELO formula — test extensively |
@@ -207,16 +203,12 @@ Required envs by phase:
 **ENS:** Subnames issued under `chaingammon.eth`. Schema for text records: `elo`, `match_count`, `last_match_id`, `style_uri` (`0g://...`), `archive_uri` (`0g://...`). Frontend resolves subnames to display human-readable names everywhere addresses would otherwise appear.
 
 **0G Storage usage:**
-- Log per match → game record (gnubg `.mat` wrapped in JSON envelope)
+- Log per match → game record (JSON envelope with move history)
 - Log per match → KeeperHub audit JSON
 - KV per player → style profile (% openings, cube tendency, bear-off speed)
-- Blob per agent → encrypted gnubg weights, hash committed to iNFT
+- Blob per agent → encrypted BackgammonNet ONNX weights, hash committed to iNFT
 
 **KeeperHub:** Settlement workflow (`recordMatch` → ENS text records → on-chain hash commit → audit). Server triggers via HTTP POST. Audit pulled via `kh run status --json` and mirrored to 0G Storage so it's publicly viewable through our app.
-
-## gnubg External Player Protocol
-
-gnubg is driven via its socket-based External Player interface. Install with `sudo apt install gnubg`. `gnubg_client.py` manages the subprocess; do not bypass it.
 
 ## Commit Messages
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -5,11 +5,6 @@
 # (MetaMask Mobile, Rainbow, etc.) can connect by scanning a QR code or deeplink.
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
 
-# Local gnubg agent process URL (the gnubg_service FastAPI from agent/).
-# Used by the match flow page (frontend/app/match/page.tsx) for
-# /new, /apply, /move, /resign, /evaluate. Defaults to localhost:8001 if unset.
-NEXT_PUBLIC_GNUBG_URL=http://localhost:8001
-
 # Coach LLM now runs on 0G Compute, called from the Next.js Route Handler
 # at frontend/app/api/coach/hint/route.ts — no local coach process and no
 # NEXT_PUBLIC_COACH_URL needed.
@@ -22,9 +17,8 @@ NEXT_PUBLIC_GNUBG_URL=http://localhost:8001
 # runs on a different host than the backend services.
 NEXT_PUBLIC_SERVER_URL=http://localhost:8000
 
-# 0G Storage root hash of the gnubg strategy docs blob (uploaded once
-# by scripts/upload_gnubg_docs.py). Passed to /hint as RAG context.
-# Leave unset to fall back to the built-in backgammon summary.
+# 0G Storage root hash of the strategy docs blob (uploaded once to 0G Storage).
+# Passed to /hint as RAG context. Leave unset to fall back to the built-in summary.
 NEXT_PUBLIC_GNUBG_DOCS_HASH=
 
 # Optional RPC override for 0G testnet (use a self-hosted RPC if you

--- a/frontend/app/AgentTeammatePanel.tsx
+++ b/frontend/app/AgentTeammatePanel.tsx
@@ -1,30 +1,27 @@
 // AgentTeammatePanel.tsx — Phase 76: DeepMind-inspired Agent Teammate UI.
 //
-// Dynamic chat panel beneath the game board where the LLM acts as a
+// Dynamic chat panel beneath the game board where the LLM acts as an
 // "Agent Teammate" that negotiates move trade-offs with the human in
 // real-time. The human dictates macro-strategy; the AI selects the specific
 // tagged move that best fits it.
 //
-// Layout:
-//   1. Tagged candidates row (top-5 with colour-coded strategy tags)
-//   2. LLM recommendation bubble (highlights the selected move)
-//   3. Deep-dive badge (shown when the LLM ran a mocked historical search)
-//   4. Human strategy input + Send button
-//   5. Conversation history (last 8 messages)
+// Move evaluation runs fully client-side via the ONNX BackgammonNet
+// (onnx_eval.ts) + heuristic move tagger (move_tagger.ts). No gnubg
+// subprocess or network call to port 8001 required.
 //
 // Props:
 //   positionId, matchId, dice  — current board state (feed from match state)
-//   board                      — board array for more accurate hit detection
+//   board, bar, off            — full board state for ONNX evaluation
+//   turn                       — who is on roll (0 = human, 1 = agent)
 //   agentId                    — used to surface opponent features
 //   onMoveSelect               — called with the LLM-recommended move string
-//                                so the match page can pre-fill the move input
 //   disabled                   — true when it's the agent's turn or game over
 
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-
-const GNUBG = process.env.NEXT_PUBLIC_GNUBG_URL ?? "http://localhost:8001";
+import { evaluateMoves } from "../../lib/onnx_eval";
+import { tagCandidates } from "../../lib/move_tagger";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -54,6 +51,9 @@ interface Props {
   matchId: string;
   dice: [number, number] | null;
   board?: number[];
+  bar?: [number, number];
+  off?: [number, number];
+  turn?: 0 | 1;
   agentId?: number;
   onMoveSelect?: (move: string) => void;
   disabled?: boolean;
@@ -107,6 +107,9 @@ export function AgentTeammatePanel({
   matchId,
   dice,
   board,
+  bar,
+  off,
+  turn = 0,
   agentId,
   onMoveSelect,
   disabled = false,
@@ -124,41 +127,37 @@ export function AgentTeammatePanel({
   const inputRef = useRef<HTMLInputElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
 
-  // ── Step 1: Fetch tagged candidates whenever dice change ──────────────
+  // ── Step 1: Evaluate candidates with ONNX BackgammonNet ──────────────
 
   useEffect(() => {
-    if (!dice || !positionId || !matchId) return;
+    if (disabled || !dice || !board) return;
     setTaggedCandidates([]);
     setLastResponse(null);
     setLoadingCandidates(true);
 
-    const controller = new AbortController();
+    let cancelled = false;
     void (async () => {
       try {
-        const res = await fetch(`${GNUBG}/evaluate-tagged`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            position_id: positionId,
-            match_id: matchId,
-            dice,
-            board: board ?? null,
-            top_n: 5,
-          }),
-          signal: controller.signal,
-        });
-        if (!res.ok) return;
-        const data = (await res.json()) as { tagged_candidates: TaggedCandidate[] };
-        setTaggedCandidates(data.tagged_candidates ?? []);
+        const gameBoard = {
+          points: board,
+          bar: bar ?? ([0, 0] as [number, number]),
+          off: off ?? ([0, 0] as [number, number]),
+        };
+        const candidates = await evaluateMoves(gameBoard, turn, dice);
+        if (cancelled) return;
+        const tagged = tagCandidates(candidates, board, 5) as TaggedCandidate[];
+        setTaggedCandidates(tagged);
       } catch {
-        // gnubg offline — panel shows nothing but doesn't block the game.
+        // ONNX model unavailable — panel shows nothing but doesn't block the game.
       } finally {
-        setLoadingCandidates(false);
+        if (!cancelled) setLoadingCandidates(false);
       }
     })();
-    return () => controller.abort();
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [positionId, matchId, dice?.[0], dice?.[1]]);
+  }, [disabled, positionId, matchId, dice?.[0], dice?.[1]]);
 
   // Scroll to latest message whenever dialogue grows.
   useEffect(() => {

--- a/frontend/app/ChiefOfStaffPanel.tsx
+++ b/frontend/app/ChiefOfStaffPanel.tsx
@@ -5,26 +5,23 @@
 // real-time. The human dictates macro-strategy; the AI selects the specific
 // tagged move that best fits it.
 //
-// Layout:
-//   1. Tagged candidates row (top-5 with colour-coded strategy tags)
-//   2. LLM recommendation bubble (highlights the selected move)
-//   3. Deep-dive badge (shown when the LLM ran a mocked historical search)
-//   4. Human strategy input + Send button
-//   5. Conversation history (last 8 messages)
+// Move evaluation runs fully client-side via the ONNX BackgammonNet
+// (onnx_eval.ts) + heuristic move tagger (move_tagger.ts). No gnubg
+// subprocess or network call to port 8001 required.
 //
 // Props:
 //   positionId, matchId, dice  — current board state (feed from match state)
-//   board                      — board array for more accurate hit detection
-//   agentId                    — used to surface opponent features
+//   board, bar, off            — full board state for ONNX evaluation
+//   turn                       — who is on roll (0 = human, 1 = agent)
+//   opponentId                 — used to surface opponent features
 //   onMoveSelect               — called with the LLM-recommended move string
-//                                so the match page can pre-fill the move input
 //   disabled                   — true when it's the agent's turn or game over
 
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-
-const GNUBG = process.env.NEXT_PUBLIC_GNUBG_URL ?? "http://localhost:8001";
+import { evaluateMoves } from "../../lib/onnx_eval";
+import { tagCandidates } from "../../lib/move_tagger";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -54,6 +51,9 @@ interface Props {
   matchId: string;
   dice: [number, number] | null;
   board?: number[];
+  bar?: [number, number];
+  off?: [number, number];
+  turn?: 0 | 1;
   opponentId?: number;
   onMoveSelect?: (move: string) => void;
   disabled?: boolean;
@@ -107,6 +107,9 @@ export function ChiefOfStaffPanel({
   matchId,
   dice,
   board,
+  bar,
+  off,
+  turn = 0,
   opponentId,
   onMoveSelect,
   disabled = false,
@@ -124,41 +127,37 @@ export function ChiefOfStaffPanel({
   const inputRef = useRef<HTMLInputElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
 
-  // ── Step 1: Fetch tagged candidates whenever dice change ──────────────
+  // ── Step 1: Evaluate candidates with ONNX BackgammonNet ──────────────
 
   useEffect(() => {
-    if (!dice || !positionId || !matchId) return;
+    if (disabled || !dice || !board) return;
     setTaggedCandidates([]);
     setLastResponse(null);
     setLoadingCandidates(true);
 
-    const controller = new AbortController();
+    let cancelled = false;
     void (async () => {
       try {
-        const res = await fetch(`${GNUBG}/evaluate-tagged`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            position_id: positionId,
-            match_id: matchId,
-            dice,
-            board: board ?? null,
-            top_n: 5,
-          }),
-          signal: controller.signal,
-        });
-        if (!res.ok) return;
-        const data = (await res.json()) as { tagged_candidates: TaggedCandidate[] };
-        setTaggedCandidates(data.tagged_candidates ?? []);
+        const gameBoard = {
+          points: board,
+          bar: bar ?? ([0, 0] as [number, number]),
+          off: off ?? ([0, 0] as [number, number]),
+        };
+        const candidates = await evaluateMoves(gameBoard, turn, dice);
+        if (cancelled) return;
+        const tagged = tagCandidates(candidates, board, 5) as TaggedCandidate[];
+        setTaggedCandidates(tagged);
       } catch {
-        // gnubg offline — panel shows nothing but doesn't block the game.
+        // ONNX model unavailable — panel shows nothing but doesn't block the game.
       } finally {
-        setLoadingCandidates(false);
+        if (!cancelled) setLoadingCandidates(false);
       }
     })();
-    return () => controller.abort();
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [positionId, matchId, dice?.[0], dice?.[1]]);
+  }, [disabled, positionId, matchId, dice?.[0], dice?.[1]]);
 
   // Scroll to latest message whenever dialogue grows.
   useEffect(() => {

--- a/frontend/app/log/[matchId]/LogClient.tsx
+++ b/frontend/app/log/[matchId]/LogClient.tsx
@@ -25,7 +25,7 @@ import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 
-// FastAPI server URL — distinct from the local gnubg service (port 8001).
+// FastAPI server URL for KeeperHub / settlement operations.
 const SERVER = process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:8000";
 
 // Sentinel value written to the URL when no match is active in localStorage.

--- a/frontend/app/match/page.tsx
+++ b/frontend/app/match/page.tsx
@@ -1,44 +1,37 @@
-// Phase 26: match flow over the local gnubg agent process (HTTP on localhost:8001).
-// Phase 31: drag-and-drop checker movement with optimistic board display and undo.
+// match/page.tsx — browser-owned backgammon match flow.
 //
 // URL: /match?agentId=<N>
 //
-// State machine (browser-owned game state — no central server):
-//   on mount         → POST /new {match_length} → opening MatchState
+// All game logic runs client-side via the match engine:
+//   on mount         → newMatch(3) → opening MatchState
 //                       → roll dice client-side for whichever side starts
 //   if turn === 0    → render board + dice + move input, wait for human
-//   human submits    → POST /apply {position_id, match_id, dice, move}
-//                       on 200 → replace state, roll next side's dice
-//                       on 422 → surface error, leave state unchanged
+//   human submits    → applyMoveToState(state, move)
+//                       on success → replace state, roll next side's dice
+//                       on error   → surface error, leave state unchanged
 //   agent loop (turn === 1)
-//                    → POST /move → best move
-//                    → POST /apply with that move
+//                    → getBestMove(board, 1, dice) via ONNX BackgammonNet
+//                    → applyMoveToState with that move
 //                    → replace state, roll next side's dice
-//   forfeit          → POST /resign → game_over response
+//   forfeit          → resignMatch(state) → game_over response
 //
-// Phase 31 additions:
+// Phase 31: drag-and-drop checker movement with optimistic board display and undo.
 //   stagedMoves      — array of "from/to" segments the human has clicked/dragged
-//   displayBoardState — optimistic board/bar/off after applying staged moves locally;
-//                       null when no moves staged (falls back to game.board)
+//   displayBoardState — optimistic board/bar/off after applying staged moves locally
 //   stageMove        — appends a segment, applies it to displayBoardState, and
 //                       auto-submits via doMoveWithNotation when all dice are used
 //   Undo button      — clears staged moves and resets display to start-of-turn
-//   Drag events      — onDragStart/onDrop forwarded to Board so users can drag
-//                       checkers in addition to clicking source then destination
-//   Text input + Move button still present for backward compatibility with tests
-//   and power users who prefer notation.
+//   Drag events      — onDragStart/onDrop forwarded to Board
+//   Text input + Move button still present for power users who prefer notation.
 //
 // After each move a non-blocking coach hint is requested (skipped during
 // fast-forward since the human is not choosing moves):
-//   → POST /evaluate       (gnubg_service)        → ranked candidates
+//   → evaluateCandidates(board, side, dice) via ONNX
 //   → POST /api/coach/hint (Next.js Route Handler → 0G Compute / Qwen 2.5 7B)
-//                                                 → plain-English hint
 // Coach calls are best-effort — any failure is silently swallowed so
 // the game continues regardless of 0G Compute availability.
 //
-// Move notation is gnubg's standard: "8/5 6/5" (from-point/to-point,
-// space-separated for multiple checker movements). See
-// agent/gnubg_service.py or the agent test suite for examples.
+// Move notation: "8/5 6/5" (from-point/to-point, space-separated).
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
@@ -65,26 +58,21 @@ import { useActiveChain } from "../chains";
 import { useComputeBackends } from "../ComputeBackendsContext";
 import { MatchEscrowABI, MatchRegistryABI, useChainContracts } from "../contracts";
 import { useChaingammonName } from "../useChaingammonName";
-
-// ── Types matching agent/gnubg_state.py:MatchStateDict ────────────────────
-
-interface MatchState {
-  position_id: string;
-  match_id: string;
-  board: number[];
-  bar: [number, number];
-  off: [number, number];
-  turn: 0 | 1;
-  dice: [number, number] | null;
-  score: [number, number];
-  match_length: number;
-  game_over: boolean;
-  winner: 0 | 1 | null;
-}
+import {
+  type MatchState,
+  newMatch,
+  applyMoveToState,
+  getBestMove,
+  evaluateCandidates,
+  skipTurn,
+  resignMatch,
+  playMatchToEnd,
+  hasLegalMoves,
+} from "../../lib/match_engine";
+import { type Board as GameBoard } from "../../lib/rules_engine";
 
 // ── API helpers ───────────────────────────────────────────────────────────
 
-const GNUBG = process.env.NEXT_PUBLIC_GNUBG_URL ?? "http://localhost:8001";
 const SERVER = process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:8000";
 
 const ZERO_ADDR = "0x0000000000000000000000000000000000000000" as `0x${string}`;
@@ -104,30 +92,6 @@ function safeParseEther(value: string): bigint {
   }
 }
 
-/**
- * POST helper for gnubg_service. All endpoints use POST with a JSON
- * body. 422 responses surface as Error with the `detail` string so
- * the page can render gnubg's complaint to the user.
- */
-async function gnubgPost<T>(path: string, body: unknown): Promise<T> {
-  const res = await fetch(`${GNUBG}${path}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body ?? {}),
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => res.statusText);
-    let detail = text;
-    try {
-      const parsed = JSON.parse(text);
-      if (parsed && typeof parsed.detail === "string") detail = parsed.detail;
-    } catch {
-      // text wasn't JSON — keep raw.
-    }
-    throw new Error(`${res.status}: ${detail}`);
-  }
-  return (await res.json()) as T;
-}
 
 // Coach backend choices the user can pick in the toggle. "compute" is the
 // paid 0G Compute path (Qwen 2.5 7B Instruct via @0glabs/0g-serving-broker);
@@ -153,27 +117,25 @@ interface HintResult {
  * state only if still mounted.
  */
 async function fetchHint(
-  positionId: string,
-  matchId: string,
-  dice: [number, number],
+  state: MatchState,
   docsHash: string,
   backend: CoachBackend,
 ): Promise<HintResult | null> {
   try {
-    // Step 1: get ranked candidates from gnubg_service.
-    const { candidates } = await gnubgPost<{
-      candidates: { move: string; equity: number }[];
-    }>("/evaluate", { position_id: positionId, match_id: matchId, dice });
+    if (!state.dice) return null;
+    // Step 1: evaluate candidates with ONNX BackgammonNet.
+    const board: GameBoard = { points: state.board, bar: state.bar, off: state.off };
+    const candidates = await evaluateCandidates(board, state.turn, state.dice);
     if (!candidates || candidates.length === 0) return null;
 
-    // Step 2: ask the local Next.js Route Handler to narrate the top move.
+    // Step 2: ask the Next.js Route Handler to narrate the top move.
     const res = await fetch("/api/coach/hint", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        position_id: positionId,
-        match_id: matchId,
-        dice,
+        position_id: state.position_id,
+        match_id: state.match_id,
+        dice: state.dice,
         candidates,
         docs_hash: docsHash,
         backend,
@@ -410,7 +372,7 @@ function MatchInner() {
   // React re-renders while an agent step is mid-flight.
   const agentMoving = useRef(false);
 
-  // Whether the human has handed off to the gnubg agent to finish the game.
+  // Whether the human has handed off the ONNX engine to finish the game.
   const [fastForward, setFastForward] = useState(false);
 
   // KeeperHub mode: game hasn't started yet (show "Start Game" card first).
@@ -485,9 +447,7 @@ function MatchInner() {
     setCoachServedBy(null);
     setCoachLoading(true);
     fetchHint(
-      state.position_id,
-      state.match_id,
-      state.dice,
+      state,
       docsHash,
       coachBackendRef.current,
     )
@@ -516,25 +476,18 @@ function MatchInner() {
   // immediately (gameStarted initialises to true when agentId === 0).
   useEffect(() => {
     if (!gameStarted) return;
-    let cancelled = false;
     setLoading(true);
     setError(null);
-    gnubgPost<MatchState>("/new", { match_length: 3 })
-      .then((state) => {
-        if (cancelled) return;
-        const withDice = withFreshDice(state);
-        setGame(withDice);
-        requestCoachHint(withDice);
-      })
-      .catch((e: unknown) => {
-        if (!cancelled) setError(String(e));
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
+    try {
+      const state = newMatch(3);
+      const withDice = withFreshDice(state);
+      setGame(withDice);
+      requestCoachHint(withDice);
+    } catch (e: unknown) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gameStarted]);
 
@@ -550,38 +503,18 @@ function MatchInner() {
 
     const step = async () => {
       try {
-        const { move: best } = await gnubgPost<{ move: string | null }>(
-          "/move",
-          {
-            position_id: game.position_id,
-            match_id: game.match_id,
-            dice: game.dice,
-          },
-        );
+        const board: GameBoard = { points: game.board, bar: game.bar, off: game.off };
+        const best = await getBestMove(board, 1, game.dice!);
         if (!best) {
-          // No legal moves — typically a bar dance (checker on the bar,
-          // opponent's home board closed). Pass the turn via gnubg
-          // (board unchanged, match_id flipped to the other side) and
-          // roll dice for the new side. requestCoachHint is skipped
-          // because the side that lost the turn didn't actually choose
-          // a move worth narrating.
-          const skipped = await gnubgPost<MatchState>("/skip", {
-            position_id: game.position_id,
-            match_id: game.match_id,
-            current_turn: game.turn,
-          });
+          // No legal moves — bar dance. Skip turn and roll for the new side.
+          const skipped = skipTurn(game);
           const skippedWithDice = skipped.game_over
             ? skipped
             : withFreshDice(skipped);
           setGame(skippedWithDice);
           return;
         }
-        const next = await gnubgPost<MatchState>("/apply", {
-          position_id: game.position_id,
-          match_id: game.match_id,
-          dice: game.dice,
-          move: best,
-        });
+        const next = applyMoveToState(game, best);
         const nextWithDice = next.game_over ? next : withFreshDice(next);
         setGame(nextWithDice);
         requestCoachHint(nextWithDice);
@@ -598,14 +531,10 @@ function MatchInner() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [game, fastForward]);
 
-  // ── Fast-forward (server-side) ────────────────────────────────────────────
-  // Single round-trip: gnubg auto-plays both seats inside one subprocess at
-  // 0-ply evaluation and returns the final match state. The previous client-
-  // side per-turn loop spawned a fresh gnubg subprocess for every /move and
-  // /apply (tens of seconds for a typical match); /play_to_end collapses
-  // that to one call that completes in well under a second. Trade-off: dice
-  // come from gnubg's PRNG instead of the browser's crypto.getRandomValues.
-  // That's acceptable — fast-forward is a UX shortcut, not the rated path.
+  // ── Fast-forward (client-side ONNX) ─────────────────────────────────────
+  // Runs the full remaining match in the browser via playMatchToEnd, which
+  // uses the ONNX BackgammonNet to pick moves for both sides. Dice come from
+  // Math.random — acceptable since fast-forward is a UX shortcut, not rated.
   useEffect(() => {
     if (!fastForward || !game || game.game_over) return;
     if (agentMoving.current) return;
@@ -615,10 +544,7 @@ function MatchInner() {
 
     void (async () => {
       try {
-        const final = await gnubgPost<MatchState>("/play_to_end", {
-          position_id: game.position_id,
-          match_id: game.match_id,
-        });
+        const final = await playMatchToEnd(game);
         if (!cancelled) setGame(final);
       } catch (e: unknown) {
         if (!cancelled) setError(String(e));
@@ -635,42 +561,19 @@ function MatchInner() {
 
   // ── Auto-skip the human's turn when they have no legal moves ──────────────
   // Symmetric counterpart to the agent loop above. Runs only on the human's
-  // turn outside fast-forward (fast-forward already routes through the agent
-  // loop). Calls /evaluate to detect a bar dance; when the candidate list is
-  // empty, /skip flips the turn and a fresh roll is seeded for the new side.
+  // turn outside fast-forward. Uses hasLegalMoves from the rules engine to
+  // detect bar-dance; when no moves exist, skipTurn flips the turn.
   useEffect(() => {
     if (!game || game.game_over) return;
     if (game.turn !== 0 || fastForward) return;
     if (!game.dice) return;
     if (agentMoving.current) return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const { candidates } = await gnubgPost<{
-          candidates: { move: string; equity: number }[];
-        }>("/evaluate", {
-          position_id: game.position_id,
-          match_id: game.match_id,
-          dice: game.dice,
-        });
-        if (cancelled || candidates.length > 0) return;
-        const skipped = await gnubgPost<MatchState>("/skip", {
-          position_id: game.position_id,
-          match_id: game.match_id,
-          current_turn: 0,
-        });
-        if (cancelled) return;
-        const skippedWithDice = skipped.game_over
-          ? skipped
-          : withFreshDice(skipped);
-        setGame(skippedWithDice);
-      } catch {
-        // gnubg offline — silently no-op so the human can still use /resign.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
+    const board: GameBoard = { points: game.board, bar: game.bar, off: game.off };
+    if (!hasLegalMoves(board, 0, game.dice)) {
+      const skipped = skipTurn(game);
+      const skippedWithDice = skipped.game_over ? skipped : withFreshDice(skipped);
+      setGame(skippedWithDice);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [game, fastForward]);
 
@@ -687,9 +590,9 @@ function MatchInner() {
   }, [game?.turn]);
 
   /**
-   * Submit a move notation string to /apply. Shared by the manual Move
-   * button (text input) and the auto-submit path (click/drag staging).
-   * Clears all staged state on success or error.
+   * Apply a move notation string via the client-side engine. Shared by the
+   * manual Move button (text input) and the auto-submit path (click/drag
+   * staging). Clears all staged state on success or error.
    */
   const doMoveWithNotation = async (notation: string) => {
     if (!game || !game.dice) return;
@@ -697,12 +600,7 @@ function MatchInner() {
     setError(null);
     setSelectedSource(null);
     try {
-      const next = await gnubgPost<MatchState>("/apply", {
-        position_id: game.position_id,
-        match_id: game.match_id,
-        dice: game.dice,
-        move: notation,
-      });
+      const next = applyMoveToState(game, notation);
       const nextWithDice = next.game_over ? next : withFreshDice(next);
       setGame(nextWithDice);
       setStagedMoves([]);
@@ -826,10 +724,7 @@ function MatchInner() {
     setLoading(true);
     setError(null);
     try {
-      const next = await gnubgPost<MatchState>("/resign", {
-        position_id: game.position_id,
-        match_id: game.match_id,
-      });
+      const next = resignMatch(game);
       setGame(next);
     } catch (e: unknown) {
       setError(String(e));
@@ -1137,7 +1032,7 @@ function MatchInner() {
             </p>
             <ul className="mt-3 space-y-1 text-xs text-emerald-700 dark:text-emerald-400">
               <li>✓ drand dice — publicly verifiable randomness each turn</li>
-              <li>✓ gnubg move validation — every move audited on-chain</li>
+              <li>✓ ONNX move validation — every move audited on-chain</li>
               <li>
                 ✓ automatic ELO settlement — no manual "Settle on-chain" click
               </li>
@@ -1227,10 +1122,6 @@ function MatchInner() {
         <p className="text-red-600 dark:text-red-400">
           Could not start game: {error}
         </p>
-        <p className="text-sm text-zinc-500 dark:text-zinc-400">
-          Make sure the local gnubg agent process is running at{" "}
-          <code className="font-mono">{GNUBG}</code>.
-        </p>
         <Link
           href="/"
           className="text-sm text-indigo-600 underline dark:text-indigo-400"
@@ -1254,7 +1145,7 @@ function MatchInner() {
     selectedSource !== null;
 
   // Show Apply button when moves are staged but not all dice are used (player
-  // can't use remaining dice — let them submit a partial move for gnubg to validate).
+  // can't use remaining dice — let them submit a partial move for the rules engine to validate).
   const canApplyPartial =
     stagedMoves.length > 0 && diceCount > 0 && stagedMoves.length < diceCount;
 
@@ -1277,11 +1168,8 @@ function MatchInner() {
 
       {/* Main */}
       <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-6 px-3 py-6 sm:px-8 sm:py-8">
-        {/* Phase F: inference-backend chip. Mirrors the global Compute
-            pill so the user can see at a glance which backend the
-            agent's per-move equity calls run on. Currently decorative
-            — /agent-move uses gnubg, not the per-agent NN. Phase G
-            wires the flag through to og_compute_eval_client.evaluate. */}
+        {/* Inference-backend chip. Mirrors the global Compute pill so the
+            user can see which backend the per-move ONNX evaluation runs on. */}
         <InferenceChip />
 
         {/* Career-mode teammate-preference chip. Renders only when the
@@ -1604,7 +1492,10 @@ function MatchInner() {
             matchId={game.match_id}
             dice={game.dice}
             board={game.board}
-            agentId={agentId}
+            bar={game.bar}
+            off={game.off}
+            turn={game.turn}
+            opponentId={agentId}
             disabled={!isHumanTurn || game.game_over}
             onMoveSelect={(move) => {
               // Pre-fill the text move input so the human can review and
@@ -1639,17 +1530,12 @@ function MatchInner() {
   );
 }
 
-// Phase I.3: chip mirroring the global Compute pill's inference
-// backend. When 0G is on, fetches a one-shot probe from
-// /training/estimate so the chip can render real provider state +
-// per-inference cost when a backgammon-net provider is registered.
-// When local, the chip is a static label.
-//
-// The match flow today goes through gnubg_service (port 8001) which
-// doesn't know about 0G; per-move billing through /agent-move is
-// part of Phase J's per-agent-NN cutover. For now the chip surfaces
-// the standing 0G availability + cost so judges can see the matrix
-// is wired, even though each in-flight move doesn't tick the meter.
+// InferenceChip: mirrors the global Compute pill's inference backend.
+// When 0G is on, fetches a one-shot probe from /training/estimate so
+// the chip can render real provider state + per-inference cost when a
+// backgammon-net provider is registered. When local, shows a static
+// label. Agent moves now run via ONNX BackgammonNet in the browser;
+// 0G Compute is used for the coach LLM only.
 function InferenceChip() {
   const { backends, hydrated } = useComputeBackends();
   const is0G = hydrated && backends.inference === "0g";

--- a/frontend/app/team-demo/page.tsx
+++ b/frontend/app/team-demo/page.tsx
@@ -13,25 +13,18 @@ import { ChiefOfStaffPanel } from "../ChiefOfStaffPanel";
 import { DiceRoll } from "../DiceRoll";
 import { rollDice } from "../dice";
 import { useComputeBackends } from "../ComputeBackendsContext";
+import {
+  type MatchState,
+  newMatch,
+  applyMoveToState,
+  getBestMove,
+  skipTurn,
+} from "../../lib/match_engine";
+import { type Board as GameBoard } from "../../lib/rules_engine";
 
-const GNUBG = process.env.NEXT_PUBLIC_GNUBG_URL ?? "http://localhost:8001";
 const SERVER = process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:8000";
 
 // ── Types ──────────────────────────────────────────────────────────────────
-
-interface MatchState {
-  position_id: string;
-  match_id: string;
-  board: number[];
-  bar: [number, number];
-  off: [number, number];
-  turn: 0 | 1;
-  dice: [number, number] | null;
-  score: [number, number];
-  match_length: number;
-  game_over: boolean;
-  winner: 0 | 1 | null;
-}
 
 interface AgentRow {
   agent_id: number;
@@ -52,21 +45,6 @@ interface AdvisorSnapshot {
   captain_id: string | null;
   move_idx: number;
   team_mode: boolean;
-}
-
-// ── gnubg_service helper ───────────────────────────────────────────────────
-
-async function gnubgPost<T>(path: string, body: unknown): Promise<T> {
-  const res = await fetch(`${GNUBG}${path}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body ?? {}),
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => res.statusText);
-    throw new Error(`${res.status}: ${text}`);
-  }
-  return (await res.json()) as T;
 }
 
 /**
@@ -138,12 +116,14 @@ export default function TeamDemoPage() {
     if (!teammateId || opponentIds.length === 0) return;
     setSetup(false);
     setLoading(true);
-    gnubgPost<MatchState>("/new", { match_length: 3 })
-      .then((state) => {
-        setGame({ ...state, dice: rollDice() });
-      })
-      .catch((e) => setError(String(e)))
-      .finally(() => setLoading(false));
+    try {
+      const state = newMatch(3);
+      setGame({ ...state, dice: rollDice() });
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
   };
 
   useEffect(() => {
@@ -154,29 +134,14 @@ export default function TeamDemoPage() {
     agentMoving.current = true;
     const step = async () => {
       try {
-        const { move: best } = await gnubgPost<{ move: string | null }>(
-          "/move",
-          {
-            position_id: game.position_id,
-            match_id: game.match_id,
-            dice: game.dice,
-          },
-        );
+        const board: GameBoard = { points: game.board, bar: game.bar, off: game.off };
+        const best = await getBestMove(board, 1, game.dice!);
         if (!best) {
-          const skipped = await gnubgPost<MatchState>("/skip", {
-            position_id: game.position_id,
-            match_id: game.match_id,
-            current_turn: 1,
-          });
+          const skipped = skipTurn(game);
           setGame(skipped.game_over ? skipped : { ...skipped, dice: rollDice() });
           return;
         }
-        const next = await gnubgPost<MatchState>("/apply", {
-          position_id: game.position_id,
-          match_id: game.match_id,
-          dice: game.dice,
-          move: best,
-        });
+        const next = applyMoveToState(game, best);
         setGame(next.game_over ? next : { ...next, dice: rollDice() });
       } catch (e) {
         setError(String(e));
@@ -192,12 +157,7 @@ export default function TeamDemoPage() {
     if (!game || !game.dice) return;
     setLoading(true);
     try {
-      const next = await gnubgPost<MatchState>("/apply", {
-        position_id: game.position_id,
-        match_id: game.match_id,
-        dice: game.dice,
-        move: notation,
-      });
+      const next = applyMoveToState(game, notation);
       setGame(next.game_over ? next : { ...next, dice: rollDice() });
       setStagedMoves([]);
       setDisplayBoardState(null);
@@ -443,6 +403,9 @@ export default function TeamDemoPage() {
             matchId={game.match_id}
             dice={game.dice}
             board={game.board}
+            bar={game.bar}
+            off={game.off}
+            turn={game.turn}
             opponentId={opponentIds[0] || 0}
             disabled={!isHumanTurn || game.game_over}
             onMoveSelect={previewMove}

--- a/frontend/app/test-discovery/page.tsx
+++ b/frontend/app/test-discovery/page.tsx
@@ -19,10 +19,10 @@ const MOCK_ENTRIES = [
   },
   {
     node: "0x0000000000000000000000000000000000000000000000000000000000000002" as `0x${string}`,
-    label: "gnubg-1",
+    label: "backgammonnet-1",
     kind: "agent",
     elo: "1520",
-    endpoint: "http://localhost:8001",
+    endpoint: "http://localhost:8000",
     inftId: "1",
     address: null,
   },

--- a/frontend/lib/match_engine.ts
+++ b/frontend/lib/match_engine.ts
@@ -1,0 +1,218 @@
+/**
+ * match_engine.ts — client-side backgammon match engine.
+ *
+ * Replaces the local gnubg_service (port 8001) entirely. All game logic
+ * runs in the browser:
+ *   - Move legality and application: rules_engine.ts
+ *   - Neural-net move selection:     onnx_eval.ts (BackgammonNet)
+ *   - Position/match encoding:       gnubg_state.ts (gnubg-compatible IDs
+ *                                    for settlement / KeeperHub wiring)
+ *
+ * The exported MatchState interface is a drop-in replacement for the
+ * previous gnubg_service MatchStateDict so callers need no type changes.
+ */
+
+import {
+  Board,
+  OPENING_BOARD,
+  applyMove,
+  isLegal,
+  generateLegalMoves,
+} from "./rules_engine";
+import { evaluateMoves, CandidateMove } from "./onnx_eval";
+import { encodePositionId, encodeMatchId } from "./gnubg_state";
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+export interface MatchState {
+  position_id: string;
+  match_id: string;
+  board: number[];
+  bar: [number, number];
+  off: [number, number];
+  turn: 0 | 1;
+  dice: [number, number] | null;
+  score: [number, number];
+  match_length: number;
+  game_over: boolean;
+  winner: 0 | 1 | null;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function toBoard(state: MatchState): Board {
+  return { points: state.board, bar: state.bar, off: state.off };
+}
+
+function makeState(
+  board: Board,
+  turn: 0 | 1,
+  score: [number, number],
+  matchLength: number,
+  gameOver: boolean,
+  winner: 0 | 1 | null,
+  resign = false,
+  dice: [number, number] | null = null
+): MatchState {
+  return {
+    position_id: encodePositionId(board),
+    match_id: encodeMatchId(turn, matchLength, score, gameOver, resign ? 1 : 0),
+    board: board.points,
+    bar: board.bar,
+    off: board.off,
+    turn,
+    dice,
+    score,
+    match_length: matchLength,
+    game_over: gameOver,
+    winner,
+  };
+}
+
+function freshBoard(): Board {
+  return {
+    points: [...OPENING_BOARD.points],
+    bar: [0, 0],
+    off: [0, 0],
+  };
+}
+
+function randomDie(): number {
+  return Math.floor(Math.random() * 6) + 1;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/** Create the opening state for a new match. No dice — caller rolls. */
+export function newMatch(matchLength = 3): MatchState {
+  return makeState(freshBoard(), 0, [0, 0], matchLength, false, null);
+}
+
+/**
+ * Apply a move string to the current state. Validates legality; throws
+ * on an illegal or malformed move. Handles game/match score transitions:
+ *   - When a player bears off all 15 checkers → score incremented.
+ *   - If winner's score reaches match_length → game_over=true.
+ *   - Otherwise → board resets for the next game, match continues.
+ */
+export function applyMoveToState(state: MatchState, moveStr: string): MatchState {
+  if (!state.dice) throw new Error("No dice to play");
+  const board = toBoard(state);
+  const side = state.turn;
+
+  if (!isLegal(board, state.dice, side, moveStr)) {
+    throw new Error(`Illegal move: ${moveStr}`);
+  }
+
+  const newBoard = applyMove(board, side, moveStr);
+
+  if (newBoard.off[side] === 15) {
+    // Current player bore off all checkers — wins this game (1 pt, no cube).
+    const newScore: [number, number] =
+      side === 0
+        ? [state.score[0] + 1, state.score[1]]
+        : [state.score[0], state.score[1] + 1];
+
+    const matchOver =
+      newScore[0] >= state.match_length || newScore[1] >= state.match_length;
+
+    if (matchOver) {
+      return makeState(newBoard, side, newScore, state.match_length, true, side);
+    }
+
+    // Match continues — reset board, swap turn.
+    const nextTurn = (1 - side) as 0 | 1;
+    return makeState(freshBoard(), nextTurn, newScore, state.match_length, false, null);
+  }
+
+  const nextTurn = (1 - side) as 0 | 1;
+  return makeState(newBoard, nextTurn, state.score, state.match_length, false, null);
+}
+
+/** Pass the turn without moving (bar-dance: checker on bar, board closed). */
+export function skipTurn(state: MatchState): MatchState {
+  const nextTurn = (1 - state.turn) as 0 | 1;
+  return makeState(toBoard(state), nextTurn, state.score, state.match_length, false, null);
+}
+
+/** Human forfeits — agent (side 1) wins the match. */
+export function resignMatch(state: MatchState): MatchState {
+  const agentWinner: 0 | 1 = 1;
+  const newScore: [number, number] = [state.score[0], state.score[1] + 1];
+  return makeState(
+    toBoard(state),
+    state.turn,
+    newScore,
+    state.match_length,
+    true,
+    agentWinner,
+    true,
+  );
+}
+
+/**
+ * Pick the best move for the current side using the BackgammonNet ONNX model.
+ * Returns null when there are no legal moves (bar-dance).
+ */
+export async function getBestMove(
+  board: Board,
+  side: 0 | 1,
+  dice: [number, number]
+): Promise<string | null> {
+  const candidates = await evaluateMoves(board, side, dice);
+  return candidates.length > 0 ? candidates[0].move : null;
+}
+
+/**
+ * Evaluate legal moves and return ranked candidates (at most topN).
+ * Used by the coach panel to get candidates before calling the LLM.
+ */
+export async function evaluateCandidates(
+  board: Board,
+  side: 0 | 1,
+  dice: [number, number],
+  topN = 3
+): Promise<CandidateMove[]> {
+  const candidates = await evaluateMoves(board, side, dice);
+  return candidates.slice(0, topN);
+}
+
+/**
+ * Check whether the current side has any legal moves at all.
+ * Used to detect bar-dance situations before skipping the turn.
+ */
+export function hasLegalMoves(
+  board: Board,
+  side: 0 | 1,
+  dice: [number, number]
+): boolean {
+  return generateLegalMoves(board, side, dice).length > 0;
+}
+
+/**
+ * Fast-forward: run the full remaining match with both sides picking their
+ * best move from the ONNX BackgammonNet. Returns the final MatchState.
+ *
+ * Bound to 300 half-moves to prevent infinite loops in degenerate positions.
+ * Dice are rolled locally (Math.random) — this is a UX shortcut, not the
+ * rated path (which uses drand for verifiable randomness).
+ */
+export async function playMatchToEnd(state: MatchState): Promise<MatchState> {
+  let s = state;
+
+  for (let i = 0; i < 300 && !s.game_over; i++) {
+    const dice: [number, number] = s.dice ?? [randomDie(), randomDie()];
+    const stateWithDice: MatchState = { ...s, dice };
+    const board = toBoard(stateWithDice);
+
+    const candidates = await evaluateMoves(board, s.turn, dice);
+    if (candidates.length === 0) {
+      // No legal moves — skip turn, roll fresh dice for the new side.
+      s = skipTurn(stateWithDice);
+    } else {
+      s = applyMoveToState(stateWithDice, candidates[0].move);
+    }
+  }
+
+  return s;
+}

--- a/frontend/lib/move_tagger.ts
+++ b/frontend/lib/move_tagger.ts
@@ -1,0 +1,127 @@
+/**
+ * move_tagger.ts — heuristic strategy labels for candidate moves.
+ *
+ * TypeScript port of agent/move_tagger.py. Assigns human-readable strategy
+ * tags to ranked candidates so the Chief of Staff / Agent Teammate panel can
+ * speak in strategic terms rather than raw equity numbers.
+ *
+ * Tags applied in priority order:
+ *   Blitz      — hits two or more opponent blots
+ *   Aggressive — hits exactly one blot, or dominant equity gap ≥ 0.15
+ *   Anchor     — places a checker in the opponent's home board (points 19-24)
+ *   Priming    — extends an existing prime (interior point 7-18 already occupied)
+ *   Safe       — default when none of the above match
+ */
+
+export type MoveTag = "Safe" | "Aggressive" | "Priming" | "Anchor" | "Blitz";
+
+export interface TaggedCandidate {
+  move: string;
+  equity: number;
+  tag: MoveTag;
+  tag_reason: string;
+}
+
+interface Candidate {
+  move: string;
+  equity: number;
+}
+
+const SEG_RE = /(\bbar\b|\d+)\/(\d+|\boff\b)/gi;
+
+function parseSegments(move: string): Array<[string, string]> {
+  const cleaned = move.replace(/\*/g, "");
+  const segs: Array<[string, string]> = [];
+  SEG_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = SEG_RE.exec(cleaned)) !== null) {
+    segs.push([m[1].toLowerCase(), m[2].toLowerCase()]);
+  }
+  return segs;
+}
+
+function toPoint(s: string): number | null {
+  if (s === "bar" || s === "off") return null;
+  const n = parseInt(s, 10);
+  return isNaN(n) ? null : n;
+}
+
+function countHits(move: string, board: number[] | null): number {
+  if (!board) return 0;
+  let hits = 0;
+  for (const [, toS] of parseSegments(move)) {
+    const pt = toPoint(toS);
+    if (pt === null) continue;
+    const idx = pt - 1;
+    if (idx >= 0 && idx < board.length && board[idx] === -1) hits++;
+  }
+  return hits;
+}
+
+function isAnchorMove(move: string): boolean {
+  for (const [, toS] of parseSegments(move)) {
+    const pt = toPoint(toS);
+    if (pt !== null && pt >= 19 && pt <= 24) return true;
+  }
+  return false;
+}
+
+function isPrimingMove(move: string, board: number[] | null): boolean {
+  if (!board) return false;
+  for (const [, toS] of parseSegments(move)) {
+    const pt = toPoint(toS);
+    if (pt === null) continue;
+    if (pt >= 7 && pt <= 18) {
+      const idx = pt - 1;
+      if (idx >= 0 && idx < board.length && board[idx] > 0) return true;
+    }
+  }
+  return false;
+}
+
+function tagOne(candidate: Candidate, board: number[] | null): TaggedCandidate {
+  const { move } = candidate;
+  const hits = countHits(move, board);
+
+  if (hits >= 2)
+    return { ...candidate, tag: "Blitz", tag_reason: `hits ${hits} blots` };
+  if (hits === 1)
+    return { ...candidate, tag: "Aggressive", tag_reason: "hits an opponent blot" };
+  if (isAnchorMove(move))
+    return { ...candidate, tag: "Anchor", tag_reason: "establishes a point in opponent's home" };
+  if (isPrimingMove(move, board))
+    return { ...candidate, tag: "Priming", tag_reason: "extends a prime" };
+  return { ...candidate, tag: "Safe", tag_reason: "positional, low blot exposure" };
+}
+
+/**
+ * Tag the top-N candidates with heuristic strategy labels.
+ *
+ * @param candidates Ranked list of {move, equity}, best-first (index 0 = highest equity).
+ * @param board      Optional 24-element points array (positive = player 0). When null,
+ *                   board-dependent rules (hit detection, prime detection) are skipped.
+ * @param topN       How many candidates to return (default 5).
+ */
+export function tagCandidates(
+  candidates: Candidate[],
+  board: number[] | null = null,
+  topN = 5
+): TaggedCandidate[] {
+  const pool = candidates.slice(0, topN);
+  if (pool.length === 0) return [];
+
+  const bestEquity = pool[0].equity;
+  const secondEquity = pool.length > 1 ? pool[1].equity : bestEquity - 1;
+
+  return pool.map((cand, rank) => {
+    const tc = tagOne(cand, board);
+    if (rank === 0 && tc.tag === "Safe" && bestEquity - secondEquity >= 0.15) {
+      return {
+        ...tc,
+        tag: "Aggressive" as MoveTag,
+        tag_reason: "dominant equity advantage vs next-best",
+      };
+    }
+    return tc;
+  });
+}

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -374,10 +374,10 @@ def get_last_advisor_signals(game_id: str):
     captain who decided that turn. The frontend's AdvisorSignalsPanel
     polls this so it can render the latest signals without driving
     /agent-move directly. Returns empty arrays when no move has been
-    recorded yet — the live match page uses gnubg_service for moves,
-    not /agent-move, so this stays empty unless the operator drives
-    moves through the main backend (e.g. team-mode integration tests
-    or a future end-to-end UI cutover)."""
+    recorded yet — the live match page uses the client-side ONNX engine
+    for moves, not /agent-move, so this stays empty unless the operator
+    drives moves through the main backend (e.g. team-mode integration
+    tests or a future end-to-end UI cutover)."""
     history = _move_history.get(game_id, [])
     if not history:
         return {"signals": [], "captain_id": None, "move_idx": -1, "team_mode": game_id in _game_teams}
@@ -1049,7 +1049,7 @@ def finalize_game(game_id: str, req: FinalizeRequest):
 # ---------------------------------------------------------------------------
 # KeeperHub integration: /finalize-direct, /settle (relayer), /replay
 #
-# The match page drives gameplay through gnubg_service (port 8001) without
+# The match page drives gameplay through the client-side ONNX engine without
 # creating a game at this server. These three endpoints close the settlement
 # loop for that path:
 #
@@ -1061,20 +1061,20 @@ def finalize_game(game_id: str, req: FinalizeRequest):
 #       payload (step 7 of keeperhub/match-settle.yaml) and calls
 #       recordMatch on 0G Chain. Returns {tx_hash}.
 #
-#   POST /replay — GNUBG replay validation endpoint. Receives {archive_uri,
+#   POST /replay — Move replay validation endpoint. Receives {archive_uri,
 #       match_id} from KeeperHub's fetch-and-replay step, fetches the
-#       GameRecord from 0G Storage, and validates every move through gnubg.
-#       Returns {valid: bool, winner: str}.
+#       GameRecord from 0G Storage, and validates every move via the
+#       rules engine. Returns {valid: bool, winner: str}.
 # ---------------------------------------------------------------------------
 
 
 class DirectFinalizeRequest(BaseModel):
-    """Finalize a match from the gnubg service state without a server game_id.
+    """Finalize a match from the client-side engine state without a server game_id.
 
-    The match page drives gameplay through gnubg_service directly (port 8001)
-    and never registers a game at this server. At game-end the frontend calls
-    this endpoint so the audit pipeline runs automatically: 0G Storage upload
-    → recordMatch on-chain → overlay updates → ENS push.
+    The match page drives gameplay through the ONNX BackgammonNet engine in
+    the browser and never registers a game at this server. At game-end the
+    frontend calls this endpoint so the audit pipeline runs automatically:
+    0G Storage upload → recordMatch on-chain → overlay updates → ENS push.
     """
 
     winner_agent_id: int = 0


### PR DESCRIPTION
Closes #93

Removes `gnubg_service:app --port 8001` as a runtime dependency. All game logic now runs client-side in the browser via the ONNX BackgammonNet.

- Agent moves come from the per-agent BackgammonNet (ONNX forward pass via `onnx_eval.ts`)
- Game engine (legality, apply, skip, resign, fast-forward) implemented in `frontend/lib/match_engine.ts`
- Move tagging for Chief of Staff panel ported to `frontend/lib/match_engine.ts` (no more /evaluate-tagged HTTP call)

Generated with [Claude Code](https://claude.ai/code)