### PR TITLE
Enable landscape layout on phones below lg breakpoint

### DIFF
--- a/frontend/app/team-demo/page.tsx
+++ b/frontend/app/team-demo/page.tsx
@@ -1410,7 +1410,7 @@ function TeamDemoPageInner() {
   // ── Game screen ───────────────────────────────────────────────────────────
 
   return (
-    <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-6 p-6 lg:flex-row">
+    <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-6 p-6 landscape:max-lg:flex-row lg:flex-row">
       <div className="flex flex-1 flex-col gap-6">
         {/* Match header */}
         <header
@@ -1734,7 +1734,7 @@ function TeamDemoPageInner() {
           overflow: "hidden",
           ...(panelPos ? { boxShadow: "var(--cg-shadow-2)" } : {}),
         }}
-        className="w-full lg:w-80"
+        className="w-full landscape:max-lg:w-56 lg:w-80"
       >
         {/* Drag handle */}
         <div

--- a/frontend/tests/board-landscape.spec.ts
+++ b/frontend/tests/board-landscape.spec.ts
@@ -1,0 +1,65 @@
+// board-landscape.spec.ts
+//
+// Verifies that the team-demo game layout flips to a horizontal (board left,
+// advisor panel right) arrangement when the device is in landscape orientation
+// — even on phone-sized viewports below the desktop `lg` breakpoint.
+//
+// The mechanism under test is pure CSS: Tailwind's `landscape:max-lg:flex-row`
+// modifier stacked on the main page wrapper in app/team-demo/page.tsx. No JS
+// orientation hook is involved.
+//
+// Layout matrix being pinned:
+//   - landscape + viewport < 1024px  → flex-direction: row     (new behavior)
+//   - portrait  + viewport < 1024px  → flex-direction: column  (existing)
+//   - landscape + viewport ≥ 1024px  → flex-direction: row     (existing lg)
+//
+// Like game-flow.spec.ts we use `?opponents=1` so the page skips the agent-
+// picker setup screen and renders the game `<main>` immediately. The agents
+// fetch is mocked because no backend server is running in tests.
+
+import { test, expect, devices, type Page } from "@playwright/test";
+
+async function mockAgentList(page: Page): Promise<void> {
+  await page.route("http://localhost:8000/agents", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify([
+        { agent_id: 1, weights_hash: "0xabc", match_count: 0, tier: 1 },
+      ]),
+    })
+  );
+}
+
+test.describe("game layout — phone landscape", () => {
+  test.use({ ...devices["iPhone 12 landscape"] });
+
+  test("board and advisor panel sit side-by-side", async ({ page }) => {
+    await mockAgentList(page);
+    await page.goto("/team-demo?opponents=1");
+
+    // Wait for the game screen to render (header is unique to it).
+    await expect(
+      page.locator("h1", { hasText: "Off-Chain Game" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    // The game-screen <main> is the only one carrying `max-w-5xl`.
+    const main = page.locator("main.max-w-5xl");
+    await expect(main).toHaveCSS("flex-direction", "row");
+  });
+});
+
+test.describe("game layout — phone portrait", () => {
+  test.use({ ...devices["iPhone 12"] });
+
+  test("layout stays stacked", async ({ page }) => {
+    await mockAgentList(page);
+    await page.goto("/team-demo?opponents=1");
+
+    await expect(
+      page.locator("h1", { hasText: "Off-Chain Game" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    const main = page.locator("main.max-w-5xl");
+    await expect(main).toHaveCSS("flex-direction", "column");
+  });
+});


### PR DESCRIPTION
## Summary
Adds responsive layout support for landscape orientation on phone-sized viewports by using Tailwind's `landscape:max-lg:` modifier. This allows the game board and advisor panel to sit side-by-side on landscape phones, improving usability without requiring JavaScript orientation detection.

## Changes
- **app/team-demo/page.tsx**: Added `landscape:max-lg:flex-row` to the main game container to enable horizontal layout in landscape mode on viewports below the `lg` (1024px) breakpoint
- **app/team-demo/page.tsx**: Added `landscape:max-lg:w-56` to the advisor panel to constrain its width appropriately in landscape phone mode
- **frontend/tests/board-landscape.spec.ts**: Added comprehensive Playwright tests to verify the layout behavior across orientation and viewport combinations:
  - Landscape phone: board and panel sit side-by-side (flex-direction: row)
  - Portrait phone: layout remains stacked (flex-direction: column)

## Implementation Details
The solution uses pure CSS via Tailwind's responsive modifiers, stacking `landscape:max-lg:flex-row` with the existing `lg:flex-row` to create the desired layout matrix:
- Landscape + viewport < 1024px → horizontal layout (new)
- Portrait + viewport < 1024px → vertical layout (existing)
- Landscape + viewport ≥ 1024px → horizontal layout (existing)

Tests mock the agent list API and use Playwright's device presets to verify the CSS behavior without requiring a backend server.

https://claude.ai/code/session_01JLmibZsdEvGkq9x9gojXmd