### PR TITLE
Sponsor embedded-wallet gas via Privy native sponsorship (useSponsoredWrite)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -5,6 +5,16 @@
 # "Log in" button will surface a configuration error.
 NEXT_PUBLIC_PRIVY_APP_ID=
 
+# Gas sponsorship (no env var — Privy Dashboard only). On-chain writes from
+# Privy embedded wallets (email / Google logins) are sent through Privy's
+# native gas sponsorship via `useSponsoredWrite` (frontend/app/useSponsoredWrite.ts),
+# so those users transact without holding the chain's native token. To turn
+# it on: in the Privy Dashboard open the Gas Sponsorship tab, enable
+# sponsorship, and select the chains to cover; the app must also run on
+# Privy's TEE execution. External wallets (MetaMask, WalletConnect) keep
+# paying their own gas. Without the Dashboard toggle the transaction still
+# submits but Privy rejects the sponsorship request.
+
 # WalletConnect Project ID — Privy forwards this to its internal
 # WalletConnect connector so the modal can render the WalletConnect QR
 # option. Create a free project at https://cloud.walletconnect.com and

--- a/frontend/app/AgentWalletPanel.tsx
+++ b/frontend/app/AgentWalletPanel.tsx
@@ -6,10 +6,10 @@ import {
   usePublicClient,
   useReadContract,
   useWalletClient,
-  useWriteContract,
 } from "wagmi";
 
 import { AgentVaultABI, useChainContracts } from "./contracts";
+import { useSponsoredWrite } from "./useSponsoredWrite";
 import { useActiveChainId } from "./chains";
 import { useI18n } from "./i18n";
 
@@ -51,7 +51,7 @@ export function AgentWalletPanel({ agentId, stakeWei, onBalanceChange }: Props) 
     query: { enabled: !noVault && agentId > 0 },
   });
 
-  const { writeContractAsync } = useWriteContract();
+  const { writeContractAsync } = useSponsoredWrite();
 
   const balanceWei = (rawBalance as bigint | undefined) ?? BigInt(0);
   const shortfall = stakeWei > balanceWei ? stakeWei - balanceWei : BigInt(0);

--- a/frontend/app/ProfileBadge.tsx
+++ b/frontend/app/ProfileBadge.tsx
@@ -14,10 +14,11 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { useReadContract, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
+import { useReadContract, useWaitForTransactionReceipt } from "wagmi";
 
 import { useChaingammonName } from "./useChaingammonName";
 import { useChaingammonProfile, useSyncEnsProfile } from "./useChaingammonProfile";
+import { useSponsoredWrite } from "./useSponsoredWrite";
 import { useActiveChainId } from "./chains";
 import { MatchRegistryABI, useChainContracts } from "./contracts";
 import { recordTransaction } from "./transactions";
@@ -78,7 +79,7 @@ export function ClaimForm({ address: _address }: { address: `0x${string}` }) {
     error: writeError,
     isPending: signing,
     reset: resetWrite,
-  } = useWriteContract();
+  } = useSponsoredWrite();
 
   const { isLoading: confirming, isSuccess } = useWaitForTransactionReceipt({ hash: txHash });
 

