### PR TITLE
feat(themes): add 6 image-skin board themes from composite sprite (#143)

### DIFF
--- a/frontend/app/Board.tsx
+++ b/frontend/app/Board.tsx
@@ -858,18 +858,47 @@ export function Board({
                 <feMergeNode in="SourceGraphic" />
               </feMerge>
             </filter>
+            {/* Clip region for cropped sprite-sheet backgrounds */}
+            {usingImage && theme.backgroundImageCrop && (
+              <clipPath id="cg-bg-crop">
+                <rect x={0} y={0} width={TOTAL_W} height={TOTAL_H} />
+              </clipPath>
+            )}
           </defs>
 
           {/* Image-based themes: render only the image; classic themes: render the SVG frame + felt */}
           {usingImage ? (
-            <image
-              href={theme.backgroundImageUrl}
-              x="0"
-              y="0"
-              width={TOTAL_W}
-              height={TOTAL_H}
-              preserveAspectRatio="none"
-            />
+            (() => {
+              const crop = theme.backgroundImageCrop;
+              if (crop) {
+                // Scale so the cropped section of the sprite exactly fills the
+                // 716×440 viewport, then offset the image element so the crop
+                // origin sits at (0,0).
+                const scaleX = TOTAL_W / crop.srcW;
+                const scaleY = TOTAL_H / crop.srcH;
+                return (
+                  <image
+                    href={theme.backgroundImageUrl}
+                    x={-crop.srcX * scaleX}
+                    y={-crop.srcY * scaleY}
+                    width={crop.totalSrcW * scaleX}
+                    height={crop.totalSrcH * scaleY}
+                    clipPath="url(#cg-bg-crop)"
+                    preserveAspectRatio="none"
+                  />
+                );
+              }
+              return (
+                <image
+                  href={theme.backgroundImageUrl}
+                  x="0"
+                  y="0"
+                  width={TOTAL_W}
+                  height={TOTAL_H}
+                  preserveAspectRatio="none"
+                />
+              );
+            })()
           ) : (
             <>
               {/* Outer Frame */}

--- a/frontend/app/BoardThemePicker.tsx
+++ b/frontend/app/BoardThemePicker.tsx
@@ -53,14 +53,32 @@ export function BoardThemePicker({ value, onChange }: Props) {
               aria-pressed={active}
             >
               {t.backgroundImageUrl ? (
-                /* Image thumbnail for image-based themes */
-                <span style={{
-                  position: "absolute", top: 0, left: 0,
-                  width: "100%", height: "100%",
-                  backgroundImage: `url(${t.backgroundImageUrl})`,
-                  backgroundSize: "cover",
-                  backgroundPosition: "center",
-                }} />
+                /* Image thumbnail for image-based themes.
+                   When backgroundImageCrop is set, use CSS background-size
+                   + background-position to show only the relevant crop. */
+                <span style={(() => {
+                  const crop = t.backgroundImageCrop;
+                  if (crop) {
+                    // Scale so that the crop section fills the 28×28 thumbnail.
+                    const sx = 28 / crop.srcW;
+                    const sy = 28 / crop.srcH;
+                    return {
+                      position: "absolute" as const, top: 0, left: 0,
+                      width: "100%", height: "100%",
+                      backgroundImage: `url(${t.backgroundImageUrl})`,
+                      backgroundSize: `${crop.totalSrcW * sx}px ${crop.totalSrcH * sy}px`,
+                      backgroundPosition: `${-crop.srcX * sx}px ${-crop.srcY * sy}px`,
+                      backgroundRepeat: "no-repeat",
+                    };
+                  }
+                  return {
+                    position: "absolute" as const, top: 0, left: 0,
+                    width: "100%", height: "100%",
+                    backgroundImage: `url(${t.backgroundImageUrl})`,
+                    backgroundSize: "cover",
+                    backgroundPosition: "center",
+                  };
+                })()} />
               ) : (
                 <>
                   {/* Left half: felt color */}

--- a/frontend/app/api/board-sprite/route.ts
+++ b/frontend/app/api/board-sprite/route.ts
@@ -1,0 +1,65 @@
+/**
+ * GET /api/board-sprite
+ *
+ * Serves the composite board sprite (1024×1024 PNG, 2-col × 3-row layout).
+ * Board.tsx crops six individual themes out of this single image at render
+ * time using SVG positioning, so no pre-split files are required.
+ *
+ * Resolution order:
+ *   1. Local file: public/boards/source.png  (fastest; add via
+ *      `node scripts/download_board_sprite.mjs`)
+ *   2. GitHub CDN fallback: the original upload URL (always works in dev,
+ *      but incurs a network round-trip and depends on the CDN link remaining
+ *      active)
+ *
+ * The response is cached for 24 h at the CDN / browser layer.
+ */
+
+import { NextResponse } from "next/server";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/** GitHub CDN URL of the composite board sprite uploaded with issue #143. */
+const CDN_URL =
+  "https://github.com/user-attachments/assets/5ff80b7f-f391-4547-95c9-7ba46f8aa1a6";
+
+export async function GET() {
+  // Attempt to serve the locally cached copy first.
+  try {
+    const localPath = join(process.cwd(), "public", "boards", "source.png");
+    const data = await readFile(localPath);
+    return new NextResponse(data, {
+      headers: {
+        "Content-Type": "image/png",
+        "Cache-Control": "public, max-age=86400, stale-while-revalidate=3600",
+      },
+    });
+  } catch {
+    // File absent — fall through to CDN fetch.
+  }
+
+  // Proxy from the GitHub CDN.
+  let cdnRes: Response;
+  try {
+    cdnRes = await fetch(CDN_URL, { next: { revalidate: 86400 } });
+  } catch (err) {
+    return NextResponse.json(
+      { error: "Could not fetch board sprite from CDN", detail: String(err) },
+      { status: 502 }
+    );
+  }
+
+  if (!cdnRes.ok) {
+    return NextResponse.json(
+      { error: `CDN returned ${cdnRes.status}` },
+      { status: 502 }
+    );
+  }
+
+  return new NextResponse(cdnRes.body, {
+    headers: {
+      "Content-Type": "image/png",
+      "Cache-Control": "public, max-age=86400, stale-while-revalidate=3600",
+    },
+  });
+}

--- a/frontend/app/boardThemes.ts
+++ b/frontend/app/boardThemes.ts
@@ -10,6 +10,22 @@ export interface BoardTheme {
     cool: string; // P1 (agent, top)
   };
   /**
+   * When set, the background image is cropped to the given rectangle instead
+   * of being stretched to fill the full viewport. All pixel values refer to
+   * the source (un-cropped) image coordinate system. Board.tsx scales and
+   * positions the image element so that exactly this rectangle maps onto the
+   * 716×440 SVG viewport. Use this to carve individual board skins out of a
+   * composite sprite sheet without pre-splitting the file.
+   */
+  backgroundImageCrop?: {
+    srcX: number;       // left edge of the crop region (source pixels)
+    srcY: number;       // top edge of the crop region (source pixels)
+    srcW: number;       // width of the crop region (source pixels)
+    srcH: number;       // height of the crop region (source pixels)
+    totalSrcW: number;  // total source image width (source pixels)
+    totalSrcH: number;  // total source image height (source pixels)
+  };
+  /**
    * Per-spot checker landing coordinates for image-based boards. All values
    * are fractions of the 716×440 viewport (0–1). When set, Board.tsx looks
    * each checker's (x, y) up directly so they land on the painted triangles
@@ -235,10 +251,162 @@ export const BOARD_THEMES: Record<string, BoardTheme> = {
     checkerWarm: { fill: "#10B981", stroke: "#059669" },
     checkerCool: { fill: "#F43F5E", stroke: "#E11D48" },
   },
+
+  // ── Image-skin themes ────────────────────────────────────────────────────────
+  // These six themes share a single composite sprite served via /api/board-sprite
+  // (which proxies the GitHub CDN or serves a local copy from public/boards/source.png).
+  // Each theme declares a `backgroundImageCrop` that isolates one of the six
+  // panels in the 2-column × 3-row layout.  Board.tsx uses SVG image positioning
+  // to show only the relevant crop; no pre-split files are required at build time.
+  //
+  // To serve the sprite locally (recommended for production):
+  //   node scripts/download_board_sprite.mjs
+  //   # → writes frontend/public/boards/source.png
+  //
+  // To generate individually split PNG files:
+  //   node scripts/split_board_image.mjs
+  //
+  // The composite is a 1024×1024 PNG arranged as:
+  //   col 0 (x 0–511)    col 1 (x 512–1023)
+  //   row 0 (y 0–340)    Desert         Classic
+  //   row 1 (y 341–681)  Asian          Minimal
+  //   row 2 (y 682–1023) Adventure      Sci-fi
+
+  board_desert: {
+    label: "Desert Sands",
+    backgroundImageUrl: "/api/board-sprite",
+    backgroundImageCrop: { srcX: 0, srcY: 0, srcW: 512, srcH: 341, totalSrcW: 1024, totalSrcH: 1024 },
+    frameStart:  "#C8960C",
+    frameEnd:    "#7A4E12",
+    frameInner:  "#4A2E08",
+    felt:        "#D4A855",
+    feltAccent:  "#E6C56A",
+    pointLight:  "#FFD780",
+    pointDark:   "#8B3A0F",
+    pointStroke: "rgba(0,0,0,0.2)",
+    bar:         "#7A4E12",
+    barEdge:     "#4A2E08",
+    rail:        "#7A4E12",
+    railText:    "#FFD780",
+    checkerWarm: { fill: "#2DD4BF", stroke: "#0D9488" },
+    checkerCool: { fill: "#B45309", stroke: "#78350F" },
+  },
+
+  board_classic: {
+    label: "Classic Mahogany",
+    backgroundImageUrl: "/api/board-sprite",
+    backgroundImageCrop: { srcX: 512, srcY: 0, srcW: 512, srcH: 341, totalSrcW: 1024, totalSrcH: 1024 },
+    frameStart:  "#3D1F0F",
+    frameEnd:    "#1C0D06",
+    frameInner:  "#0C0603",
+    felt:        "#2D1508",
+    feltAccent:  "#3D1F0F",
+    pointLight:  "#F5EBD8",
+    pointDark:   "#8B1A1A",
+    pointStroke: "rgba(0,0,0,0.3)",
+    bar:         "#1C0D06",
+    barEdge:     "#0C0603",
+    rail:        "#1C0D06",
+    railText:    "#F5EBD8",
+    checkerWarm: { fill: "#F5F0E8", stroke: "#C8B89A" },
+    checkerCool: { fill: "#1A1208", stroke: "#000000" },
+  },
+
+  board_asian: {
+    label: "Imperial Dragon",
+    backgroundImageUrl: "/api/board-sprite",
+    backgroundImageCrop: { srcX: 0, srcY: 341, srcW: 512, srcH: 341, totalSrcW: 1024, totalSrcH: 1024 },
+    frameStart:  "#1A1A1A",
+    frameEnd:    "#0A0A0A",
+    frameInner:  "#000000",
+    felt:        "#0D1F0D",
+    feltAccent:  "#142814",
+    pointLight:  "#CA8A04",
+    pointDark:   "#1A2E1A",
+    pointStroke: "rgba(202,138,4,0.3)",
+    bar:         "#1A1A1A",
+    barEdge:     "#000000",
+    rail:        "#1A1A1A",
+    railText:    "#CA8A04",
+    checkerWarm: { fill: "#10B981", stroke: "#059669" },
+    checkerCool: { fill: "#F5F0E8", stroke: "#C8B89A" },
+  },
+
+  board_minimal: {
+    label: "Shadow Steel",
+    backgroundImageUrl: "/api/board-sprite",
+    backgroundImageCrop: { srcX: 512, srcY: 341, srcW: 512, srcH: 341, totalSrcW: 1024, totalSrcH: 1024 },
+    frameStart:  "#1E2028",
+    frameEnd:    "#0E1018",
+    frameInner:  "#080A10",
+    felt:        "#242830",
+    feltAccent:  "#1C2028",
+    pointLight:  "#8BAAC8",
+    pointDark:   "#3A4560",
+    pointStroke: "rgba(0,0,0,0.35)",
+    bar:         "#0E1018",
+    barEdge:     "#080A10",
+    rail:        "#0E1018",
+    railText:    "#8BAAC8",
+    checkerWarm: { fill: "#C8D8E8", stroke: "#8BAAC8" },
+    checkerCool: { fill: "#1A1E28", stroke: "#000000" },
+  },
+
+  board_adventure: {
+    label: "Old World Adventure",
+    backgroundImageUrl: "/api/board-sprite",
+    backgroundImageCrop: { srcX: 0, srcY: 682, srcW: 512, srcH: 342, totalSrcW: 1024, totalSrcH: 1024 },
+    frameStart:  "#4A2C0A",
+    frameEnd:    "#2A1806",
+    frameInner:  "#180E03",
+    felt:        "#3A2208",
+    feltAccent:  "#4A2C0A",
+    pointLight:  "#D4A040",
+    pointDark:   "#2A1806",
+    pointStroke: "rgba(0,0,0,0.35)",
+    bar:         "#2A1806",
+    barEdge:     "#180E03",
+    rail:        "#2A1806",
+    railText:    "#D4A040",
+    checkerWarm: { fill: "#E8C050", stroke: "#A07820" },
+    checkerCool: { fill: "#1C1008", stroke: "#000000" },
+  },
+
+  board_scifi: {
+    label: "Cyber Matrix",
+    backgroundImageUrl: "/api/board-sprite",
+    backgroundImageCrop: { srcX: 512, srcY: 682, srcW: 512, srcH: 342, totalSrcW: 1024, totalSrcH: 1024 },
+    frameStart:  "#060606",
+    frameEnd:    "#000000",
+    frameInner:  "#000000",
+    felt:        "#020202",
+    feltAccent:  "#050505",
+    pointLight:  "#00CC88",
+    pointDark:   "#CC0044",
+    pointStroke: "rgba(0,204,136,0.4)",
+    bar:         "#0A0A0A",
+    barEdge:     "#000000",
+    rail:        "#0A0A0A",
+    railText:    "#00CC88",
+    checkerWarm: { fill: "#00CC88", stroke: "#009966" },
+    checkerCool: { fill: "#FF3366", stroke: "#CC0044" },
+  },
 };
 
-export const THEME_ORDER = ["walnut", "emerald", "slate", "onyx", "linen", "nard", "tabula", "east_asian", "english", "manhattan", "neural_net"] as const;
+export const THEME_ORDER = [
+  "walnut", "emerald", "slate", "onyx", "linen",
+  "nard", "tabula", "east_asian", "english", "manhattan", "neural_net",
+  "board_desert", "board_classic", "board_asian", "board_minimal", "board_adventure", "board_scifi",
+] as const;
 export type BoardThemeKey = typeof THEME_ORDER[number];
+
+/**
+ * URL of the composite board sprite sheet used by the six image-skin themes.
+ * Points to the Next.js proxy route which serves public/boards/source.png
+ * when present, or falls back to the GitHub CDN upload.
+ * Run `node scripts/download_board_sprite.mjs` to cache the sprite locally.
+ */
+export const BOARD_SPRITE_URL = "/api/board-sprite";
 
 const STORAGE_KEY = "chaingammon.boardTheme";
 

--- a/frontend/lib/splitBoardImage.ts
+++ b/frontend/lib/splitBoardImage.ts
@@ -1,0 +1,130 @@
+/**
+ * splitBoardImage — browser-side utility for splitting a composite board image.
+ *
+ * Loads a single sprite PNG (or any image URL) into an off-screen Canvas,
+ * then crops it into `cols × rows` equal sections and returns each section
+ * as a Blob URL.  Blob URLs remain valid for the lifetime of the current
+ * page; call URL.revokeObjectURL(url) when a board image is no longer needed.
+ *
+ * Usage (React example):
+ *   const [urls, setUrls] = useState<string[]>([]);
+ *   useEffect(() => {
+ *     splitBoardImage("/boards/source.png", 2, 3).then(setUrls);
+ *     return () => urls.forEach(URL.revokeObjectURL);
+ *   }, []);
+ *
+ * For server-side splitting (build step / CI), use the companion Node.js
+ * script at scripts/split_board_image.mjs instead.
+ */
+
+export interface SplitOptions {
+  /** Number of columns in the composite (default 2). */
+  cols?: number;
+  /** Number of rows in the composite (default 3). */
+  rows?: number;
+  /** Output MIME type (default "image/png"). "image/jpeg" is smaller. */
+  mimeType?: "image/png" | "image/jpeg";
+  /** JPEG quality 0–1 (only used when mimeType is "image/jpeg"; default 0.9). */
+  quality?: number;
+}
+
+/**
+ * Split a composite board image into individual board images.
+ *
+ * @param src    URL of the composite image (may be a same-origin path, a
+ *               crossOrigin URL, or a data-URL).
+ * @param opts   Optional tuning parameters.
+ * @returns      Promise resolving to an array of Blob URLs, ordered
+ *               left-to-right, top-to-bottom.
+ */
+export async function splitBoardImage(
+  src: string,
+  opts: SplitOptions = {}
+): Promise<string[]> {
+  const { cols = 2, rows = 3, mimeType = "image/png", quality = 0.9 } = opts;
+
+  const img = await loadImage(src);
+  const cellW = Math.floor(img.naturalWidth / cols);
+  const cellH = Math.floor(img.naturalHeight / rows);
+
+  const blobUrls: string[] = [];
+
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const x = c * cellW;
+      const y = r * cellH;
+      // Last column/row absorbs any remainder pixels from integer division.
+      const w = c === cols - 1 ? img.naturalWidth - x : cellW;
+      const h = r === rows - 1 ? img.naturalHeight - y : cellH;
+
+      const canvas = document.createElement("canvas");
+      canvas.width = w;
+      canvas.height = h;
+
+      const ctx = canvas.getContext("2d");
+      if (!ctx) throw new Error("Canvas 2D context not available");
+
+      ctx.drawImage(img, x, y, w, h, 0, 0, w, h);
+      const blob = await canvasToBlob(canvas, mimeType, quality);
+      blobUrls.push(URL.createObjectURL(blob));
+    }
+  }
+
+  return blobUrls;
+}
+
+/**
+ * Compute the crop geometry for one cell in a composite image without doing
+ * any actual pixel work.  The returned object is compatible with the
+ * `backgroundImageCrop` field in `BoardTheme` (boardThemes.ts), so you can
+ * build themes programmatically.
+ *
+ * @param totalW  Total composite image width (pixels).
+ * @param totalH  Total composite image height (pixels).
+ * @param cols    Number of columns.
+ * @param rows    Number of rows.
+ * @param idx     Zero-based index of the desired cell (left-to-right, top-to-bottom).
+ */
+export function computeCrop(
+  totalW: number,
+  totalH: number,
+  cols: number,
+  rows: number,
+  idx: number
+) {
+  const col = idx % cols;
+  const row = Math.floor(idx / cols);
+  const cellW = Math.floor(totalW / cols);
+  const cellH = Math.floor(totalH / rows);
+  const srcX = col * cellW;
+  const srcY = row * cellH;
+  const srcW = col === cols - 1 ? totalW - srcX : cellW;
+  const srcH = row === rows - 1 ? totalH - srcY : cellH;
+  return { srcX, srcY, srcW, srcH, totalSrcW: totalW, totalSrcH: totalH };
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error(`Failed to load image: ${src}`));
+    img.src = src;
+  });
+}
+
+function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  mimeType: string,
+  quality: number
+): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error("canvas.toBlob returned null"))),
+      mimeType,
+      quality
+    );
+  });
+}

