### PR TITLE
feat(frontend): Visualize ghost moves with colored halos and dotted trajectories

### DIFF
--- a/frontend/app/Board.tsx
+++ b/frontend/app/Board.tsx
@@ -78,22 +78,33 @@ export function Board({
   // Parse ghostMove into an array of {from, to} segments for visualization
   const previewSegments = React.useMemo(() => {
     if (!ghostMove) return [];
-    return ghostMove.split(/\s+/).filter(Boolean).map(seg => {
+    return ghostMove.split(/\s+/).filter(Boolean).map((seg, index) => {
       const parts = seg.split("/");
       if (parts.length !== 2) return null;
       const from = parts[0] === "bar" ? 25 : parseInt(parts[0], 10);
       const to = parts[1] === "off" ? 0 : parseInt(parts[1], 10);
       if (isNaN(from) || isNaN(to)) return null;
-      return { from, to };
-    }).filter(Boolean) as { from: number; to: number }[];
+      return { from, to, segIndex: index };
+    }).filter(Boolean) as { from: number; to: number, segIndex: number }[];
   }, [ghostMove]);
 
+  const GHOST_COLORS = [
+    "#34d399", // emerald-400
+    "#60a5fa", // blue-400
+    "#f472b6", // pink-400
+    "#fbbf24", // amber-400
+    "#a78bfa", // violet-400
+  ];
+
   // Aggregate ghost states per point
-  const ghostDepartures: Record<number, number> = {};
-  const ghostArrivals: Record<number, number> = {};
+  const ghostDepartures: Record<number, number[]> = {};
+  const ghostArrivals: Record<number, number[]> = {};
   previewSegments.forEach(seg => {
-    ghostDepartures[seg.from] = (ghostDepartures[seg.from] || 0) + 1;
-    ghostArrivals[seg.to] = (ghostArrivals[seg.to] || 0) + 1;
+    if (!ghostDepartures[seg.from]) ghostDepartures[seg.from] = [];
+    ghostDepartures[seg.from].push(seg.segIndex);
+
+    if (!ghostArrivals[seg.to]) ghostArrivals[seg.to] = [];
+    ghostArrivals[seg.to].push(seg.segIndex);
   });
 
   const turnLabel = turn === 0 ? "Your turn" : `${opponentName ?? "Agent"}'s turn`;
@@ -102,6 +113,38 @@ export function Board({
   const getColXOffset = (col: number, rightHalf: boolean) => {
     const baseX = rightHalf ? R_QUAD_X : L_QUAD_X;
     return baseX + col * POINT_W;
+  };
+
+  const getCheckerCenter = (point: number | "bar" | "off", index: number, isP0: boolean) => {
+    if (point === "bar") {
+      const cy = isP0
+        ? TOTAL_H - FRAME - 60 - index * CHECKER_GAP
+        : FRAME + 60 + index * CHECKER_GAP;
+      return { x: BAR_X + BAR_W / 2, y: cy };
+    }
+
+    if (point === "off") {
+      const x = isP0 ? R_BEAR_X + BEAR_W / 2 : L_BEAR_X + BEAR_W / 2;
+      const cy = TOTAL_H - FRAME - 20 - index * 14 + 5; // +5 for middle of the 10px rect
+      return { x, y: cy };
+    }
+
+    const isTop = point >= 13;
+    const isLeft = (isTop && point <= 18) || (!isTop && point >= 7);
+    let col = 0;
+    if (isTop) {
+      col = isLeft ? point - 13 : point - 19;
+    } else {
+      col = isLeft ? 12 - point : 6 - point;
+    }
+    const startX = getColXOffset(col, !isLeft);
+    const x = startX + POINT_W / 2;
+
+    const cy = isTop
+      ? FRAME + CHECKER_R + index * CHECKER_GAP
+      : TOTAL_H - FRAME - CHECKER_R - index * CHECKER_GAP;
+
+    return { x, y: cy };
   };
 
   const clientToSvg = (clientX: number, clientY: number) => {
@@ -207,15 +250,26 @@ export function Board({
     }
   };
 
-  const renderChecker = (cx: number, cy: number, isP0: boolean, key: string, isDragging: boolean = false) => {
+  const renderChecker = (cx: number, cy: number, isP0: boolean, key: string, isDragging: boolean = false, haloColor?: string) => {
     return (
       <g key={key} style={{ pointerEvents: "none" }}>
+        {haloColor && (
+          <circle
+            cx={cx}
+            cy={cy}
+            r={CHECKER_R + 2}
+            fill="none"
+            stroke={haloColor}
+            strokeWidth="3"
+            opacity={0.8}
+          />
+        )}
         <circle
           cx={cx}
           cy={cy}
           r={CHECKER_R}
           fill={isP0 ? "url(#cg-p0)" : "url(#cg-p1)"}
-          stroke="rgba(0,0,0,0.5)"
+          stroke={haloColor ? haloColor : "rgba(0,0,0,0.5)"}
           strokeWidth="1"
           opacity={isDragging ? 0.3 : 1}
         />
@@ -256,8 +310,10 @@ export function Board({
 
     const isDragSource = dragState?.fromPoint === point;
     // Preview departures
-    const departures = ghostDepartures[point] || 0;
-    const arrivals = ghostArrivals[point] || 0;
+    const departuresArr = ghostDepartures[point] || [];
+    const arrivalsArr = ghostArrivals[point] || [];
+    const departures = departuresArr.length;
+    const arrivals = arrivalsArr.length;
 
     // Visually, if we're dragging from here or departing, we show fewer real checkers
     const displayCount = Math.max(0, absCount - (isDragSource ? 1 : 0) - departures);
@@ -337,22 +393,31 @@ export function Board({
             // Determine if this specific dot is solid, a departure ghost, or an arrival ghost
             let isDragging = false;
             let dotIsP0 = isP0;
+            let haloColor: string | undefined;
 
             if (i >= displayCount) {
               if (i < displayCount + departures) {
                 // It's a departing checker (show as transparent)
                 isDragging = true;
                 dotIsP0 = count > 0;
+                const depIndex = i - displayCount;
+                if (depIndex < departuresArr.length) {
+                   haloColor = GHOST_COLORS[departuresArr[depIndex] % GHOST_COLORS.length];
+                }
               } else {
                 // It's an arriving checker (show as transparent ghost belonging to current turn)
                 isDragging = true;
                 dotIsP0 = turn === 0;
+                const arrIndex = i - (displayCount + departures);
+                if (arrIndex < arrivalsArr.length) {
+                   haloColor = GHOST_COLORS[arrivalsArr[arrIndex] % GHOST_COLORS.length];
+                }
               }
             } else {
               dotIsP0 = count > 0;
             }
 
-            return renderChecker(startX + POINT_W / 2, cy, dotIsP0, `checker-${point}-${i}`, isDragging);
+            return renderChecker(startX + POINT_W / 2, cy, dotIsP0, `checker-${point}-${i}`, isDragging, haloColor);
           })}
           {extra > 0 && (
             <text
@@ -377,7 +442,8 @@ export function Board({
     const isSelected = selectedPoint === 25;
     const [p0Bar, p1Bar] = bar;
 
-    const p0Departures = ghostDepartures[25] || 0;
+    const p0DeparturesArr = ghostDepartures[25] || [];
+    const p0Departures = p0DeparturesArr.length;
     // p1 bar is not playable by the human turn, so we don't ghost it
     const p0Display = Math.max(0, p0Bar - (dragState?.fromPoint === "bar" ? 1 : 0) - p0Departures);
     const p0Combined = Math.min(p0Display + p0Departures, 3);
@@ -455,7 +521,14 @@ export function Board({
         <g pointerEvents="none">
           {Array.from({ length: p0Combined }).map((_, i) => {
             const isDragging = i >= p0Display;
-            return renderChecker(BAR_X + BAR_W / 2, TOTAL_H - FRAME - 60 - i * CHECKER_GAP, true, `bar-p0-${i}`, isDragging);
+            let haloColor: string | undefined;
+            if (isDragging) {
+              const depIndex = i - p0Display;
+              if (depIndex < p0DeparturesArr.length) {
+                haloColor = GHOST_COLORS[p0DeparturesArr[depIndex] % GHOST_COLORS.length];
+              }
+            }
+            return renderChecker(BAR_X + BAR_W / 2, TOTAL_H - FRAME - 60 - i * CHECKER_GAP, true, `bar-p0-${i}`, isDragging, haloColor);
           })}
           {p0Extra > 0 && (
             <text
@@ -477,7 +550,8 @@ export function Board({
   const renderBearOff = () => {
     const [p0Off, p1Off] = off;
 
-    const arrivals = ghostArrivals[0] || 0;
+    const arrivalsArr = ghostArrivals[0] || [];
+    const arrivals = arrivalsArr.length;
     const p0CombinedOff = p0Off + (turn === 0 ? arrivals : 0);
     const p1CombinedOff = p1Off + (turn === 1 ? arrivals : 0);
 
@@ -505,7 +579,8 @@ export function Board({
                 height={10}
                 rx={3}
                 fill="url(#cg-p1)"
-                stroke="rgba(0,0,0,0.5)"
+                stroke={isGhost && arrivalsArr[i - p1Off] !== undefined ? GHOST_COLORS[arrivalsArr[i - p1Off] % GHOST_COLORS.length] : "rgba(0,0,0,0.5)"}
+                strokeWidth={isGhost ? 2 : 1}
                 opacity={isGhost ? 0.3 : 1}
               />
             );
@@ -543,7 +618,8 @@ export function Board({
                 height={10}
                 rx={3}
                 fill="url(#cg-p0)"
-                stroke="rgba(0,0,0,0.5)"
+                stroke={isGhost && arrivalsArr[i - p0Off] !== undefined ? GHOST_COLORS[arrivalsArr[i - p0Off] % GHOST_COLORS.length] : "rgba(0,0,0,0.5)"}
+                strokeWidth={isGhost ? 2 : 1}
                 opacity={isGhost ? 0.3 : 1}
               />
             );
@@ -631,6 +707,65 @@ export function Board({
 
           {/* Center Bar */}
           {renderBar()}
+
+          {/* Dotted Connecting Lines for Ghost Moves */}
+          <g style={{ pointerEvents: "none" }}>
+            {previewSegments.map((seg) => {
+              // Find the indices for this segment in departures/arrivals arrays
+              const depArr = ghostDepartures[seg.from] || [];
+              const arrArr = ghostArrivals[seg.to] || [];
+              const depIndex = depArr.indexOf(seg.segIndex);
+              const arrIndex = arrArr.indexOf(seg.segIndex);
+
+              if (depIndex === -1 || arrIndex === -1) return null;
+
+              // We need to calculate the actual stacked index on the board to position the line
+              let fromDisplayIndex = 0;
+              if (seg.from === 25) {
+                // Bar (P0 is the only human bar we support ghosting from)
+                const p0Display = Math.max(0, bar[0] - (dragState?.fromPoint === "bar" ? 1 : 0) - depArr.length);
+                fromDisplayIndex = p0Display + depIndex;
+              } else {
+                const count = board[seg.from - 1] || 0;
+                const isDragSource = dragState?.fromPoint === seg.from;
+                const absCount = Math.abs(count);
+                const displayCount = Math.max(0, absCount - (isDragSource ? 1 : 0) - depArr.length);
+                fromDisplayIndex = displayCount + depIndex;
+              }
+
+              let toDisplayIndex = 0;
+              if (seg.to === 0) {
+                 // Off
+                 toDisplayIndex = (turn === 0 ? off[0] : off[1]) + arrIndex;
+              } else {
+                 const count = board[seg.to - 1] || 0;
+                 const isDragSource = dragState?.fromPoint === seg.to;
+                 const absCount = Math.abs(count);
+                 const displayCount = Math.max(0, absCount - (isDragSource ? 1 : 0) - (ghostDepartures[seg.to]?.length || 0));
+                 const baseIndex = displayCount + (ghostDepartures[seg.to]?.length || 0);
+                 toDisplayIndex = baseIndex + arrIndex;
+              }
+
+              const fromCenter = getCheckerCenter(seg.from === 25 ? "bar" : seg.from, Math.min(fromDisplayIndex, MAX_DOTS - 1), turn === 0);
+              const toCenter = getCheckerCenter(seg.to === 0 ? "off" : seg.to, seg.to === 0 ? toDisplayIndex : Math.min(toDisplayIndex, MAX_DOTS - 1), turn === 0);
+
+              const color = GHOST_COLORS[seg.segIndex % GHOST_COLORS.length];
+
+              return (
+                <line
+                  key={`ghost-line-${seg.segIndex}`}
+                  x1={fromCenter.x}
+                  y1={fromCenter.y}
+                  x2={toCenter.x}
+                  y2={toCenter.y}
+                  stroke={color}
+                  strokeWidth="3"
+                  strokeDasharray="6, 6"
+                  opacity={0.6}
+                />
+              );
+            })}
+          </g>
 
           {/* Drag Ghost */}
           {dragState && (


### PR DESCRIPTION
This commit visualizes suggested ghost moves on the backgammon board more clearly by differentiating multi-checker moves with unique colors, adding a visual halo ring around origin and destination points, and drawing a dotted trajectory line to trace the exact movement path across the board.

---
*PR created automatically by Jules for task [18057864651689476346](https://jules.google.com/task/18057864651689476346) started by @oslinin*