--- a/frontend/app/agent/[agentId]/AgentClient.tsx
+++ b/frontend/app/agent/[agentId]/AgentClient.tsx
@@ -20,10 +20,11 @@
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
-import { useAccount, useBalance, usePublicClient, useReadContracts, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
+import { useAccount, useBalance, usePublicClient, useReadContracts, useWaitForTransactionReceipt } from "wagmi";
 import { formatEther, parseAbiItem } from "viem";
 
 import { useActiveChain, useActiveChainId } from "../../chains";
+import { useSponsoredWrite } from "../../useSponsoredWrite";
 import {
   AgentRegistryABI,
   MatchRegistryABI,
@@ -307,7 +308,7 @@ export default function AgentClient() {
 
   const isContractOwner = userAddress?.toLowerCase() === contractOwner?.toLowerCase();
 
-  const { writeContract, data: burnTxHash, isPending: burnSigning } = useWriteContract();
+  const { writeContract, data: burnTxHash, isPending: burnSigning } = useSponsoredWrite();
   const { isLoading: burnConfirming, isSuccess: burnSuccess } = useWaitForTransactionReceipt({
     hash: burnTxHash,
   });

--- a/frontend/app/create-agent/page.tsx
+++ b/frontend/app/create-agent/page.tsx
@@ -29,11 +29,11 @@ import {
   usePublicClient,
   useWaitForTransactionReceipt,
   useWalletClient,
-  useWriteContract,
 } from "wagmi";
 import { decodeEventLog, parseEther } from "viem";
 
 import { AgentVaultABI, useChainContracts } from "../contracts";
+import { useSponsoredWrite } from "../useSponsoredWrite";
 import { recordTransaction } from "../transactions";
 import { ModelAdvisorPanel } from "./ModelAdvisorPanel";
 
@@ -172,7 +172,7 @@ export default function CreateAgentPage() {
   const { agentRegistry, agentVault } = useChainContracts();
   const { data: walletClient } = useWalletClient();
   const publicClient = usePublicClient();
-  const { writeContractAsync: writeVaultAsync } = useWriteContract();
+  const { writeContractAsync: writeVaultAsync } = useSponsoredWrite();
 
   const [agentLabel, setAgentLabel] = useState("");
   const [agentTier, setAgentTier] = useState<number>(0);
@@ -187,7 +187,7 @@ export default function CreateAgentPage() {
     error: writeError,
     isPending: signing,
     reset,
-  } = useWriteContract();
+  } = useSponsoredWrite();
 
   const { isLoading: confirming, isSuccess, data: receipt } =
     useWaitForTransactionReceipt({ hash: txHash });

--- a/frontend/app/match/page.tsx
+++ b/frontend/app/match/page.tsx
@@ -12,13 +12,13 @@ import { useRouter, useSearchParams } from "next/navigation";
 import {
   useAccount,
   usePublicClient,
-  useWriteContract,
 } from "wagmi";
 import { parseEther } from "viem";
 import { generatePrivateKey } from "viem/accounts";
 
 import { AgentWalletPanel } from "../AgentWalletPanel";
 import { AgentVaultABI, MatchEscrowABI, useChainContracts } from "../contracts";
+import { useSponsoredWrite } from "../useSponsoredWrite";
 import { useAppMode } from "../AppModeContext";
 import { useI18n } from "../i18n";
 
@@ -64,7 +64,7 @@ function MatchInner() {
   const { address, isConnected } = useAccount();
   const publicClient = usePublicClient();
   const { matchEscrow, agentVault } = useChainContracts();
-  const { writeContractAsync } = useWriteContract();
+  const { writeContractAsync } = useSponsoredWrite();
   const { mode } = useAppMode();
   const showStake = mode === "money" || mode === "advanced" || params.get("stake") === "1";
 

--- a/frontend/app/team-demo/page.tsx
+++ b/frontend/app/team-demo/page.tsx
@@ -14,7 +14,6 @@ import {
   useSignMessage,
   useSwitchChain,
   useWaitForTransactionReceipt,
-  useWriteContract,
 } from "wagmi";
 import {
   encodeAbiParameters,
@@ -34,6 +33,7 @@ import { rollDice } from "../dice";
 import { useActiveChain, useActiveChainId } from "../chains";
 import { AgentRegistryABI, MatchRegistryABI, useChainContracts } from "../contracts";
 import { useChaingammonName } from "../useChaingammonName";
+import { useSponsoredWrite } from "../useSponsoredWrite";
 import {
   type MatchState,
   newMatch,
@@ -548,7 +548,7 @@ function TeamDemoPageInner() {
   const { agentRegistry, matchRegistry, agentVault } = useChainContracts();
   const { label: humanLabel } = useChaingammonName(address);
   const { signMessageAsync } = useSignMessage();
-  const { writeContractAsync } = useWriteContract();
+  const { writeContractAsync } = useSponsoredWrite();
   const { switchChain, isPending: isSwitchingChain, error: switchChainError } =
     useSwitchChain();
   const txReceipt = useWaitForTransactionReceipt({ hash: settleTxHash ?? undefined });

--- a/frontend/app/useChaingammonProfile.ts
+++ b/frontend/app/useChaingammonProfile.ts
@@ -10,10 +10,11 @@
 "use client";
 
 import { encodePacked, keccak256, toBytes } from "viem";
-import { usePublicClient, useReadContract, useWriteContract } from "wagmi";
+import { usePublicClient, useReadContract } from "wagmi";
 
 import { useActiveChainId, useEnsInfra } from "./chains";
 import { PlayerSubnameRegistrarABI, PublicResolverABI, useChainContracts } from "./contracts";
+import { useSponsoredWrite } from "./useSponsoredWrite";
 
 function subnameNode(parentNode: `0x${string}`, label: string): `0x${string}` {
   const labelHash = keccak256(toBytes(label));
@@ -79,7 +80,7 @@ export function useSyncEnsProfile() {
   const { playerSubnameRegistrar } = useChainContracts();
   const chainId = useActiveChainId();
   const publicClient = usePublicClient();
-  const { writeContractAsync, isPending } = useWriteContract();
+  const { writeContractAsync, isPending } = useSponsoredWrite();
 
   const { data: parentNode } = useReadContract({
     address: playerSubnameRegistrar,

--- a/frontend/app/useSponsoredWrite.ts
+++ b/frontend/app/useSponsoredWrite.ts
@@ -1,0 +1,139 @@
+// Gas-sponsored contract writes (Privy native gas sponsorship).
+//
+// Privy can cover gas for transactions sent from a Privy *embedded* wallet
+// (the wallet auto-created for email / Google logins). External wallets
+// (MetaMask, WalletConnect) sign and pay their own gas as before — Privy
+// cannot sponsor a wallet it does not control.
+//
+// This hook is a drop-in replacement for wagmi's `useWriteContract`: it
+// exposes the same `writeContract` / `writeContractAsync` / `data` /
+// `error` / `isPending` / `reset` surface so call sites swap the import and
+// nothing else. Internally it branches on the active wallet:
+//
+//   - Embedded wallet  → encode the call to calldata and submit it through
+//     Privy's `useSendTransaction({ sponsor: true })`. Privy's paymaster
+//     pays the gas (configured per-chain in the Privy Dashboard).
+//   - External wallet  → fall through to wagmi's `writeContractAsync`, the
+//     existing behaviour, with the user paying gas.
+//
+// The returned `data` is a normal on-chain tx hash in both cases, so the
+// usual `useWaitForTransactionReceipt({ hash: data })` keeps working
+// regardless of who paid for gas.
+//
+// Dashboard requirement: native gas sponsorship must be enabled in the
+// Privy Dashboard (Gas Sponsorship tab → enable + select the chains to
+// sponsor), and the app must run on Privy's TEE execution. Without that the
+// embedded-wallet path still submits the transaction but Privy rejects the
+// `sponsor: true` flag.
+"use client";
+
+import { useState } from "react";
+import { encodeFunctionData, type Abi } from "viem";
+import { useAccount, useWriteContract } from "wagmi";
+import { useSendTransaction, useWallets } from "@privy-io/react-auth";
+
+export interface SponsoredWriteParams {
+  address: `0x${string}`;
+  abi: Abi;
+  functionName: string;
+  args?: readonly unknown[];
+  /** Native value to attach (wei). */
+  value?: bigint;
+  /** Target chain; defaults to the embedded wallet's active chain when omitted. */
+  chainId?: number;
+}
+
+export function useSponsoredWrite() {
+  const { address } = useAccount();
+  const { wallets } = useWallets();
+  const { sendTransaction } = useSendTransaction();
+  const wagmi = useWriteContract();
+
+  // State for the sponsored (embedded-wallet) path. wagmi owns the
+  // equivalent state for the external-wallet path.
+  const [sponsoredHash, setSponsoredHash] = useState<`0x${string}` | undefined>();
+  const [sponsoredPending, setSponsoredPending] = useState(false);
+  const [sponsoredError, setSponsoredError] = useState<Error | null>(null);
+
+  // The active wallet is a Privy embedded wallet → eligible for gas
+  // sponsorship. `privy-v2` covers Privy's newer embedded wallet client;
+  // this mirrors the detection already used in team-demo settlement.
+  const sponsored =
+    !!address &&
+    wallets.some(
+      (w) =>
+        w.address?.toLowerCase() === address.toLowerCase() &&
+        (w.walletClientType === "privy" || w.walletClientType === "privy-v2"),
+    );
+
+  // Plain functions — the React Compiler memoizes them, so no manual
+  // useCallback (which the compiler flags as unpreservable here).
+  const writeContractAsync = async (
+    params: SponsoredWriteParams,
+  ): Promise<`0x${string}`> => {
+    if (!sponsored) {
+      return wagmi.writeContractAsync({
+        address: params.address,
+        abi: params.abi,
+        functionName: params.functionName,
+        args: params.args,
+        value: params.value,
+        chainId: params.chainId,
+      } as Parameters<typeof wagmi.writeContractAsync>[0]);
+    }
+
+    setSponsoredPending(true);
+    setSponsoredError(null);
+    try {
+      const data = encodeFunctionData({
+        abi: params.abi,
+        functionName: params.functionName,
+        args: params.args ?? [],
+      });
+      const { hash } = await sendTransaction(
+        {
+          to: params.address,
+          data,
+          value: params.value,
+          chainId: params.chainId,
+        },
+        // Privy covers gas for this transaction. `address` pins the send
+        // to the active embedded wallet when a user has more than one.
+        { sponsor: true, address },
+      );
+      setSponsoredHash(hash);
+      return hash;
+    } catch (e) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      setSponsoredError(err);
+      throw err;
+    } finally {
+      setSponsoredPending(false);
+    }
+  };
+
+  // Fire-and-forget variant mirroring wagmi's `writeContract`. Errors land
+  // in `error` (sponsored path) or `wagmi.error` (external path); the
+  // rejected promise is swallowed here so it doesn't surface as unhandled.
+  const writeContract = (params: SponsoredWriteParams) => {
+    void writeContractAsync(params).catch(() => {});
+  };
+
+  const reset = () => {
+    setSponsoredHash(undefined);
+    setSponsoredError(null);
+    setSponsoredPending(false);
+    wagmi.reset();
+  };
+
+  return {
+    writeContract,
+    writeContractAsync,
+    data: sponsored ? sponsoredHash : wagmi.data,
+    error: sponsored ? sponsoredError : wagmi.error,
+    isPending: sponsored ? sponsoredPending : wagmi.isPending,
+    reset,
+    /** True when writes are routed through Privy gas sponsorship. */
+    sponsored,
+  };
+}


### PR DESCRIPTION
Routes on-chain writes from Privy embedded wallets (the wallet auto-created for email / Google logins) through Privy's native gas sponsorship so those users transact without holding the chain's native token. External wallets (MetaMask, WalletConnect) keep signing and paying their own gas.

useSponsoredWrite (frontend/app/useSponsoredWrite.ts, new):
- Drop-in replacement for wagmi's `useWriteContract`, exposing the same `writeContract` / `writeContractAsync` / `data` / `error` / `isPending` / `reset` surface so call sites swap the import and nothing else.
- Embedded wallet path: `encodeFunctionData` + Privy `useSendTransaction(tx, { sponsor: true })`; Privy's paymaster pays the gas.
- External wallet path: falls through to wagmi `writeContractAsync`, unchanged.
- Returns a standard on-chain tx hash in both cases, so `useWaitForTransactionReceipt({ hash: data })` keeps working regardless of who paid for gas.
- Embedded detection reuses the `walletClientType === "privy" | "privy-v2"` check already used in team-demo settlement.

Call sites swapped to the helper (import-only change):
- ProfileBadge (ENS subname claim)
- useSyncEnsProfile (ENS text records)
- AgentWalletPanel (vault fund / withdraw)
- match/page (escrow deposits)
- AgentClient (burn agent)
- create-agent (mint agent + fund vault)
- team-demo (match settlement)

frontend/.env.example (updated):
- Documents that gas sponsorship is a Privy Dashboard setting (Gas Sponsorship tab → enable + select chains) requiring TEE execution; no env var.

Note: full `next build` + Playwright e2e could not run in this environment because the Solidity compiler binary download is blocked by the network allowlist, so contract artifacts can't be generated. Verified via `tsc --noEmit` (no new type errors) and eslint (no new errors in changed files).

https://claude.ai/code/session_016YKmjsbqTZXx3Y8FgR6ddf