### PR TITLE
Phase 101: fix WASM OOM and add game-flow E2E tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint",
     "test": "next build --webpack",
     "test:e2e": "playwright test",
-    "copy:wasm": "mkdir -p public/js && cp node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.mjs node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.wasm node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.jsep.mjs node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.jsep.wasm public/js/",
+    "copy:wasm": "mkdir -p public/js && cp node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.mjs node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.wasm public/js/",
     "postinstall": "pnpm run copy:wasm"
   },
   "dependencies": {

--- a/frontend/tests/game-flow.spec.ts
+++ b/frontend/tests/game-flow.spec.ts
@@ -1,0 +1,163 @@
+// game-flow.spec.ts — Phase 101: E2E tests for off-chain and on-chain game flows.
+//
+// Verifies that a full match (using the ⏩ Fast forward button) plays to
+// completion without visible errors in both game modes:
+//   - Off-chain: /team-demo?opponents=1   (no settlement, no server required)
+//   - On-chain:  /team-demo?opponents=1&settle=1  (KeeperHub settlement mocked)
+//
+// The ?opponents=N URL parameter causes the page to auto-start (skipping the
+// setup screen), so no agent-list server call is needed for the game to begin.
+// Backend HTTP calls are intercepted with page.route() so no real server is
+// required. The wallet is mocked via addInitScript (same technique as
+// wallet_persistence.spec.ts) so wagmi's injected connector hydrates correctly.
+
+import { test, expect, type Page } from "@playwright/test";
+
+// ── Mock wallet ────────────────────────────────────────────────────────────
+// Minimal EIP-1193 provider. Satisfies wagmi's injected connector so the app
+// hydrates without a real MetaMask extension.
+
+const MOCK_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"; // Hardhat account 0
+const MOCK_CHAIN_HEX = "0x7a69"; // 31337 decimal — Hardhat local
+
+const MOCK_ETHEREUM_SCRIPT = `
+  (() => {
+    if (window.__mockEthereumInstalled) return;
+    window.__mockEthereumInstalled = true;
+    const handlers = {};
+    const provider = {
+      isMetaMask: true,
+      _accounts: ["${MOCK_ADDRESS}"],
+      _chainId: "${MOCK_CHAIN_HEX}",
+      async request({ method }) {
+        switch (method) {
+          case "eth_requestAccounts":
+          case "eth_accounts":
+            return this._accounts;
+          case "eth_chainId":
+            return this._chainId;
+          case "net_version":
+            return "31337";
+          case "wallet_switchEthereumChain":
+          case "wallet_addEthereumChain":
+            return null;
+          case "eth_blockNumber":
+            return "0x1";
+          case "eth_getBalance":
+            return "0x0";
+          default:
+            return null;
+        }
+      },
+      on(event, handler) {
+        (handlers[event] = handlers[event] || []).push(handler);
+        return this;
+      },
+      removeListener(event, handler) {
+        if (handlers[event]) {
+          handlers[event] = handlers[event].filter(h => h !== handler);
+        }
+        return this;
+      },
+      emit(event, ...args) {
+        (handlers[event] || []).forEach(h => h(...args));
+      },
+    };
+    window.ethereum = provider;
+    Promise.resolve().then(() =>
+      provider.emit("connect", { chainId: "${MOCK_CHAIN_HEX}" })
+    );
+  })();
+`;
+
+async function injectMockEthereum(page: Page): Promise<void> {
+  await page.addInitScript({ content: MOCK_ETHEREUM_SCRIPT });
+}
+
+// ── Mock backend routes ────────────────────────────────────────────────────
+// The backend server (default http://localhost:8000) is not started in tests.
+// We intercept its calls so the component can complete the on-chain settlement
+// flow without a real server.
+
+async function mockServerRoutes(page: Page): Promise<void> {
+  // Agent list — the agentsQuery always fires even though the setup screen is
+  // skipped when ?opponents=N is set. Mocking silences the network-error noise.
+  await page.route("http://localhost:8000/agents", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify([
+        { agent_id: 1, weights_hash: "0xabc", match_count: 0, tier: 1 },
+      ]),
+    })
+  );
+
+  // Settlement endpoint — called automatically when ?settle=1 and game ends.
+  await page.route("http://localhost:8000/finalize-direct", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ match_id: 42 }),
+    })
+  );
+
+  // KeeperHub workflow trigger — fire-and-forget; just needs to not error.
+  await page.route("http://localhost:8000/keeper-workflow/**", (route) =>
+    route.fulfill({ status: 200, body: "" })
+  );
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+test.describe("off-chain game flow", () => {
+  test("plays a full match to completion via fast-forward — no errors", async ({ page }) => {
+    // ?opponents=1 skips the setup screen and auto-starts with opponent Agent 1.
+    await page.goto("/team-demo?opponents=1");
+
+    // Header confirms we're in an off-chain game (not settlement mode).
+    await expect(
+      page.locator("h1", { hasText: "Off-Chain Game" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Fast-forward button only renders once the game state is initialised; wait
+    // for it then click to invoke playMatchToEnd (ONNX-free random play).
+    await page.locator("button", { hasText: "Fast forward" }).click({ timeout: 10_000 });
+
+    // playMatchToEnd runs up to 3000 half-moves; random games finish in ~200.
+    // Allow 60 s to be safe in slow CI environments.
+    await expect(page.locator("text=Game Over!")).toBeVisible({ timeout: 60_000 });
+
+    // No inline error text should be visible after a clean run.
+    await expect(page.locator("p.text-red-500")).not.toBeVisible();
+  });
+});
+
+test.describe("on-chain game flow", () => {
+  test.beforeEach(async ({ page }) => {
+    await injectMockEthereum(page);
+    await mockServerRoutes(page);
+  });
+
+  test("plays a full on-chain match via fast-forward and settles — no errors", async ({ page }) => {
+    // opponents=1&settle=1 — auto-start with KeeperHub settlement enabled.
+    await page.goto("/team-demo?opponents=1&settle=1");
+
+    // On-chain mode labels the header "Official Game".
+    await expect(
+      page.locator("h1", { hasText: "Official Game" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Click fast-forward to run playMatchToEnd (no ONNX needed).
+    await page.locator("button", { hasText: "Fast forward" }).click({ timeout: 10_000 });
+
+    // Wait for the match to finish.
+    await expect(page.locator("text=Game Over!")).toBeVisible({ timeout: 60_000 });
+
+    // After game_over + settle=1, the component auto-calls /finalize-direct.
+    // The mock returns match_id: 42 → "KeeperHub settled" banner should appear.
+    await expect(
+      page.locator("text=KeeperHub settled")
+    ).toBeVisible({ timeout: 10_000 });
+
+    // No inline error text.
+    await expect(page.locator("p.text-red-500")).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
Fixes #101

## Summary
- Remove jsep WASM files from `copy:wasm` so the 26 MB `.jsep.wasm` is never served, eliminating the OOM crash
- Add E2E Playwright tests for off-chain and on-chain game flows with fast-forward

Generated with [Claude Code](https://claude.ai/code)