### PR TITLE
fix(frontend): auto-skip human turn when bar-danced; return [] for no legal moves

### DIFF
--- a/frontend/app/team-demo/page.tsx
+++ b/frontend/app/team-demo/page.tsx
@@ -38,6 +38,7 @@ import {
   newMatch,
   applyMoveToState,
   getBestMove,
+  hasLegalMoves,
   skipTurn,
   playMatchToEnd,
   resignMatch,
@@ -740,6 +741,23 @@ function TeamDemoPageInner() {
     }, 800);
     return () => clearTimeout(timer);
   }, [game, setup, fastForward]);
+
+  // Auto-skip the human's turn when they have no legal moves (bar-dance
+  // against a closed home board, or a roll that leaves nothing playable).
+  // Without this the UI just shows the dice and waits for a move that
+  // can't exist, and any attempt prints "Illegal move".
+  useEffect(() => {
+    if (setup || !game || game.game_over) return;
+    if (game.turn !== 0 || !game.dice) return;
+    if (stagedMoves.length > 0) return;
+    const gboard: GameBoard = { points: game.board, bar: game.bar, off: game.off };
+    if (hasLegalMoves(gboard, 0, game.dice)) return;
+    const timer = setTimeout(() => {
+      const skipped = skipTurn(game);
+      setGame(skipped.game_over ? skipped : { ...skipped, dice: rollDice() });
+    }, 600);
+    return () => clearTimeout(timer);
+  }, [game, setup, stagedMoves.length]);
 
   useEffect(() => {
     if (!fastForward || !game || game.game_over) return;

--- a/frontend/lib/rules_engine.ts
+++ b/frontend/lib/rules_engine.ts
@@ -331,6 +331,12 @@ export function generateLegalMoves(board: Board, side: number, dice: [number, nu
 
   // Rule 1: Must play as many dice as possible.
   const maxLen = Math.max(...sequences.map(s => s.length));
+  // Bar-dance / fully blocked: the only "sequence" is the empty one
+  // (backtrack records [] when getSingleMoves returns []). Returning
+  // [""] from here lets callers like hasLegalMoves and the advisor
+  // mistake "no moves" for "one no-op move" — the human ends up stuck
+  // because the auto-skip path never fires.
+  if (maxLen === 0) return [];
   let validSeqs = sequences.filter(s => s.length === maxLen);
 
   // Rule 2: If we can only play one die of a non-double roll, we must play the larger one if possible.

--- a/frontend/tests/rules_engine.spec.ts
+++ b/frontend/tests/rules_engine.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
-import { generateLegalMoves, OPENING_BOARD, encodeFullBoard } from "../lib/rules_engine";
+import { generateLegalMoves, OPENING_BOARD, encodeFullBoard, type Board } from "../lib/rules_engine";
+import { hasLegalMoves } from "../lib/match_engine";
 
 test("generateLegalMoves opening board", () => {
     // Player 0 opening roll 3-1
@@ -7,6 +8,29 @@ test("generateLegalMoves opening board", () => {
     expect(moves.length).toBeGreaterThan(0);
     // Typical 3-1 moves like 8/5 6/5
     expect(moves).toContain("8/5 6/5");
+});
+
+test("generateLegalMoves returns [] when bar-danced against a closed home board", () => {
+    // Player 0 has a checker on the bar; opponent (player 1) has all six
+    // points 19-24 closed (≥2 negative checkers each), so a 6-6 roll
+    // leaves no legal entry. Previously this returned [""] (one no-op
+    // "move") which made the human-turn auto-skip never fire and the
+    // advisor render an empty AGGRESSIVE row.
+    const points = new Array(24).fill(0);
+    // Close points 19..24 with 2 opponent checkers each. Distribute the
+    // remaining 3 opponent checkers safely on point 13.
+    for (let p = 19; p <= 24; p++) points[p - 1] = -2;
+    points[13 - 1] = -3;
+    // Place player 0's other 14 checkers safely on points 1..6.
+    for (let p = 1; p <= 6; p++) points[p - 1] = 2;
+    points[6 - 1] = 4;
+    const board: Board = {
+        points,
+        bar: [1, 0],
+        off: [0, 0],
+    };
+    expect(generateLegalMoves(board, 0, [6, 6])).toEqual([]);
+    expect(hasLegalMoves(board, 0, [6, 6])).toBe(false);
 });
 
 test("encodeFullBoard produces Float32Array of length 198", () => {


### PR DESCRIPTION
## Summary

When the human player was bar-danced (a checker on the bar against a fully closed home board), the UI sat there waiting for a move that couldn't exist, and any attempt printed `Illegal move: bar/19 bar/19`. The move advisor simultaneously rendered a ghost `AGGRESSIVE +0.743` row with no move text.

Single root cause: `generateLegalMoves` returned `[""]` (one empty-string "move") instead of `[]` when the longest backtracking sequence had length 0. The formatter joins the empty parts list to `""` and `Set.add("")` makes it look like one legal move to every caller.

## Fix

- `frontend/lib/rules_engine.ts` — return `[]` when `maxLen === 0` (the only sequence found was the empty one). Single-line guard, with a comment explaining the failure mode.
- `frontend/app/team-demo/page.tsx` — add a human-turn auto-skip `useEffect` that mirrors the existing agent-turn auto-skip. Fires after a 600ms beat when `hasLegalMoves(board, 0, dice)` is false and no moves are staged.

## Regression test

`frontend/tests/rules_engine.spec.ts` constructs a bar-dance position (P0 on the bar, P1's 19-24 all closed, roll 6-6) and asserts:

- `generateLegalMoves(...).toEqual([])`
- `hasLegalMoves(...).toBe(false)`

To answer the bug report directly &mdash; **no, there wasn't a test for this before**; the existing rules-engine spec only covered the opening board. With the fix removed, the new test fails on `expect([""]).toEqual([])`.

## Test plan

- [ ] `cd frontend && pnpm exec playwright test tests/rules_engine.spec.ts` &mdash; both tests pass.
- [ ] On `/team-demo`, force a bar-dance (P0 on bar, opponent's home board closed, roll 6-6): the turn auto-skips after ~600ms instead of getting stuck, and the move advisor goes empty rather than showing a phantom `AGGRESSIVE` row.

I couldn't run Playwright in the sandbox (dev server needs compiled contract artifacts; `solc` download is blocked here), but `tsc --noEmit` passes and a standalone sanity script verifies both branches of `generateLegalMoves`: opening board → 31 moves, bar-dance → `[]`.

https://claude.ai/code/session_01KGrUC5uoWkciqWe22kdeEo

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGrUC5uoWkciqWe22kdeEo)_