### PR TITLE
fix(frontend): make wrong-network banner mobile-aware, pin wagmi storage

### DIFF
--- a/frontend/app/team-demo/page.tsx
+++ b/frontend/app/team-demo/page.tsx
@@ -137,6 +137,95 @@ const card: React.CSSProperties = {
   boxShadow: "var(--cg-shadow-1)",
 };
 
+// Banner shown when the wallet is on a chain we don't deploy to (e.g.
+// mainnet) and the match needs an on-chain settlement. The dapp's
+// switchChain button calls `wallet_switchEthereumChain` on the injected
+// provider; on MetaMask Mobile this reloads the in-app browser, so the
+// banner explains what to do if the page comes back and the wallet is
+// still on the wrong chain.
+function WrongNetworkBanner({
+  walletChainName,
+  walletChainId,
+  targetChainName,
+  isSwitching,
+  switchError,
+  onSwitch,
+}: {
+  walletChainName: string | undefined;
+  walletChainId: number | undefined;
+  targetChainName: string;
+  isSwitching: boolean;
+  switchError: string | null;
+  onSwitch: () => void;
+}) {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    setIsMobile(
+      typeof navigator !== "undefined" &&
+        /Android|iPhone|iPad|iPod|IEMobile|Opera Mini/i.test(navigator.userAgent),
+    );
+  }, []);
+
+  const fromLabel =
+    walletChainName ??
+    (walletChainId !== undefined ? `chain ${walletChainId}` : "an unknown chain");
+
+  return (
+    <div
+      style={{
+        borderRadius: "var(--cg-radius-sm)",
+        border: "1px solid var(--cg-warn)",
+        background: "rgba(208,138,60,0.10)",
+        padding: "10px 14px",
+        fontSize: 13,
+        color: "var(--cg-fg-2)",
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}
+    >
+      <div>
+        Your wallet is on <strong>{fromLabel}</strong>. Switch to{" "}
+        <strong>{targetChainName}</strong> to continue.
+      </div>
+      <button
+        type="button"
+        onClick={onSwitch}
+        disabled={isSwitching}
+        style={{
+          alignSelf: "flex-start",
+          borderRadius: "var(--cg-radius-sm)",
+          border: "1px solid var(--cg-warn)",
+          background: "transparent",
+          color: "var(--cg-warn)",
+          padding: "6px 12px",
+          fontSize: 12,
+          fontWeight: 500,
+          cursor: isSwitching ? "not-allowed" : "pointer",
+          opacity: isSwitching ? 0.6 : 1,
+        }}
+      >
+        {isSwitching ? "Switching…" : `Switch to ${targetChainName}`}
+      </button>
+      {isMobile && (
+        <div style={{ fontSize: 11, color: "var(--cg-fg-3)", lineHeight: 1.5 }}>
+          On MetaMask Mobile the in-app browser may reload after the switch.
+          If the page comes back and still says wrong network, switch
+          directly inside MetaMask: tap the network selector at the top of
+          the app, pick <strong>{targetChainName}</strong>, then return to
+          this tab. Enable test networks under Settings → Advanced if{" "}
+          {targetChainName} isn&apos;t listed.
+        </div>
+      )}
+      {switchError && (
+        <span style={{ fontSize: 11, color: "var(--cg-danger)" }}>
+          {switchError}
+        </span>
+      )}
+    </div>
+  );
+}
+
 function SettlementBanner({
   status,
   txHash,
@@ -1079,57 +1168,14 @@ function TeamDemoPageInner() {
         </header>
 
         {settleOnChain && address && !walletOnSupportedChain && (
-          <div
-            style={{
-              borderRadius: "var(--cg-radius-sm)",
-              border: "1px solid var(--cg-warn)",
-              background: "rgba(208,138,60,0.10)",
-              padding: "10px 14px",
-              fontSize: 13,
-              color: "var(--cg-fg-2)",
-              display: "flex",
-              flexDirection: "column",
-              gap: 8,
-            }}
-          >
-            <div>
-              Your wallet is on{" "}
-              <strong>
-                {walletChain?.name ??
-                  (walletChainId !== undefined
-                    ? `chain ${walletChainId}`
-                    : "an unknown chain")}
-              </strong>
-              . Switch to <strong>{activeChain?.chain.name ?? "Sepolia"}</strong>{" "}
-              to continue. Don't reload — the page is waiting for the switch.
-            </div>
-            <button
-              type="button"
-              onClick={() => switchChain({ chainId })}
-              disabled={isSwitchingChain}
-              style={{
-                alignSelf: "flex-start",
-                borderRadius: "var(--cg-radius-sm)",
-                border: "1px solid var(--cg-warn)",
-                background: "transparent",
-                color: "var(--cg-warn)",
-                padding: "6px 12px",
-                fontSize: 12,
-                fontWeight: 500,
-                cursor: isSwitchingChain ? "not-allowed" : "pointer",
-                opacity: isSwitchingChain ? 0.6 : 1,
-              }}
-            >
-              {isSwitchingChain
-                ? "Switching…"
-                : `Switch to ${activeChain?.chain.name ?? "Sepolia"}`}
-            </button>
-            {switchChainError && (
-              <span style={{ fontSize: 11, color: "var(--cg-danger)" }}>
-                {switchChainError.message}
-              </span>
-            )}
-          </div>
+          <WrongNetworkBanner
+            walletChainName={walletChain?.name}
+            walletChainId={walletChainId}
+            targetChainName={activeChain?.chain.name ?? "Sepolia"}
+            isSwitching={isSwitchingChain}
+            switchError={switchChainError?.message ?? null}
+            onSwitch={() => switchChain({ chainId })}
+          />
         )}
 
         {settleOnChain && settleStatus === "awaiting-auth" && !humanAuthSig && walletOnSupportedChain && (

--- a/frontend/app/wagmi.ts
+++ b/frontend/app/wagmi.ts
@@ -4,7 +4,7 @@
 // To add a chain: edit `chains.ts`, not this file.
 
 import { http } from "viem";
-import { createConfig } from "wagmi";
+import { createConfig, createStorage, noopStorage } from "wagmi";
 // Import `injected` from `@wagmi/core` rather than `wagmi/connectors` to
 // avoid the latter's umbrella export, which transitively pulls in
 // `@wagmi/core/tempo` — that file imports a missing `accounts` package
@@ -19,6 +19,15 @@ import { walletConnect } from "@wagmi/connectors";
 import { ALL_CHAINS, CHAIN_REGISTRY } from "./chains";
 
 const transports = Object.fromEntries(ALL_CHAINS.map((c) => [c.id, http()]));
+
+// Explicit localStorage so the connection survives a page reload — required
+// for MetaMask Mobile, which reloads its in-app browser when the dapp calls
+// `wallet_switchEthereumChain`. wagmi's default storage is `localStorage`,
+// but pinning it here documents the dependency and avoids future regressions
+// (e.g. if a contributor toggles `ssr` and triggers a different default).
+const storage = createStorage({
+  storage: typeof window !== "undefined" ? window.localStorage : noopStorage,
+});
 
 // WalletConnect requires a Project ID from cloud.walletconnect.com.
 // Set NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID in your .env (or GitHub secrets
@@ -49,9 +58,7 @@ export const config = createConfig({
   connectors,
   transports,
   ssr: true,
-  // Default localStorage persistence — wagmi restores the connection on page
-  // load/refresh. "Chain not configured" toasts are suppressed by Phase 100's
-  // error-hiding logic in the UI; noopStorage is not needed here.
+  storage,
 });
 
 declare module "wagmi" {


### PR DESCRIPTION
MetaMask Mobile reloads its in-app browser when a dapp calls
`wallet_switchEthereumChain`. Reports from a mobile tester showed the
"Switch to Sepolia" button looking broken: the user approves the switch
in MetaMask, the page reloads, and the in-app browser sometimes loses
the wagmi session — so the dapp comes back still showing "Wrong network"
or, worse, disconnected. Two changes target the two failure modes.

Wagmi storage (**frontend/app/wagmi.ts**, updated):
- Pass an explicit `createStorage({ storage: localStorage })` to
  `createConfig` so the wagmi state and connector identity survive a
  page reload regardless of how `ssr` defaults evolve.
- `noopStorage` is used during SSR / SSG where `window` is undefined.
- This was wagmi's default anyway, but pinning it documents the
  dependency (reload-survival) and prevents regressions if a contributor
  toggles `ssr` and inadvertently changes the default storage.

Wrong-network banner (**frontend/app/team-demo/page.tsx**, new component):
- Extract the inline banner into a `WrongNetworkBanner` component.
- On mobile user agents, append a hint explaining that MetaMask Mobile
  may reload after the dapp-triggered switch, and that the user can
  switch directly inside MetaMask (network selector at the top of the
  app) as a more reliable alternative — including the "enable test
  networks under Settings → Advanced" pointer for users whose MetaMask
  hides Sepolia by default.
- Drops the now-misleading "Don't reload" instruction since MetaMask
  Mobile reloads regardless of what the page asks.