### PR TITLE
feat: add Settings page with i18n and trainer mode configuration

### DIFF
--- a/frontend/app/BoardThemePicker.tsx
+++ b/frontend/app/BoardThemePicker.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useI18n } from "./i18n";
 import { BOARD_THEMES, THEME_ORDER, type BoardThemeKey } from "./boardThemes";
 
 interface Props {
@@ -8,6 +9,7 @@ interface Props {
 }
 
 export function BoardThemePicker({ value, onChange }: Props) {
+  const { t } = useI18n();
   return (
     <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
       <span style={{
@@ -19,7 +21,7 @@ export function BoardThemePicker({ value, onChange }: Props) {
         fontWeight: 600,
         whiteSpace: "nowrap",
       }}>
-        Board
+        {t('board_theme')}
       </span>
       <div style={{ display: "flex", gap: 6 }}>
         {THEME_ORDER.map((key) => {

--- a/frontend/app/HeaderLinks.tsx
+++ b/frontend/app/HeaderLinks.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Link from "next/link";
+import { useI18n } from "./i18n";
+
+export function HeaderLinks() {
+  const { t } = useI18n();
+
+  return (
+    <>
+      <Link
+        href="/help"
+        target="_blank"
+        rel="noreferrer"
+        className="cg-nav-link"
+        style={{
+          fontSize: 13,
+          textDecoration: "none",
+          fontFamily: "var(--cg-font-sans)",
+          padding: "4px 8px",
+          borderRadius: "var(--cg-radius-sm)",
+        }}
+      >
+        {t("help")}
+      </Link>
+      <Link
+        href="/settings"
+        className="cg-nav-link"
+        style={{
+          fontSize: 13,
+          textDecoration: "none",
+          fontFamily: "var(--cg-font-sans)",
+          padding: "4px 8px",
+          borderRadius: "var(--cg-radius-sm)",
+        }}
+      >
+        {t("settings")}
+      </Link>
+    </>
+  );
+}

--- a/frontend/app/MobileNav.tsx
+++ b/frontend/app/MobileNav.tsx
@@ -6,9 +6,11 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { useI18n } from "./i18n";
 
 export function MobileNav() {
   const [lastAgentId, setLastAgentId] = useState<number | null>(null);
+  const { t } = useI18n();
 
   useEffect(() => {
     const stored = window.localStorage.getItem("lastAgentId");
@@ -29,10 +31,10 @@ export function MobileNav() {
       className="fixed bottom-0 left-0 right-0 z-50 flex border-t border-zinc-200 bg-white md:hidden dark:border-zinc-800 dark:bg-zinc-950"
     >
       <Link href="/" data-testid="mobile-nav-home" className={linkClass}>
-        Home
+        {t("home")}
       </Link>
       <Link href={playHref} data-testid="mobile-nav-play" className={linkClass}>
-        Play
+        {t("play")}
       </Link>
     </nav>
   );

--- a/frontend/app/i18n.tsx
+++ b/frontend/app/i18n.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+export type Language = "en" | "es" | "tr" | "ru" | "uk";
+
+export const LANGUAGES: Record<Language, string> = {
+  en: "English",
+  es: "Spanish",
+  tr: "Turkish",
+  ru: "Russian",
+  uk: "Ukrainian",
+};
+
+const DICTIONARY: Record<Language, Record<string, string>> = {
+  en: {
+    home: "Home",
+    play: "Play",
+    help: "Help",
+    settings: "Settings",
+    language: "Language",
+    board_theme: "Board Theme",
+    trainer_mode: "Trainer Mode",
+    round_robin: "Round Robin",
+    challenge_trainer: "Challenge Trainer",
+  },
+  es: {
+    home: "Inicio",
+    play: "Jugar",
+    help: "Ayuda",
+    settings: "Ajustes",
+    language: "Idioma",
+    board_theme: "Tema del Tablero",
+    trainer_mode: "Modo Entrenador",
+    round_robin: "Round Robin",
+    challenge_trainer: "Entrenador de Retos",
+  },
+  tr: {
+    home: "Ana Sayfa",
+    play: "Oyna",
+    help: "Yardım",
+    settings: "Ayarlar",
+    language: "Dil",
+    board_theme: "Tahta Teması",
+    trainer_mode: "Eğitmen Modu",
+    round_robin: "Round Robin",
+    challenge_trainer: "Meydan Okuma Eğitmeni",
+  },
+  ru: {
+    home: "Главная",
+    play: "Играть",
+    help: "Помощь",
+    settings: "Настройки",
+    language: "Язык",
+    board_theme: "Тема доски",
+    trainer_mode: "Режим тренера",
+    round_robin: "Круговой турнир",
+    challenge_trainer: "Тренер-челлендж",
+  },
+  uk: {
+    home: "Головна",
+    play: "Грати",
+    help: "Допомога",
+    settings: "Налаштування",
+    language: "Мова",
+    board_theme: "Тема дошки",
+    trainer_mode: "Режим тренера",
+    round_robin: "Круговий турнір",
+    challenge_trainer: "Тренер-челендж",
+  },
+};
+
+interface I18nContextValue {
+  language: Language;
+  setLanguage: (lang: Language) => void;
+  t: (key: string) => string;
+}
+
+const I18nContext = createContext<I18nContextValue>({
+  language: "en",
+  setLanguage: () => {},
+  t: (key) => key,
+});
+
+export function I18nProvider({ children }: { children: React.ReactNode }) {
+  const [language, setLanguageState] = useState<Language>("en");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const saved = localStorage.getItem("app_language") as Language;
+    if (saved && LANGUAGES[saved]) {
+      setLanguageState(saved);
+    }
+  }, []);
+
+  const setLanguage = (lang: Language) => {
+    setLanguageState(lang);
+    localStorage.setItem("app_language", lang);
+  };
+
+  const t = (key: string) => {
+    const translation = DICTIONARY[language]?.[key] || DICTIONARY["en"]?.[key] || key;
+    return translation;
+  };
+
+  // If not mounted yet, render children with default English to prevent hydration mismatch
+  if (!mounted) {
+    return (
+      <I18nContext.Provider value={{ language: "en", setLanguage, t }}>
+        {children}
+      </I18nContext.Provider>
+    );
+  }
+
+  return (
+    <I18nContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </I18nContext.Provider>
+  );
+}
+
+export function useI18n() {
+  return useContext(I18nContext);
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -7,6 +7,7 @@ import type { Metadata, Viewport } from "next";
 import { Space_Grotesk, JetBrains_Mono, Instrument_Serif } from "next/font/google";
 import Link from "next/link";
 import "./globals.css";
+import { HeaderLinks } from "./HeaderLinks";
 import { ComputeBackendsPill } from "./ComputeBackendsPill";
 import { ConnectButton } from "./ConnectButton";
 import { Providers } from "./providers";
@@ -102,21 +103,7 @@ export default function RootLayout({
                   <span className="hidden md:block">
                     <ComputeBackendsPill />
                   </span>
-                  <Link
-                    href="/help"
-                    target="_blank"
-                    rel="noreferrer"
-                    className="cg-nav-link"
-                    style={{
-                      fontSize: 13,
-                      textDecoration: "none",
-                      fontFamily: "var(--cg-font-sans)",
-                      padding: "4px 8px",
-                      borderRadius: "var(--cg-radius-sm)",
-                    }}
-                  >
-                    Help
-                  </Link>
+                  <HeaderLinks />
                   <ConnectButton />
                 </div>
               </header>

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from "react";
 import { ComputeBackendsProvider } from "./ComputeBackendsContext";
 import { config } from "./wagmi";
 import { warmupOnnx } from "../lib/onnx_eval";
+import { I18nProvider } from "./i18n";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   // One QueryClient per render tree, kept stable across renders. Avoids
@@ -26,7 +27,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <WagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>
-        <ComputeBackendsProvider>{children}</ComputeBackendsProvider>
+        <ComputeBackendsProvider>
+          <I18nProvider>{children}</I18nProvider>
+        </ComputeBackendsProvider>
       </QueryClientProvider>
     </WagmiProvider>
   );

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useI18n, LANGUAGES, Language } from "../i18n";
+import { BoardThemePicker } from "../BoardThemePicker";
+import { loadTheme, saveTheme, type BoardThemeKey } from "../boardThemes";
+
+export default function SettingsPage() {
+  const { language, setLanguage, t } = useI18n();
+  const [boardTheme, setBoardTheme] = useState<BoardThemeKey>("walnut");
+  const [trainerMode, setTrainerMode] = useState<string>("round_robin");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    setBoardTheme(loadTheme());
+    const savedTrainerMode = localStorage.getItem("trainer_mode");
+    if (savedTrainerMode === "round_robin" || savedTrainerMode === "challenge") {
+      setTrainerMode(savedTrainerMode);
+    }
+  }, []);
+
+  const handleTrainerModeChange = (mode: string) => {
+    setTrainerMode(mode);
+    localStorage.setItem("trainer_mode", mode);
+  };
+
+  if (!mounted) {
+    return null; // Avoid hydration mismatch
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-8">
+      <h1 className="mb-8 text-2xl font-semibold text-zinc-100" style={{ fontFamily: "var(--cg-font-display)" }}>
+        {t("settings")}
+      </h1>
+
+      <div className="space-y-8">
+        {/* Language Selection */}
+        <section>
+          <h2 className="mb-4 text-sm font-semibold tracking-wider text-zinc-400 uppercase">
+            {t("language")}
+          </h2>
+          <select
+            value={language}
+            onChange={(e) => setLanguage(e.target.value as Language)}
+            className="w-full max-w-xs rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2 text-sm text-zinc-300 focus:border-zinc-700 focus:outline-none focus:ring-1 focus:ring-zinc-700"
+          >
+            {(Object.entries(LANGUAGES) as [Language, string][]).map(([code, name]) => (
+              <option key={code} value={code}>
+                {name}
+              </option>
+            ))}
+          </select>
+        </section>
+
+        {/* Board Theme Selection */}
+        <section>
+          <h2 className="mb-4 text-sm font-semibold tracking-wider text-zinc-400 uppercase">
+            {t("board_theme")}
+          </h2>
+          <BoardThemePicker
+            value={boardTheme}
+            onChange={(k) => {
+              setBoardTheme(k);
+              saveTheme(k);
+            }}
+          />
+        </section>
+
+        {/* Trainer Mode Selection */}
+        <section>
+          <h2 className="mb-4 text-sm font-semibold tracking-wider text-zinc-400 uppercase">
+            {t("trainer_mode")}
+          </h2>
+          <div className="space-y-3">
+            <label className="flex items-center gap-3 text-sm text-zinc-300">
+              <input
+                type="radio"
+                name="trainer_mode"
+                value="round_robin"
+                checked={trainerMode === "round_robin"}
+                onChange={() => handleTrainerModeChange("round_robin")}
+                className="h-4 w-4 border-zinc-700 bg-zinc-900 text-zinc-100 focus:ring-zinc-700 focus:ring-offset-zinc-900"
+              />
+              {t("round_robin")}
+            </label>
+            <label className="flex items-center gap-3 text-sm text-zinc-300">
+              <input
+                type="radio"
+                name="trainer_mode"
+                value="challenge"
+                checked={trainerMode === "challenge"}
+                onChange={() => handleTrainerModeChange("challenge")}
+                className="h-4 w-4 border-zinc-700 bg-zinc-900 text-zinc-100 focus:ring-zinc-700 focus:ring-offset-zinc-900"
+              />
+              {t("challenge_trainer")}
+            </label>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/team-demo/page.tsx
+++ b/frontend/app/team-demo/page.tsx
@@ -26,7 +26,6 @@ import {
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
 import { Board } from "../Board";
-import { BoardThemePicker } from "../BoardThemePicker";
 import { loadTheme, saveTheme, type BoardThemeKey } from "../boardThemes";
 import { AgentTeammatePanel } from "../ChiefOfStaffPanel";
 import { DiceRoll } from "../DiceRoll";
@@ -1252,12 +1251,7 @@ function TeamDemoPageInner() {
 
         {game && (
           <div className="flex flex-col gap-6">
-            <div className="flex justify-end">
-              <BoardThemePicker
-                value={boardTheme}
-                onChange={(k) => { setBoardTheme(k); saveTheme(k); }}
-              />
-            </div>
+
             <Board
               board={currentBoard}
               bar={currentBar}

--- a/frontend/app/training/page.tsx
+++ b/frontend/app/training/page.tsx
@@ -341,12 +341,14 @@ export default function TrainingPage() {
 
   const startLocalMutation = useMutation({
     mutationFn: async (target: string = SERVER) => {
+      const trainerMode = window.localStorage.getItem("trainer_mode") || "round_robin";
       const r = await fetch(`${target}/training/start`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           epochs,
           agent_ids: selectedIds,
+          trainer_mode: trainerMode,
           use_0g_inference: use0gInference,
           use_0g_coaching: use0gCoaching,
           upload_to_0g: true,

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1213,6 +1213,7 @@ class StartTrainingRequest(BaseModel):
     use_0g_coaching: bool = False
     extras_dim: int = 16
     seed: int = 42
+    trainer_mode: str = "round_robin"
     # When True, save a checkpoint per agent at end of run and upload to
     # 0G Storage. Auto-derived as True when any 0G backend is selected
     # (inference or coaching), because the user has signalled 0G intent.
@@ -1238,6 +1239,7 @@ def post_training_start(req: StartTrainingRequest):
         job = start_job(
             epochs=req.epochs,
             agent_ids=req.agent_ids,
+            trainer_mode=req.trainer_mode,
             use_0g_inference=req.use_0g_inference,
             use_0g_coaching=req.use_0g_coaching,
             extras_dim=req.extras_dim,

--- a/server/app/training_service.py
+++ b/server/app/training_service.py
@@ -42,6 +42,7 @@ from .agent_wallets import AgentWalletManager
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _AGENT_DIR = _REPO_ROOT / "agent"
 _TRAINER = _AGENT_DIR / "round_robin_trainer.py"
+_CHALLENGE_TRAINER = _AGENT_DIR / "challenge_trainer.py"
 
 
 # Used by /training/estimate when use_0g_inference is true. Calibrated
@@ -111,6 +112,7 @@ def start_job(
     *,
     epochs: int,
     agent_ids: list[int],
+    trainer_mode: str = "round_robin",
     use_0g_inference: bool = False,
     use_0g_coaching: bool = False,
     extras_dim: int = 16,
@@ -160,9 +162,10 @@ def start_job(
     # are available without requiring uv in the subprocess's PATH.
     _agent_python = _AGENT_DIR / ".venv" / "bin" / "python"
     _trainer_exe = str(_agent_python) if _agent_python.exists() else sys.executable
+    target_trainer = _CHALLENGE_TRAINER if trainer_mode == "challenge" else _TRAINER
     cmd = [
         _trainer_exe,
-        str(_TRAINER),
+        str(target_trainer),
         "--agent-ids", ",".join(str(a) for a in agent_ids),
         "--epochs", str(epochs),
         "--status-file", str(status_file),


### PR DESCRIPTION
Adds a new Settings page to configure app language, board theme, and training mode.
  - Implements a basic lightweight i18n dictionary context for multiple languages.
  - Exposes a toggle to select the backend trainer script for the Training page.

---
*PR created automatically by Jules for task [11006989488924015425](https://jules.google.com/task/11006989488924015425) started by @oslinin*