### PR TITLE
fix: gate injected connector on runtime window.ethereum check

### DIFF
--- a/frontend/app/ConnectButton.tsx
+++ b/frontend/app/ConnectButton.tsx
@@ -61,6 +61,11 @@ function isMobileBrowser(): boolean {
   return /Android|iPhone|iPad|iPod|IEMobile|Opera Mini/i.test(navigator.userAgent);
 }
 
+/** True when an EIP-1193 provider (window.ethereum) is actually injected. */
+function hasInjectedProvider(): boolean {
+  return typeof window !== "undefined" && Boolean((window as { ethereum?: unknown }).ethereum);
+}
+
 /** Deep link that opens the current page inside MetaMask Mobile's in-app browser. */
 function metaMaskDeepLink(): string {
   const { hostname, pathname, search } = window.location;
@@ -73,14 +78,23 @@ export function ConnectButton() {
   const { disconnect } = useDisconnect();
   const [mounted, setMounted] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
+  const [hasProvider, setHasProvider] = useState(false);
   const [userAttempted, setUserAttempted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
     setIsMobile(isMobileBrowser());
+    setHasProvider(hasInjectedProvider());
   }, []);
 
-  const injectedConnector = connectors.find((c: Connector) => c.type === "injected");
+  // wagmi v3 always includes the `injected()` connector in its config regardless
+  // of whether window.ethereum exists, so a truthy `connectors.find(...)` does
+  // NOT mean a wallet is installed. Gate the injected flow on `hasProvider`
+  // (a runtime window.ethereum check) — otherwise clicking "Browser wallet" on
+  // a vanilla mobile browser throws `ProviderNotFoundError`.
+  const injectedConnector = hasProvider
+    ? connectors.find((c: Connector) => c.type === "injected")
+    : undefined;
   const wcConnector = connectors.find((c: Connector) => c.type === "walletConnect");
 
   if (!mounted) return null;


### PR DESCRIPTION
Mobile Chrome/Safari users at oslinin.github.io/chaingammon saw a red "Provider not found. Version: @wagmi/core@3.4.6" banner under the header. The banner is wagmi v3's ProviderNotFoundError surfaced through ConnectButton's existing connectError display. Root cause: wagmi v3 always keeps the configured `injected()` connector in `useConnect`'s `connectors` list regardless of whether window.ethereum is actually injected, so the `isMobile && !injectedConnector` mobile-fallback branch in ConnectButton never fired on a vanilla mobile browser. The page therefore rendered the "Browser wallet" button; tapping it called `connect({ connector: injected })` and threw because `getProvider()` returned undefined.

ConnectButton (**frontend/app/ConnectButton.tsx**, updated):
- `hasInjectedProvider()` — runtime `window.ethereum` check
- `hasProvider` state set on mount alongside `mounted` and `isMobile`
- `injectedConnector` now resolves to `undefined` when no provider is injected, even though wagmi still lists the connector
  - mobile UA without window.ethereum now correctly hits the "Open in MetaMask" deep-link branch
  - desktop without a wallet but with WalletConnect configured no longer shows a dead "Browser wallet" button

No new tests; existing **frontend/tests/mobile_connect.spec.ts** covers the mobile-without-provider path and still passes.