--- a/scripts/download_board_sprite.mjs
+++ b/scripts/download_board_sprite.mjs
@@ -1,0 +1,38 @@
+/**
+ * download_board_sprite.mjs
+ *
+ * One-time script: downloads the composite board sprite from the GitHub CDN
+ * and saves it to frontend/public/boards/source.png.  Run this once after
+ * cloning the repo if the file is not already present.
+ *
+ *   node scripts/download_board_sprite.mjs
+ */
+
+import { createWriteStream, mkdirSync } from "node:fs";
+import { pipeline } from "node:stream/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+
+const SPRITE_URL =
+  "https://github.com/user-attachments/assets/5ff80b7f-f391-4547-95c9-7ba46f8aa1a6";
+const DEST = join(ROOT, "frontend", "public", "boards", "source.png");
+
+async function main() {
+  mkdirSync(join(ROOT, "frontend", "public", "boards"), { recursive: true });
+
+  console.log(`Downloading board sprite from GitHub CDN…`);
+  const res = await fetch(SPRITE_URL);
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+
+  const writer = createWriteStream(DEST);
+  await pipeline(res.body, writer);
+  console.log(`Saved to ${DEST}`);
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/scripts/split_board_image.mjs
+++ b/scripts/split_board_image.mjs
@@ -1,0 +1,281 @@
+/**
+ * split_board_image.mjs
+ *
+ * Splits a composite PNG that contains N×M backgammon board screenshots into
+ * N*M individual PNG files.  Uses only Node.js built-in modules — no external
+ * dependencies required.
+ *
+ * Usage:
+ *   node scripts/split_board_image.mjs [input] [outputDir] [cols] [rows]
+ *
+ * Defaults:
+ *   input      — /tmp/github-images/image-1779424205149-0.png
+ *   outputDir  — frontend/public/boards
+ *   cols       — 2
+ *   rows       — 3
+ *
+ * The script writes files named board-1.png … board-N.png (left-to-right,
+ * top-to-bottom).  Pass --names=a,b,c,d,e,f to override the stem list.
+ *
+ * Example:
+ *   node scripts/split_board_image.mjs \
+ *     /tmp/composite.png frontend/public/boards 2 3 \
+ *     --names=board-desert,board-classic,board-asian,board-minimal,board-adventure,board-scifi
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { inflateSync, deflateSync } from "node:zlib";
+import { join } from "node:path";
+
+// ─── PNG constants ────────────────────────────────────────────────────────────
+
+const PNG_SIG = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+
+/** Pre-computed CRC32 lookup table. */
+const CRC_TABLE = (() => {
+  const t = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let j = 0; j < 8; j++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    t[i] = c;
+  }
+  return t;
+})();
+
+function crc32(buf) {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buf.length; i++)
+    crc = CRC_TABLE[(crc ^ buf[i]) & 0xff] ^ (crc >>> 8);
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+// ─── PNG chunk I/O ───────────────────────────────────────────────────────────
+
+/**
+ * Parse all chunks from a raw PNG buffer (after the 8-byte signature).
+ * Returns an array of { type: string, data: Buffer }.
+ */
+function readChunks(buf) {
+  const chunks = [];
+  let pos = 8; // skip signature
+  while (pos < buf.length) {
+    const len = buf.readUInt32BE(pos);
+    const type = buf.subarray(pos + 4, pos + 8).toString("ascii");
+    const data = Buffer.from(buf.subarray(pos + 8, pos + 8 + len));
+    chunks.push({ type, data });
+    pos += 12 + len; // length(4) + type(4) + data(len) + crc(4)
+  }
+  return chunks;
+}
+
+/**
+ * Encode a single chunk: length + type + data + crc.
+ */
+function encodeChunk(type, data) {
+  const typeBuf = Buffer.from(type, "ascii");
+  const crcInput = Buffer.concat([typeBuf, data]);
+  const out = Buffer.alloc(12 + data.length);
+  out.writeUInt32BE(data.length, 0);
+  typeBuf.copy(out, 4);
+  data.copy(out, 8);
+  out.writeUInt32BE(crc32(crcInput), 8 + data.length);
+  return out;
+}
+
+// ─── IHDR ────────────────────────────────────────────────────────────────────
+
+function parseIHDR(data) {
+  return {
+    width: data.readUInt32BE(0),
+    height: data.readUInt32BE(4),
+    bitDepth: data[8],
+    colorType: data[9],
+    compression: data[10],
+    filter: data[11],
+    interlace: data[12],
+  };
+}
+
+function buildIHDR({ width, height, bitDepth, colorType, compression, filter, interlace }) {
+  const d = Buffer.alloc(13);
+  d.writeUInt32BE(width, 0);
+  d.writeUInt32BE(height, 4);
+  d[8] = bitDepth;
+  d[9] = colorType;
+  d[10] = compression;
+  d[11] = filter;
+  d[12] = interlace;
+  return d;
+}
+
+/** Bytes per pixel for the given colorType + bitDepth combination. */
+function bpp(colorType, bitDepth) {
+  const channels =
+    colorType === 0 ? 1 :  // grayscale
+    colorType === 2 ? 3 :  // RGB
+    colorType === 3 ? 1 :  // indexed
+    colorType === 4 ? 2 :  // grayscale + alpha
+    colorType === 6 ? 4 :  // RGBA
+    (() => { throw new Error(`Unsupported colorType ${colorType}`); })();
+  return Math.ceil((channels * bitDepth) / 8);
+}
+
+// ─── PNG filter reconstruction ────────────────────────────────────────────────
+
+/**
+ * Reconstruct (un-filter) a single scanline.
+ * @param {Buffer} row    Raw scanline bytes including the leading filter byte.
+ * @param {Buffer|null} prev  Previous (already unfiltered) scanline pixels, or null.
+ * @param {number}  bytesPerPixel
+ * @returns {Buffer}  Unfiltered pixel bytes (no filter byte prefix).
+ */
+function unfilterRow(row, prev, bytesPerPixel) {
+  const f = row[0];
+  const len = row.length - 1;
+  const out = Buffer.alloc(len);
+
+  for (let i = 0; i < len; i++) {
+    const x = row[i + 1];
+    const a = i >= bytesPerPixel ? out[i - bytesPerPixel] : 0;
+    const b = prev ? prev[i] : 0;
+    const c = prev && i >= bytesPerPixel ? prev[i - bytesPerPixel] : 0;
+
+    switch (f) {
+      case 0: out[i] = x; break;                                         // None
+      case 1: out[i] = (x + a) & 0xff; break;                            // Sub
+      case 2: out[i] = (x + b) & 0xff; break;                            // Up
+      case 3: out[i] = (x + Math.floor((a + b) / 2)) & 0xff; break;      // Average
+      case 4: {                                                           // Paeth
+        const p = a + b - c;
+        const pa = Math.abs(p - a), pb = Math.abs(p - b), pc = Math.abs(p - c);
+        out[i] = (x + (pa <= pb && pa <= pc ? a : pb <= pc ? b : c)) & 0xff;
+        break;
+      }
+      default: throw new Error(`Unknown PNG filter byte ${f}`);
+    }
+  }
+  return out;
+}
+
+// ─── Main split function ──────────────────────────────────────────────────────
+
+/**
+ * Split a composite PNG into `cols × rows` individual PNGs.
+ *
+ * @param {string}   inputPath   Path to the source PNG.
+ * @param {string}   outputDir   Directory where output PNGs are written.
+ * @param {number}   cols        Number of columns in the composite.
+ * @param {number}   rows        Number of rows in the composite.
+ * @param {string[]} names       Stem names for each output file (length = cols*rows,
+ *                               ordered left-to-right, top-to-bottom).
+ * @returns {string[]}  Absolute paths of the written files.
+ */
+export function splitBoardImage(inputPath, outputDir, cols, rows, names) {
+  const buf = readFileSync(inputPath);
+
+  if (!buf.subarray(0, 8).equals(PNG_SIG)) {
+    throw new Error(`${inputPath} is not a valid PNG file`);
+  }
+
+  const chunks = readChunks(buf);
+  const ihdr = parseIHDR(chunks.find((c) => c.type === "IHDR").data);
+  const { width, height, bitDepth, colorType } = ihdr;
+  const B = bpp(colorType, bitDepth);
+  const rowStride = width * B;
+
+  console.log(`Source: ${width}×${height} px | colorType=${colorType} bitDepth=${bitDepth} bpp=${B}`);
+
+  // Decompress IDAT
+  const idatData = Buffer.concat(
+    chunks.filter((c) => c.type === "IDAT").map((c) => c.data)
+  );
+  const raw = inflateSync(idatData);
+
+  // Un-filter all scanlines
+  const filteredStride = rowStride + 1; // +1 for filter byte
+  const scanlines = [];
+  for (let y = 0; y < height; y++) {
+    const rowRaw = raw.subarray(y * filteredStride, (y + 1) * filteredStride);
+    scanlines.push(unfilterRow(rowRaw, y > 0 ? scanlines[y - 1] : null, B));
+  }
+
+  // Cell dimensions
+  const cellW = Math.floor(width / cols);
+  const cellH = Math.floor(height / rows);
+
+  mkdirSync(outputDir, { recursive: true });
+
+  const outputPaths = [];
+  let idx = 0;
+
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const x0 = c * cellW;
+      const y0 = r * cellH;
+      // Last column/row absorbs any remainder pixels from integer division.
+      const w = c === cols - 1 ? width - x0 : cellW;
+      const h = r === rows - 1 ? height - y0 : cellH;
+
+      // Crop pixel data — filter type 0 (None) for each output row.
+      const rowBufs = [];
+      for (let y = 0; y < h; y++) {
+        const src = scanlines[y0 + y];
+        const filter = Buffer.from([0]); // None
+        const pixels = Buffer.from(src.subarray(x0 * B, (x0 + w) * B));
+        rowBufs.push(Buffer.concat([filter, pixels]));
+      }
+
+      const rawCrop = Buffer.concat(rowBufs);
+      const compressed = deflateSync(rawCrop, { level: 6 });
+
+      const outIHDR = buildIHDR({ ...ihdr, width: w, height: h });
+      const outBuf = Buffer.concat([
+        PNG_SIG,
+        encodeChunk("IHDR", outIHDR),
+        encodeChunk("IDAT", compressed),
+        encodeChunk("IEND", Buffer.alloc(0)),
+      ]);
+
+      const stem = names?.[idx] ?? `board-${idx + 1}`;
+      const outPath = join(outputDir, `${stem}.png`);
+      writeFileSync(outPath, outBuf);
+      console.log(`  [${idx + 1}/${cols * rows}] ${outPath}  (${w}×${h} px)`);
+      outputPaths.push(outPath);
+      idx++;
+    }
+  }
+
+  return outputPaths;
+}
+
+// ─── CLI entry point ──────────────────────────────────────────────────────────
+
+if (process.argv[1] && new URL(import.meta.url).pathname === process.argv[1]) {
+  const args = process.argv.slice(2).filter((a) => !a.startsWith("--"));
+  const flags = Object.fromEntries(
+    process.argv.slice(2)
+      .filter((a) => a.startsWith("--"))
+      .map((a) => a.slice(2).split("="))
+  );
+
+  const inputPath = args[0] ?? "/tmp/github-images/image-1779424205149-0.png";
+  const outputDir = args[1] ?? "frontend/public/boards";
+  const cols      = parseInt(args[2] ?? "2", 10);
+  const rows      = parseInt(args[3] ?? "3", 10);
+  const names     = flags.names ? flags.names.split(",") : [
+    "board-desert",
+    "board-classic",
+    "board-asian",
+    "board-minimal",
+    "board-adventure",
+    "board-scifi",
+  ];
+
+  try {
+    splitBoardImage(inputPath, outputDir, cols, rows, names);
+    console.log("Done.");
+  } catch (err) {
+    console.error("Error:", err.message);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
Implements the split-and-apply pipeline requested in issue #143.

**Splitting function** (two variants):
- `scripts/split_board_image.mjs` — zero-dep Node.js CLI PNG splitter
- `frontend/lib/splitBoardImage.ts` — browser Canvas API equivalent

**6 new board themes** (Desert Sands, Classic Mahogany, Imperial Dragon, Shadow Steel, Old World Adventure, Cyber Matrix) that crop from the composite sprite at render time via SVG clipPath — no pre-split files required.

**`/api/board-sprite` route** — proxies composite PNG from local file or GitHub CDN.

Closes #143

Generated with [Claude Code](https://claude.ai/code)