### PR TITLE
feat(frontend): rewrite Board as fixed-size SVG with drag-and-drop an…

### DIFF
--- a/frontend/app/Board.tsx
+++ b/frontend/app/Board.tsx
@@ -12,6 +12,7 @@ interface BoardProps {
   onBarClick?: () => void;
   onOffClick?: () => void;
   selectedPoint?: number | null;  // 1-24 = board point, 25 = bar
+  ghostMove?: string | null;      // A move string to preview on hover, e.g. "24/18 13/7"
   onDragStart?: (point: number) => void;
   onDrop?: (point: number) => void;
 }
@@ -52,6 +53,7 @@ export function Board({
   onBarClick,
   onOffClick,
   selectedPoint,
+  ghostMove,
   onDragStart,
   onDrop,
 }: BoardProps) {
@@ -72,6 +74,27 @@ export function Board({
       setPendingDrop(null);
     }
   }, [selectedPoint, pendingDrop, onOffClick, onPointClick, onDrop]);
+
+  // Parse ghostMove into an array of {from, to} segments for visualization
+  const previewSegments = React.useMemo(() => {
+    if (!ghostMove) return [];
+    return ghostMove.split(/\s+/).filter(Boolean).map(seg => {
+      const parts = seg.split("/");
+      if (parts.length !== 2) return null;
+      const from = parts[0] === "bar" ? 25 : parseInt(parts[0], 10);
+      const to = parts[1] === "off" ? 0 : parseInt(parts[1], 10);
+      if (isNaN(from) || isNaN(to)) return null;
+      return { from, to };
+    }).filter(Boolean) as { from: number; to: number }[];
+  }, [ghostMove]);
+
+  // Aggregate ghost states per point
+  const ghostDepartures: Record<number, number> = {};
+  const ghostArrivals: Record<number, number> = {};
+  previewSegments.forEach(seg => {
+    ghostDepartures[seg.from] = (ghostDepartures[seg.from] || 0) + 1;
+    ghostArrivals[seg.to] = (ghostArrivals[seg.to] || 0) + 1;
+  });
 
   const turnLabel = turn === 0 ? "Your turn" : `${opponentName ?? "Agent"}'s turn`;
   const turnColor = turn === 0 ? "var(--cg-player-warm)" : "var(--cg-player-cool)";
