### PR TITLE
Add 2D/3D board style toggle to Settings

### DIFF
--- a/frontend/app/Board.tsx
+++ b/frontend/app/Board.tsx
@@ -21,6 +21,7 @@ interface BoardProps {
   cubeOwner?: number;       // -1 = centered, 0 = human, 1 = agent
   onCubeClick?: () => void; // called when the human clicks the cube to offer a double
   playerAvatarUrls?: { warm: string; cool: string };
+  prefer3d?: boolean;
 }
 
 const FRAME = 20;
@@ -63,12 +64,22 @@ export function Board({
   cubeOwner = -1,
   onCubeClick,
   playerAvatarUrls,
+  prefer3d = false,
 }: BoardProps) {
   const theme = BOARD_THEMES[themeKey] ?? BOARD_THEMES.walnut;
   // Image-based themes own the board look entirely — skip the SVG-painted
   // frame, felt, point triangles, bar, and bear-off trays so the two
   // visual systems don't bleed through each other.
   const usingImage = !!theme.backgroundImageUrl;
+
+  const perspectiveDeg = theme.perspectiveDeg ?? 20;
+  let bgTransform: string | undefined;
+  if (usingImage) {
+    if (prefer3d && !theme.imageIs3d)
+      bgTransform = `perspective(800px) rotateX(${perspectiveDeg}deg)`;
+    else if (!prefer3d && theme.imageIs3d)
+      bgTransform = `perspective(800px) rotateX(-${perspectiveDeg}deg)`;
+  }
 
   // Per-theme play-area grid. Image themes that declare `checkerSpots`
   // use per-spot lookup for checker placement; classic SVG themes fall back
@@ -812,12 +823,27 @@ export function Board({
         {turnLabel}
       </p>
 
-      <div style={{ width: "100%", maxWidth: `${TOTAL_W}px`, overflow: "hidden" }}>
+      <div style={{ width: "100%", maxWidth: `${TOTAL_W}px`, overflow: "hidden", position: "relative" }}>
+        {usingImage && (() => {
+          const crop = theme.backgroundImageCrop;
+          const imgStyle: React.CSSProperties = crop ? {
+            position: "absolute",
+            width:  `${crop.totalSrcW / crop.srcW * 100}%`,
+            height: `${crop.totalSrcH / crop.srcH * 100}%`,
+            left:   `${-crop.srcX / crop.srcW * 100}%`,
+            top:    `${-crop.srcY / crop.srcH * 100}%`,
+          } : { position: "absolute", inset: 0, width: "100%", height: "100%", objectFit: "cover" as const };
+          return (
+            <div style={{ position: "absolute", inset: 0, overflow: "hidden", transform: bgTransform, transformOrigin: "50% 50%" }}>
+              <img src={theme.backgroundImageUrl} style={imgStyle} alt="" draggable={false} />
+            </div>
+          );
+        })()}
         <svg
           ref={svgRef}
           viewBox={`0 0 ${TOTAL_W} ${TOTAL_H}`}
           width="100%"
-          style={{ touchAction: dragState ? "none" : "auto", display: "block" }}
+          style={{ touchAction: dragState ? "none" : "auto", display: "block", position: "relative" }}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
           onPointerLeave={handlePointerUp}
@@ -860,48 +886,10 @@ export function Board({
                 <feMergeNode in="SourceGraphic" />
               </feMerge>
             </filter>
-            {/* Clip region for cropped sprite-sheet backgrounds */}
-            {usingImage && theme.backgroundImageCrop && (
-              <clipPath id="cg-bg-crop">
-                <rect x={0} y={0} width={TOTAL_W} height={TOTAL_H} />
-              </clipPath>
-            )}
           </defs>
 
-          {/* Image-based themes: render only the image; classic themes: render the SVG frame + felt */}
-          {usingImage ? (
-            (() => {
-              const crop = theme.backgroundImageCrop;
-              if (crop) {
-                // Scale so the cropped section of the sprite exactly fills the
-                // 716×440 viewport, then offset the image element so the crop
-                // origin sits at (0,0).
-                const scaleX = TOTAL_W / crop.srcW;
-                const scaleY = TOTAL_H / crop.srcH;
-                return (
-                  <image
-                    href={theme.backgroundImageUrl}
-                    x={-crop.srcX * scaleX}
-                    y={-crop.srcY * scaleY}
-                    width={crop.totalSrcW * scaleX}
-                    height={crop.totalSrcH * scaleY}
-                    clipPath="url(#cg-bg-crop)"
-                    preserveAspectRatio="none"
-                  />
-                );
-              }
-              return (
-                <image
-                  href={theme.backgroundImageUrl}
-                  x="0"
-                  y="0"
-                  width={TOTAL_W}
-                  height={TOTAL_H}
-                  preserveAspectRatio="none"
-                />
-              );
-            })()
-          ) : (
+          {/* Classic SVG themes: render the frame + felt. Image themes: background is in the HTML layer above. */}
+          {!usingImage && (
             <>
               {/* Outer Frame */}
               <rect

--- a/frontend/app/boardThemes.ts
+++ b/frontend/app/boardThemes.ts
@@ -47,6 +47,10 @@ export interface BoardTheme {
     leftOffX: number;    // left tray x (agent/P1 bear-off)
     rightOffX: number;   // right tray x (human/P0 bear-off)
   };
+  /** When true, the background image is pre-rendered with a perspective tilt; 2D mode compensates with an inverse CSS transform. */
+  imageIs3d?: boolean;
+  /** Degrees of rotateX tilt applied in 3D mode (default 20). */
+  perspectiveDeg?: number;
   /** Portrait avatar spots for player coin display (image themes only). All values fractions of 716×440. */
   avatarSpots?: {
     p0: { cx: number; cy: number };  // human/warm player avatar center
@@ -475,6 +479,7 @@ export const BOARD_THEMES: Record<string, BoardTheme> = {
   },
   board_roman: {
     label: "Roman — Marble Court",
+    imageIs3d: true,
     backgroundImageUrl: "/boards/new/board3/board.png",
     backgroundImageCrop: { srcX: 168, srcY: 185, srcW: 990, srcH: 570, totalSrcW: 1248, totalSrcH: 832 },
     checkerImages: {
@@ -515,6 +520,7 @@ export const BOARD_THEMES: Record<string, BoardTheme> = {
   },
   board_cyber2: {
     label: "Cyber — Neural Grid",
+    imageIs3d: true,
     backgroundImageUrl: "/boards/new/board6/board.png",
     backgroundImageCrop: { srcX: 183, srcY: 90, srcW: 973, srcH: 598, totalSrcW: 1344, totalSrcH: 768 },
     checkerImages: {
@@ -572,6 +578,17 @@ export function loadTheme(): BoardThemeKey {
 
 export function saveTheme(key: BoardThemeKey) {
   localStorage.setItem(STORAGE_KEY, key);
+}
+
+const PREFER_3D_KEY = "chaingammon.prefer3d";
+
+export function loadPrefer3d(): boolean {
+  if (typeof window === "undefined") return false;
+  return localStorage.getItem(PREFER_3D_KEY) === "true";
+}
+
+export function savePrefer3d(v: boolean) {
+  localStorage.setItem(PREFER_3D_KEY, String(v));
 }
 
 /** URLs for the 6 historical coin portrait avatars. */

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useI18n, LANGUAGES, Language } from "../i18n";
 import { BoardThemePicker } from "../BoardThemePicker";
-import { loadTheme, saveTheme, type BoardThemeKey } from "../boardThemes";
+import { loadTheme, saveTheme, loadPrefer3d, savePrefer3d, type BoardThemeKey } from "../boardThemes";
 import { useAppMode, type AppMode } from "../AppModeContext";
 
 export default function SettingsPage() {
@@ -12,12 +12,14 @@ export default function SettingsPage() {
   const { language, setLanguage, t } = useI18n();
   const { mode, setMode } = useAppMode();
   const [boardTheme, setBoardTheme] = useState<BoardThemeKey>("walnut");
+  const [prefer3d, setPrefer3d] = useState(false);
   const [trainerMode, setTrainerMode] = useState<string>("round_robin");
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
     setBoardTheme(loadTheme());
+    setPrefer3d(loadPrefer3d());
     const savedTrainerMode = localStorage.getItem("trainer_mode");
     if (savedTrainerMode === "round_robin" || savedTrainerMode === "challenge") {
       setTrainerMode(savedTrainerMode);
@@ -83,6 +85,26 @@ export default function SettingsPage() {
               saveTheme(k);
             }}
           />
+        </section>
+
+        {/* Board Style (2D / 3D) */}
+        <section>
+          <h2 className="mb-4 text-sm font-semibold tracking-wider text-zinc-400 uppercase">
+            Board Style
+          </h2>
+          <label className="flex items-center gap-3 text-sm text-zinc-300 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={prefer3d}
+              onChange={(e) => {
+                setPrefer3d(e.target.checked);
+                savePrefer3d(e.target.checked);
+                window.dispatchEvent(new CustomEvent("prefer-3d-change", { detail: e.target.checked }));
+              }}
+              className="h-4 w-4 border-zinc-700 bg-zinc-900"
+            />
+            3D perspective (image boards only)
+          </label>
         </section>
 
         {/* App Mode Selection */}

--- a/frontend/app/team-demo/page.tsx
+++ b/frontend/app/team-demo/page.tsx
@@ -26,7 +26,7 @@ import {
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
 import { Board } from "../Board";
-import { loadTheme, saveTheme, pickGameCoins, BOARD_THEMES, type BoardThemeKey } from "../boardThemes";
+import { loadTheme, saveTheme, loadPrefer3d, pickGameCoins, BOARD_THEMES, type BoardThemeKey } from "../boardThemes";
 import { AgentTeammatePanel } from "../ChiefOfStaffPanel";
 import { DiceRoll } from "../DiceRoll";
 import { rollDice } from "../dice";
@@ -447,11 +447,17 @@ function TeamDemoPageInner() {
   const [settleTxHash, setSettleTxHash] = useState<`0x${string}` | null>(null);
   const [hasStaleSession, setHasStaleSession] = useState(false);
   const [boardTheme, setBoardTheme] = useState<BoardThemeKey>(() => loadTheme());
+  const [prefer3d, setPrefer3d] = useState<boolean>(() => loadPrefer3d());
   const [gameCoins, setGameCoins] = useState<{ warm: string; cool: string } | null>(null);
   useEffect(() => {
-    const handler = (e: Event) => setBoardTheme((e as CustomEvent<BoardThemeKey>).detail);
-    window.addEventListener("board-theme-change", handler);
-    return () => window.removeEventListener("board-theme-change", handler);
+    const themeHandler = (e: Event) => setBoardTheme((e as CustomEvent<BoardThemeKey>).detail);
+    const prefer3dHandler = (e: Event) => setPrefer3d((e as CustomEvent<boolean>).detail);
+    window.addEventListener("board-theme-change", themeHandler);
+    window.addEventListener("prefer-3d-change", prefer3dHandler);
+    return () => {
+      window.removeEventListener("board-theme-change", themeHandler);
+      window.removeEventListener("prefer-3d-change", prefer3dHandler);
+    };
   }, []);
 
   // Doubling cube UI state
@@ -1525,6 +1531,7 @@ function TeamDemoPageInner() {
               turn={game.turn}
               ghostMove={hoveredMove}
               themeKey={boardTheme}
+              prefer3d={prefer3d}
               cubeValue={game.cubeValue ?? 1}
               cubeOwner={game.cubeOwner ?? -1}
               onCubeClick={canHumanDouble ? handleCubeClick : undefined}


### PR DESCRIPTION
- Add `imageIs3d` and `perspectiveDeg` fields to `BoardTheme` interface;
  mark `board_roman` and `board_cyber2` as perspective-rendered images
- Add `loadPrefer3d` / `savePrefer3d` helpers in boardThemes.ts (mirrors
  the existing loadTheme/saveTheme localStorage pattern)
- Promote background image out of the SVG into a sibling HTML `<div>` so
  a CSS `perspective(800px) rotateX` transform can be applied without
  breaking `getScreenCTM()` hit detection on the SVG overlay
- Apply inverse tilt (-20°) to pre-3D images in 2D mode; apply forward
  tilt (+20°) to flat images in 3D mode; classic SVG themes unaffected
- Add "Board Style" checkbox section in Settings that dispatches a
  `prefer-3d-change` custom event (mirrors board-theme-change pattern)
- Wire `prefer3d` state + event listener in team-demo/page.tsx, pass as
  prop to `<Board>`

https://claude.ai/code/session_01JGeTgXi2RmUhuxHG58xGH7