### PR TITLE
Fix internal navigation and improve header responsiveness

### DIFF
--- a/frontend/app/PersonCard.tsx
+++ b/frontend/app/PersonCard.tsx
@@ -2,6 +2,10 @@
 
 import Link from "next/link";
 
+// Next.js's <Link> auto-prepends the configured basePath (e.g. "/chaingammon"
+// on GitHub Pages); a plain <a href="/agent/1"> would resolve to the apex
+// path and 404. Keep all internal navigation on <Link>.
+
 export interface MatchSummary {
   matches: number;
   wins: number;
@@ -73,7 +77,7 @@ export function PersonCard({
         </h3>
         <div style={{ display: "flex", flexShrink: 0, alignItems: "center", gap: 4 }}>
           {infoHref && (
-            <a
+            <Link
               href={infoHref}
               target="_blank"
               rel="noreferrer"
@@ -101,7 +105,7 @@ export function PersonCard({
               }}
             >
               Info ↗
-            </a>
+            </Link>
           )}
           {infoLabel && (
             <span

--- a/frontend/app/agent/[agentId]/AgentClient.tsx
+++ b/frontend/app/agent/[agentId]/AgentClient.tsx
@@ -316,7 +316,7 @@ export default function AgentClient() {
     >
       <header
         data-testid="agent-info-header"
-        className="flex items-center justify-between border-b border-zinc-200 px-8 py-4 dark:border-zinc-800"
+        className="flex items-center justify-between gap-2 border-b border-zinc-200 px-4 py-4 sm:px-8 dark:border-zinc-800"
       >
         <Link
           href="/"


### PR DESCRIPTION
## Summary
This PR fixes internal navigation to use Next.js `<Link>` component consistently and improves the agent header layout responsiveness on smaller screens.

## Key Changes
- **PersonCard.tsx**: Replaced plain `<a>` tag with Next.js `<Link>` component for the info link to ensure proper basePath handling on GitHub Pages deployments. Added explanatory comment about why internal navigation must use `<Link>`.
- **AgentClient.tsx**: Updated agent info header styling to be more responsive:
  - Added `gap-2` for consistent spacing between header items
  - Changed horizontal padding from fixed `px-8` to responsive `px-4 sm:px-8` (smaller on mobile, larger on desktop)

## Implementation Details
The `<Link>` component change ensures that internal navigation respects the configured basePath (e.g., "/chaingammon" on GitHub Pages), preventing 404 errors that would occur with plain `<a href>` tags that resolve to the apex path.

https://claude.ai/code/session_01KGrUC5uoWkciqWe22kdeEo