### PR TITLE
feat: mobile browser support — MetaMask deep link + responsive header

### DIFF
--- a/frontend/app/ConnectButton.tsx
+++ b/frontend/app/ConnectButton.tsx
@@ -2,12 +2,20 @@
 
 // Connect / disconnect button with injected-wallet and WalletConnect support.
 //
-// Four states:
-//   1. Not mounted (SSR)          → null (avoids hydration mismatch)
-//   2. No wallet / no WC config   → "Install MetaMask" link
-//   3. Not connected, wallet(s) available → injected button + WalletConnect
-//      button (if projectId is configured)
-//   4. Connected                  → network dropdown, profile badge, disconnect
+// Five states:
+//   1. Not mounted (SSR)                  → null (avoids hydration mismatch)
+//   2. Mobile, no injected wallet         → "Open in MetaMask" deep link
+//      (+ WalletConnect button if projectId is configured)
+//   3. Desktop, no wallet / no WC config  → "Install MetaMask" link
+//   4. Not connected, wallet(s) available → "Browser wallet" button
+//      + WalletConnect button (if projectId is configured)
+//   5. Connected                          → network dropdown, profile badge, disconnect
+//
+// Mobile MetaMask note: on a regular mobile browser window.ethereum is not
+// injected — wagmi's injected connector is absent. The deep link
+// `metamask.app.link/dapp/…` opens the dapp inside MetaMask Mobile's own
+// in-app browser, which *does* inject window.ethereum, restoring the normal
+// "Browser wallet" flow. WalletConnect is shown alongside as an alternative.
 //
 // SSR note: wagmi is configured with ssr:true so the server renders connectors
 // as []. The `mounted` guard defers the real render until after hydration so
@@ -48,20 +56,64 @@ const secondaryBtn: React.CSSProperties = {
   border: "1px solid var(--cg-line-2)",
 };
 
+/** True when running on a phone or tablet (UA-based; post-mount only). */
+function isMobileBrowser(): boolean {
+  return /Android|iPhone|iPad|iPod|IEMobile|Opera Mini/i.test(navigator.userAgent);
+}
+
+/** Deep link that opens the current page inside MetaMask Mobile's in-app browser. */
+function metaMaskDeepLink(): string {
+  const { hostname, pathname, search } = window.location;
+  return `https://metamask.app.link/dapp/${hostname}${pathname}${search}`;
+}
+
 export function ConnectButton() {
   const { address, isConnected } = useAccount();
   const { connectors, connect, isPending: connectPending, error: connectError } = useConnect();
   const { disconnect } = useDisconnect();
   const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
+  const [isMobile, setIsMobile] = useState(false);
+  const [userAttempted, setUserAttempted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    setIsMobile(isMobileBrowser());
+  }, []);
 
   const injectedConnector = connectors.find((c: Connector) => c.type === "injected");
   const wcConnector = connectors.find((c: Connector) => c.type === "walletConnect");
-  const [userAttempted, setUserAttempted] = useState(false);
 
   if (!mounted) return null;
 
   if (!isConnected) {
+    // Mobile browser without window.ethereum — show MetaMask deep link so the
+    // user can open the dapp inside MetaMask Mobile's browser where
+    // window.ethereum is injected.
+    if (isMobile && !injectedConnector) {
+      return (
+        <div style={{ display: "flex", flexWrap: "wrap", justifyContent: "flex-end", gap: 8 }}>
+          <a
+            href={metaMaskDeepLink()}
+            data-testid="open-in-metamask"
+            style={primaryBtn}
+          >
+            Open in MetaMask
+          </a>
+          {wcConnector && (
+            <button
+              type="button"
+              onClick={() => { setUserAttempted(true); connect({ connector: wcConnector }); }}
+              disabled={connectPending}
+              style={secondaryBtn}
+              className="disabled:opacity-60"
+            >
+              WalletConnect
+            </button>
+          )}
+        </div>
+      );
+    }
+
     const hasAnyConnector = injectedConnector || wcConnector;
     if (!hasAnyConnector) {
       return (
@@ -86,7 +138,7 @@ export function ConnectButton() {
               style={primaryBtn}
               className="disabled:opacity-60"
             >
-              {connectPending ? "Connecting…" : "Connect wallet"}
+              {connectPending ? "Connecting…" : "Browser wallet"}
             </button>
           )}
           {wcConnector && (

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -48,7 +48,7 @@ export default function RootLayout({
       lang="en"
       className={`${cgSans.variable} ${cgMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">
+      <body className="min-h-full flex flex-col overflow-x-hidden">
         <Providers>
           <div className="flex flex-1">
             {/* pb-16 reserves space for the fixed mobile bottom nav */}
@@ -90,7 +90,9 @@ export default function RootLayout({
                   </span>
                 </a>
                 <div className="flex flex-wrap items-center justify-end gap-3">
-                  <ComputeBackendsPill />
+                  <span className="hidden md:block">
+                    <ComputeBackendsPill />
+                  </span>
                   <a
                     href="/help"
                     target="_blank"

--- a/frontend/tests/mobile_connect.spec.ts
+++ b/frontend/tests/mobile_connect.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * mobile_connect.spec.ts
+ *
+ * Verifies that on a mobile browser without window.ethereum (i.e. no injected
+ * MetaMask extension), ConnectButton renders an "Open in MetaMask" deep link
+ * whose href uses the metamask.app.link/dapp/ scheme.
+ *
+ * MetaMask Mobile does not inject window.ethereum in a regular mobile browser
+ * (Chrome/Safari on iOS or Android) — it only does so inside its own in-app
+ * browser. The deep link sends the user there, where the normal "Browser
+ * wallet" flow then works.
+ *
+ * We use a Playwright mobile viewport + user-agent (iPhone 12) and
+ * deliberately do NOT inject a mock window.ethereum so the injected connector
+ * is absent, triggering the mobile-fallback branch in ConnectButton.
+ */
+
+import { test, expect } from "@playwright/test";
+import { devices } from "@playwright/test";
+
+const iPhone = devices["iPhone 12"];
+
+test.describe("mobile connect — no injected wallet", () => {
+  test.use({
+    ...iPhone,
+  });
+
+  test('shows "Open in MetaMask" deep link on mobile without window.ethereum', async ({
+    page,
+  }) => {
+    // No mock ethereum injected — simulates a regular mobile browser.
+    await page.goto("/");
+
+    const link = page.getByTestId("open-in-metamask");
+    await expect(link).toBeVisible({ timeout: 8000 });
+
+    const href = await link.getAttribute("href");
+    expect(href).toMatch(/^https:\/\/metamask\.app\.link\/dapp\//);
+    // href must include the current hostname
+    expect(href).toContain("localhost");
+  });
+
+  test("deep link href contains the current path", async ({ page }) => {
+    await page.goto("/help");
+
+    const link = page.getByTestId("open-in-metamask");
+    await expect(link).toBeVisible({ timeout: 8000 });
+
+    const href = await link.getAttribute("href");
+    expect(href).toContain("/help");
+  });
+});


### PR DESCRIPTION
Implements mobile browser support for wallet connection (path 2):

- On a regular mobile browser without `window.ethereum`, shows "Open in MetaMask" deep link (`metamask.app.link/dapp/`)
- Renames "Connect wallet" → "Browser wallet"
- Hides ComputeBackendsPill on mobile to prevent header overflow
- Adds overflow-x-hidden to body
- Adds Playwright test for mobile connect flow

Closes #104

Generated with [Claude Code](https://claude.ai/code)