@@ -231,16 +254,25 @@ export function Board({
     const pts = `${startX},${baseY} ${startX + POINT_W},${baseY} ${startX + POINT_W / 2},${tipY}`;
 
     const count = board[point - 1];
-    const isP0 = count > 0;
+    const isP0 = count > 0 || (count === 0 && turn === 0); // If empty but turn is 0, we assume dropping P0 checker
     const absCount = Math.abs(count);
 
     // Dragging state info
     const isDragSource = dragState?.fromPoint === point;
-    // Visually, if we're dragging from here, we show one fewer checker (the ghost is on the mouse)
-    const displayCount = isDragSource ? absCount - 1 : absCount;
+    // Preview departures
+    const departures = ghostDepartures[point] || 0;
+    const arrivals = ghostArrivals[point] || 0;
 
+    // Visually, if we're dragging from here or departing, we show fewer real checkers
+    const displayCount = Math.max(0, absCount - (isDragSource ? 1 : 0) - departures);
+
+    // For ghost visuals, we want to render the normal ones, then the fading out ones, then fading in ones
+    const totalPhysicalDots = Math.min(absCount - (isDragSource ? 1 : 0), MAX_DOTS);
     const dotsToShow = Math.min(displayCount, MAX_DOTS);
-    const extra = displayCount > MAX_DOTS ? displayCount - MAX_DOTS : 0;
+
+    // The visual stacked height includes arrivals up to MAX_DOTS
+    const combinedDots = Math.min(displayCount + departures + arrivals, MAX_DOTS);
+    const extra = displayCount + departures + arrivals > MAX_DOTS ? displayCount + departures + arrivals - MAX_DOTS : 0;
 
     const isSelected = selectedPoint === point;
 
@@ -301,18 +333,37 @@ export function Board({
 
         {/* Checkers */}
         <g pointerEvents="none">
-          {Array.from({ length: dotsToShow }).map((_, i) => {
+          {Array.from({ length: combinedDots }).map((_, i) => {
             const cy = isTop
               ? FRAME + CHECKER_R + i * CHECKER_GAP
               : TOTAL_H - FRAME - CHECKER_R - i * CHECKER_GAP;
-            return renderChecker(startX + POINT_W / 2, cy, isP0, `checker-${point}-${i}`);
+
+            // Determine if this specific dot is solid, a departure ghost, or an arrival ghost
+            let isDragging = false;
+            let dotIsP0 = isP0;
+
+            if (i >= displayCount) {
+              if (i < displayCount + departures) {
+                // It's a departing checker (show as transparent)
+                isDragging = true;
+                dotIsP0 = count > 0;
+              } else {
+                // It's an arriving checker (show as transparent ghost belonging to current turn)
+                isDragging = true;
+                dotIsP0 = turn === 0;
+              }
+            } else {
+              dotIsP0 = count > 0;
+            }
+
+            return renderChecker(startX + POINT_W / 2, cy, dotIsP0, `checker-${point}-${i}`, isDragging);
           })}
           {extra > 0 && (
             <text
               x={startX + POINT_W / 2}
               y={isTop
-                  ? FRAME + CHECKER_R + dotsToShow * CHECKER_GAP + 4
-                  : TOTAL_H - FRAME - CHECKER_R - dotsToShow * CHECKER_GAP + 4}
+                  ? FRAME + CHECKER_R + combinedDots * CHECKER_GAP + 4
+                  : TOTAL_H - FRAME - CHECKER_R - combinedDots * CHECKER_GAP + 4}
               textAnchor="middle"
               fontSize="12"
               fontFamily="var(--cg-font-mono, monospace)"
@@ -330,7 +381,11 @@ export function Board({
     const isSelected = selectedPoint === 25;
     const [p0Bar, p1Bar] = bar;
 
-    const p0Display = dragState?.fromPoint === "bar" ? p0Bar - 1 : p0Bar;
+    const p0Departures = ghostDepartures[25] || 0;
+    // p1 bar is not playable by the human turn, so we don't ghost it
+    const p0Display = Math.max(0, p0Bar - (dragState?.fromPoint === "bar" ? 1 : 0) - p0Departures);
+    const p0Combined = Math.min(p0Display + p0Departures, 3);
+    const p0Extra = p0Display + p0Departures > 3 ? p0Display + p0Departures - 3 : 0;
 
     return (
       <g key="bar">
@@ -402,19 +457,20 @@ export function Board({
 
         {/* P0 Bar Checkers (Bottom Up) */}
         <g pointerEvents="none">
-          {Array.from({ length: Math.min(p0Display, 3) }).map((_, i) => (
-            renderChecker(BAR_X + BAR_W / 2, TOTAL_H - FRAME - 60 - i * CHECKER_GAP, true, `bar-p0-${i}`)
-          ))}
-          {p0Display > 3 && (
+          {Array.from({ length: p0Combined }).map((_, i) => {
+            const isDragging = i >= p0Display;
+            return renderChecker(BAR_X + BAR_W / 2, TOTAL_H - FRAME - 60 - i * CHECKER_GAP, true, `bar-p0-${i}`, isDragging);
+          })}
+          {p0Extra > 0 && (
             <text
               x={BAR_X + BAR_W / 2}
-              y={TOTAL_H - FRAME - 60 - 3 * CHECKER_GAP + 4}
+              y={TOTAL_H - FRAME - 60 - p0Combined * CHECKER_GAP + 4}
               textAnchor="middle"
               fontSize="12"
               fontFamily="var(--cg-font-mono, monospace)"
               fill="var(--cg-fg-4, #4A4339)"
             >
-              +{p0Display - 3}
+              +{p0Extra}
             </text>
           )}
         </g>
@@ -427,8 +483,9 @@ export function Board({
     // Right Tray = P0
     const [p0Off, p1Off] = off;
 
-    const p1MiniRadius = 6;
-    const p0MiniRadius = 6;
+    const arrivals = ghostArrivals[0] || 0;
+    const p0CombinedOff = p0Off + (turn === 0 ? arrivals : 0);
+    const p1CombinedOff = p1Off + (turn === 1 ? arrivals : 0);
 
     return (
       <g>
@@ -442,18 +499,22 @@ export function Board({
         />
         {/* P1 Off Mini Checkers */}
         <g pointerEvents="none">
-          {Array.from({ length: p1Off }).map((_, i) => (
-            <rect
-              key={`p1off-${i}`}
-              x={L_BEAR_X + 10}
-              y={TOTAL_H - FRAME - 20 - i * 14}
-              width={BEAR_W - 20}
-              height={10}
-              rx={3}
-              fill="url(#cg-p1)"
-              stroke="rgba(0,0,0,0.5)"
-            />
-          ))}
+          {Array.from({ length: p1CombinedOff }).map((_, i) => {
+            const isGhost = i >= p1Off;
+            return (
+              <rect
+                key={`p1off-${i}`}
+                x={L_BEAR_X + 10}
+                y={TOTAL_H - FRAME - 20 - i * 14}
+                width={BEAR_W - 20}
+                height={10}
+                rx={3}
+                fill="url(#cg-p1)"
+                stroke="rgba(0,0,0,0.5)"
+                opacity={isGhost ? 0.3 : 1}
+              />
+            );
+          })}
           <text
              x={L_BEAR_X + BEAR_W/2}
              y={TOTAL_H - FRAME - 5}
@@ -462,7 +523,7 @@ export function Board({
              fontFamily="var(--cg-font-mono, monospace)"
              fill="var(--cg-player-cool, #E8E1CF)"
           >
-            {p1Off}
+            {p1CombinedOff}
           </text>
         </g>
 
@@ -476,18 +537,22 @@ export function Board({
         />
         {/* P0 Off Mini Checkers */}
         <g pointerEvents="none">
-          {Array.from({ length: p0Off }).map((_, i) => (
-            <rect
-              key={`p0off-${i}`}
-              x={R_BEAR_X + 10}
-              y={TOTAL_H - FRAME - 20 - i * 14}
-              width={BEAR_W - 20}
-              height={10}
-              rx={3}
-              fill="url(#cg-p0)"
-              stroke="rgba(0,0,0,0.5)"
-            />
-          ))}
+          {Array.from({ length: p0CombinedOff }).map((_, i) => {
+            const isGhost = i >= p0Off;
+            return (
+              <rect
+                key={`p0off-${i}`}
+                x={R_BEAR_X + 10}
+                y={TOTAL_H - FRAME - 20 - i * 14}
+                width={BEAR_W - 20}
+                height={10}
+                rx={3}
+                fill="url(#cg-p0)"
+                stroke="rgba(0,0,0,0.5)"
+                opacity={isGhost ? 0.3 : 1}
+              />
+            );
+          })}
           <text
              x={R_BEAR_X + BEAR_W/2}
              y={TOTAL_H - FRAME - 5}
@@ -496,7 +561,7 @@ export function Board({
              fontFamily="var(--cg-font-mono, monospace)"
              fill="var(--cg-player-warm, #E3B779)"
           >
-            {p0Off}
+            {p0CombinedOff}
           </text>
         </g>
       </g>

--- a/frontend/app/ChiefOfStaffPanel.tsx
+++ b/frontend/app/ChiefOfStaffPanel.tsx
@@ -57,6 +57,7 @@ interface Props {
   turn?: 0 | 1;
   opponentId?: number;
   onMoveSelect?: (move: string) => void;
+  onMoveHover?: (move: string | null) => void;
   disabled?: boolean;
   /** When true, skip the LLM entirely — show ONNX-ranked moves only. */
   noLLM?: boolean;
@@ -115,6 +116,7 @@ export function AgentTeammatePanel({
   turn = 0,
   opponentId,
   onMoveSelect,
+  onMoveHover,
   disabled = false,
   noLLM = false,
 }: Props) {
@@ -306,6 +308,8 @@ export function AgentTeammatePanel({
                       type="button"
                       disabled={disabled}
                       onClick={() => onMoveSelect?.(c.move)}
+                      onMouseEnter={() => onMoveHover?.(c.move)}
+                      onMouseLeave={() => onMoveHover?.(null)}
                       title={c.tag_reason}
                       className={[
                         "flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs font-mono transition-shadow",

--- a/frontend/app/team-demo/page.tsx
+++ b/frontend/app/team-demo/page.tsx
@@ -125,6 +125,8 @@ function TeamDemoPageInner() {
   const [loading, setLoading] = useState(false);
   const [moveInput, setMoveInput] = useState("");
 
+  const [hoveredMove, setHoveredMove] = useState<string | null>(null);
+
   const [stagedMoves, setStagedMoves] = useState<string[]>([]);
   const [displayBoardState, setDisplayBoardState] = useState<{
     board: number[];
@@ -575,6 +577,7 @@ function TeamDemoPageInner() {
               bar={currentBar}
               off={currentOff}
               turn={game.turn}
+              ghostMove={hoveredMove}
               opponentName={
                 opponentIds.length === 1
                   ? `Agent #${opponentIds[0]}`
@@ -741,6 +744,7 @@ function TeamDemoPageInner() {
               opponentId={opponentIds[0]}
               disabled={!isHumanTurn || game.game_over}
               onMoveSelect={previewMove}
+              onMoveHover={setHoveredMove}
               noLLM={teammateIds.length === 0}
             />
           )}


### PR DESCRIPTION
…d ghost moves

Rewrites `Board.tsx` from standard DOM to an intricate, fixed-size SVG (716x440 viewBox) component according to the requested design geometry, integrating custom styling purely through variables (e.g. `--cg-p0`, `--cg-bg-felt`). Implemented SVG pointer-event-based drag-and-drop functionality that intelligently hooks into the parent's existing state machine (re-using `onPointClick` and `onDrop`) for move handling. Added an internal React `pendingDrop` state resolving the state async gap. Extended the board's functionality to visualize suggested/ghost moves. `Board.tsx` now processes a `ghostMove` prop, parsing backgammon move notations (e.g., "24/18 13/7"), and dynamically renders semi-transparent ghost checkers over destination points and fading checkers from origins. Wired this prop recursively through `team-demo/page.tsx` down from a new `onMoveHover` listener inside the AI teammate suggestion module (`ChiefOfStaffPanel.tsx`).