### PR TITLE
🔒 [security fix] Restrict CORS origins in agent and server services

### DIFF
--- a/agent/coach_service.py
+++ b/agent/coach_service.py
@@ -55,10 +55,11 @@ app = FastAPI(title="Chaingammon Coach Agent")
 
 # The browser calls /hint cross-origin from http://localhost:3000.
 # Without CORS the preflight OPTIONS returns 405 and the POST is
-# blocked. Open CORS in dev; production should pin `allow_origins`.
+# blocked. Restricted to the deployed frontend host via ALLOWED_ORIGINS.
+allowed_origins = [o.strip() for o in os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(",")]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/agent/gnubg_service.py
+++ b/agent/gnubg_service.py
@@ -20,6 +20,7 @@ gnubg_service.py — local FastAPI agent process: gnubg move evaluation.
 """
 
 from __future__ import annotations
+import os
 import re
 import subprocess
 from typing import Optional
@@ -34,12 +35,12 @@ app = FastAPI(title="Chaingammon gnubg Agent")
 
 # The browser at http://localhost:3000 calls these endpoints from a
 # different origin than this service (port 8001), so without CORS the
-# preflight OPTIONS returns 405 and the browser refuses the POST. Open
-# CORS in dev — production deployments should restrict `allow_origins`
-# to the deployed frontend host.
+# preflight OPTIONS returns 405 and the browser refuses the POST.
+# Restricted to the deployed frontend host via ALLOWED_ORIGINS.
+allowed_origins = [o.strip() for o in os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(",")]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -53,12 +53,12 @@ from .og_storage_client import OgStorageError, get_blob, put_blob
 
 app = FastAPI()
 # Phase 20: the Next.js frontend at :3000 calls these endpoints cross-origin
-# (live match flow, subname mint, replay fetch). Open CORS so browser fetches
-# succeed in dev. Production should restrict `allow_origins` to the deployed
-# frontend host.
+# (live match flow, subname mint, replay fetch).
+# Restricted to the deployed frontend host via ALLOWED_ORIGINS.
+allowed_origins = [o.strip() for o in os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(",")]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
### 🔒 [security fix] Restrict CORS origins

#### 🎯 What:
Fixed an overly permissive CORS configuration that allowed all origins (`*`) to interact with the GNUbg service, Coach service, and main server.

#### ⚠️ Risk:
Leaving CORS open to all origins (`*`) allows any website to make requests to these services if they are reachable from the user's browser (e.g., running on localhost). This could lead to Cross-Site Request Forgery (CSRF) or unauthorized data access if the services are exposed.

#### 🛡️ Solution:
Implemented origin restriction using an environment variable `ALLOWED_ORIGINS`.
- The services now only accept requests from trusted origins.
- Default origin is set to `http://localhost:3000` to support standard local development.
- Multiple origins can be specified as a comma-separated list (e.g., `ALLOWED_ORIGINS=https://app.chaingammon.com,http://localhost:3000`).
- Added whitespace stripping to handle common configuration formatting.

Files modified:
- `agent/gnubg_service.py`
- `agent/coach_service.py`
- `server/app/main.py`

---
*PR created automatically by Jules for task [867269979827929859](https://jules.google.com/task/867269979827929859) started by @oslinin*