### PR TITLE
Phase 105: Fix feature tooltip visibility in agent info

### DIFF
--- a/frontend/app/agent/[agentId]/AgentClient.tsx
+++ b/frontend/app/agent/[agentId]/AgentClient.tsx
@@ -772,7 +772,7 @@ function WeightRow({
 
   return (
     <div className="flex items-center gap-3 text-xs">
-      <span className="group/tip relative flex w-44 shrink-0 cursor-help items-center gap-1 truncate font-mono text-zinc-600 dark:text-zinc-400">
+      <span className="group/tip relative flex w-44 shrink-0 cursor-help items-center gap-1 font-mono text-zinc-600 dark:text-zinc-400">
         <span className="truncate">{label}</span>
         {tooltip && (
           <>


### PR DESCRIPTION
Fixes #97

The `WeightRow` component had a `truncate` Tailwind class on its outer `group/tip` span. `truncate` expands to `overflow: hidden`, which clipped the absolutely-positioned tooltip bubble. The inner label span already had `truncate` for text truncation, so removing it from the outer span fixes the tooltip without affecting text layout.

All 20 overlay categories already had plain-English definitions in `CATEGORY_TOOLTIPS` — they just weren't visible due to the overflow clipping.

Generated with [Claude Code](https://claude.ai/code)