### PR TITLE
feat: add owner-only withdrawal from agent wallet

### DIFF
--- a/frontend/app/AgentWalletPanel.tsx
+++ b/frontend/app/AgentWalletPanel.tsx
@@ -5,6 +5,7 @@ import {
   useAccount,
   usePublicClient,
   useWalletClient,
+  useSignMessage,
 } from "wagmi";
 
 const SERVER = process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:8000";
@@ -104,6 +105,8 @@ export function AgentWalletPanel({ agentId, stakeWei, onWalletChange }: Props) {
     }
   };
 
+  const { signMessageAsync } = useSignMessage();
+
   const onWithdraw = async () => {
     if (!wallet || !address) {
       setError("Connect your wallet to receive the withdrawal.");
@@ -112,13 +115,24 @@ export function AgentWalletPanel({ agentId, stakeWei, onWalletChange }: Props) {
     try {
       setBusy(true);
       setError(null);
+
+      const signature = await signMessageAsync({
+        message: `Withdraw agent ${agentId} funds`,
+      });
+
       const res = await fetch(`${SERVER}/agents/${agentId}/withdraw`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ to: address }),
+        body: JSON.stringify({ to: address, signature }),
       });
       if (!res.ok) {
-        throw new Error(await res.text().catch(() => res.statusText));
+        const errText = await res.text().catch(() => res.statusText);
+        let parsedErr = errText;
+        try {
+          const parsed = JSON.parse(errText);
+          parsedErr = parsed.detail || errText;
+        } catch {}
+        throw new Error(parsedErr);
       }
       await refresh();
     } catch (e) {

--- a/frontend/app/agent/[agentId]/AgentClient.tsx
+++ b/frontend/app/agent/[agentId]/AgentClient.tsx
@@ -30,6 +30,7 @@ import {
   useChainContracts,
 } from "../../contracts";
 import { useAgentMatchSummary } from "../../useAgentMatchSummary";
+import { AgentWalletPanel } from "../../AgentWalletPanel";
 
 const SERVER = process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:8000";
 
@@ -370,6 +371,11 @@ export default function AgentClient() {
             </span>
           )}
         </div>
+
+        {/* Agent Wallet Management */}
+        <section className="mb-8">
+          <AgentWalletPanel agentId={agentId} stakeWei={BigInt(0)} />
+        </section>
 
         {/* On-chain data */}
         <section

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1502,6 +1502,7 @@ class AgentDepositRequest(BaseModel):
 class AgentWithdrawRequest(BaseModel):
     to: str
     amount_wei: Optional[int] = None
+    signature: str
 
 
 def _agent_wallets_or_503() -> AgentWalletManager:
@@ -1555,6 +1556,31 @@ def agent_deposit(agent_id: int, req: AgentDepositRequest):
 def agent_withdraw(agent_id: int, req: AgentWithdrawRequest):
     """Drain the agent's wallet to `to`. If `amount_wei` is omitted,
     sends the entire balance minus gas."""
+    from eth_account.messages import encode_defunct
+    from web3 import Web3
+
+    try:
+        chain = ChainClient.from_env()
+    except ChainError as e:
+        raise HTTPException(status_code=503, detail=f"chain unavailable: {e}")
+
+    try:
+        owner = chain.agent_owner(agent_id)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"could not fetch owner for agent {agent_id}: {e}")
+
+    if req.to.lower() != owner.lower():
+        raise HTTPException(status_code=403, detail="Funds can only be withdrawn to the agent's owner")
+
+    msg = encode_defunct(text=f"Withdraw agent {agent_id} funds")
+    try:
+        signer = Web3().eth.account.recover_message(msg, signature=req.signature)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"invalid signature: {e}")
+
+    if signer.lower() != owner.lower():
+        raise HTTPException(status_code=403, detail="Signature must be from the agent's owner")
+
     wallets = _agent_wallets_or_503()
     try:
         tx_hash = wallets.withdraw(


### PR DESCRIPTION
Added the ability for an agent's owner to withdraw ETH from their agent's wallet directly from the agent info page. This leverages the existing `AgentWalletPanel` and adds a strict signature verification layer to ensure only the owner can authorize withdrawals to their own address.

---
*PR created automatically by Jules for task [5542671165502195664](https://jules.google.com/task/5542671165502195664) started by @oslinin*