### PR TITLE
Fuse board+style for all model types + browser inference

### DIFF
--- a/agent/round_robin_trainer.py
+++ b/agent/round_robin_trainer.py
@@ -296,8 +296,10 @@ def run_round_robin(
     sklearn_codes = sklearn_codes or {}
     sklearn_ids: set[int] = {aid for aid in agent_ids if aid in sklearn_codes}
     # Per-agent SklearnProxy (for move selection) and training data accumulator.
-    sklearn_proxies: dict[int, SklearnProxy] = {aid: SklearnProxy() for aid in sklearn_ids}
-    # sklearn_data[aid] = list of (board_features np.ndarray, outcome float)
+    sklearn_proxies: dict[int, SklearnProxy] = {
+        aid: SklearnProxy(extras_dim=extras_dim) for aid in sklearn_ids
+    }
+    # sklearn_data[aid] = list of ([board ‖ style] np.ndarray, outcome float)
     sklearn_data: dict[int, list[tuple]] = {aid: [] for aid in sklearn_ids}
 
     # Hybrid load: try AgentRegistry → 0G storage; else seed fresh.
@@ -383,9 +385,15 @@ def run_round_robin(
             if opp_id in sklearn_ids and opp_states:
                 import numpy as _np
                 sk_won = float(winner == opp_id)
+                # The sklearn agent (opp) saw `opp_extras` as its style vector
+                # this match; train on [board ‖ style] so it conditions on style
+                # exactly as at inference, where SklearnProxy concatenates the
+                # same vector. Style is constant across the match's states.
+                opp_ext_np = opp_extras.detach().cpu().numpy().astype("float32")
                 for s in opp_states:
                     try:
-                        feat = encode_state(s, perspective=0).numpy()
+                        board_feat = encode_state(s, perspective=0).numpy()
+                        feat = _np.concatenate([board_feat, opp_ext_np])
                         sklearn_data[opp_id].append((feat, sk_won))
                     except Exception:
                         pass

--- a/agent/sample_trainer.py
+++ b/agent/sample_trainer.py
@@ -117,12 +117,19 @@ class BackgammonNet(nn.Module):
     signals, tournament position, stake size — anything that should
     affect the policy in career mode but not in single-game mode).
 
+    `core` and `extras` are summed *before* the hidden nonlinearity, so
+    together they are one first layer over [board ‖ style] — each hidden unit
+    depends jointly on board and style (genuine interaction, which a sum of two
+    separate sigmoids cannot represent).
+
     Weight layout:
-      core  : Linear(GNUBG_FEAT_DIM, hidden)  — initialized from gnubg.
-      extras: Linear(extras_dim,   hidden)    — randomly initialized.
+      core  : Linear(GNUBG_FEAT_DIM, hidden)  — initialized from gnubg (the
+              board columns of the [board‖style] first layer).
+      extras: Linear(extras_dim,   hidden)    — randomly initialized (the
+              style columns of that same first layer).
       head  : Linear(hidden,       1)         — randomly initialized.
 
-    When `extras_dim == 0` or the extras input is zero, the network's
+    When `extras_dim == 0` or the extras input is None, the network's
     behaviour reduces to the gnubg-equivalent single-game head.
     """
 
@@ -136,6 +143,8 @@ class BackgammonNet(nn.Module):
         extras_seed: int | None = None,
     ) -> None:
         super().__init__()
+        self.board_dim = in_dim
+        self.extras_dim = extras_dim
         self.core = gnubg_published_core_init(in_dim, hidden, seed=core_seed)
         if extras_dim > 0:
             self.extras = nn.Linear(extras_dim, hidden)
@@ -157,9 +166,14 @@ class BackgammonNet(nn.Module):
             self.head.bias.zero_()
 
     def forward(self, board: torch.Tensor, extras: torch.Tensor | None = None) -> torch.Tensor:
-        h = torch.sigmoid(self.core(board))
+        # Fuse board + style before the nonlinearity (one Linear over
+        # [board‖style]). Summing two separate sigmoids is board-separable, so a
+        # constant per-candidate style term cancels in the 1-ply argmax and
+        # style can never change move selection.
+        pre = self.core(board)
         if self.extras is not None and extras is not None:
-            h = h + torch.sigmoid(self.extras(extras))
+            pre = pre + self.extras(extras)
+        h = torch.sigmoid(pre)
         # Equity in [0, 1] — probability the side to move wins.
         return torch.sigmoid(self.head(h)).squeeze(-1)
 
@@ -310,7 +324,7 @@ def pick_move(net: BackgammonNet, candidates: list[RaceState], extras: torch.Ten
     """
     feats = torch.stack([encode_state(c, perspective) for c in candidates])
     with torch.no_grad():
-        ext = extras.unsqueeze(0).expand(len(candidates), -1) if net.extras is not None else None
+        ext = extras.unsqueeze(0).expand(len(candidates), -1) if getattr(net, "extras_dim", 0) > 0 else None
         equities = infer_fn(feats, ext) if infer_fn is not None else net(feats, ext)
     best = int(equities.argmax().item())
     return candidates[best], equities[best:best + 1]
@@ -360,7 +374,7 @@ def _make_eval_fn(net, extras: torch.Tensor, infer_fn=None):
     """
     def _eval(feats: torch.Tensor) -> torch.Tensor:
         n = feats.shape[0]
-        ext = extras.unsqueeze(0).expand(n, -1) if getattr(net, "extras", None) is not None else None
+        ext = extras.unsqueeze(0).expand(n, -1) if getattr(net, "extras_dim", 0) > 0 else None
         if infer_fn is not None:
             return infer_fn(feats, ext)
         with torch.no_grad():
@@ -433,7 +447,7 @@ def td_lambda_match(
             # Agent's turn — selects a successor and learns from the transition.
             board_now = encode_state(state, perspective=0)
             v_now = agent(board_now.unsqueeze(0),
-                          agent_extras.unsqueeze(0)) if agent.extras is not None else \
+                          agent_extras.unsqueeze(0)) if getattr(agent, "extras_dim", 0) > 0 else \
                     agent(board_now.unsqueeze(0))
 
             if search_depth >= 2:
@@ -447,9 +461,9 @@ def td_lambda_match(
                 with torch.no_grad():
                     board_next = encode_state(chosen, perspective=0)
                     if infer_fn is not None:
-                        ext_next = agent_extras.unsqueeze(0).expand(1, -1) if agent.extras is not None else None
+                        ext_next = agent_extras.unsqueeze(0).expand(1, -1) if getattr(agent, "extras_dim", 0) > 0 else None
                         v_next = infer_fn(board_next.unsqueeze(0), ext_next).item()
-                    elif agent.extras is not None:
+                    elif getattr(agent, "extras_dim", 0) > 0:
                         v_next = agent(board_next.unsqueeze(0), agent_extras.unsqueeze(0)).item()
                     else:
                         v_next = agent(board_next.unsqueeze(0)).item()
@@ -598,6 +612,7 @@ def save_checkpoint(net: BackgammonNet, path: Path, *, match_count: int,
         "in_dim": GNUBG_FEAT_DIM,
         "hidden": DEFAULT_HIDDEN,
         "feature_encoder": feature_encoder,
+        "input_contract": "board_style" if extras_dim > 0 else "board_only",
         "style_values": _compute_style_values(net),
     }, path)
 
@@ -605,35 +620,47 @@ def save_checkpoint(net: BackgammonNet, path: Path, *, match_count: int,
 def export_onnx(net: BackgammonNet, path: Path) -> None:
     """Export a trained BackgammonNet to ONNX for browser inference.
 
-    The extras head is omitted by tracing with extras=None, producing the
-    same board→equity interface as the bundled base model. The browser
-    ONNX worker can load this file directly without any code changes.
+    Emits the uniform agent contract shared by every model type (MLP, sklearn,
+    custom): a single `features` input — the board encoding concatenated with
+    the style/extras vector — mapping to a single `equity` output. A net with no
+    extras head (extras_dim == 0) exports a board-only `features` input of width
+    GNUBG_FEAT_DIM, so the browser worker handles both by inspecting the width.
 
-    Input:  board  float32[batch, 198]
-    Output: equity float32[batch]
+    Input:  features float32[batch, board_dim + extras_dim]
+    Output: equity   float32[batch]
     """
     import torch.onnx
 
-    class _BoardOnly(torch.nn.Module):
+    board_dim = getattr(net, "board_dim", GNUBG_FEAT_DIM)
+    extras_dim = getattr(net, "extras_dim", 0)
+
+    class _Fused(torch.nn.Module):
+        """Splits the single `features` input back into (board, extras) and
+        runs the net, so the ONNX graph exposes one uniform input."""
+
         def __init__(self, inner: BackgammonNet) -> None:
             super().__init__()
             self.inner = inner
+            self.board_dim = board_dim
 
-        def forward(self, board: torch.Tensor) -> torch.Tensor:
-            return self.inner(board, extras=None)
+        def forward(self, features: torch.Tensor) -> torch.Tensor:
+            board = features[:, : self.board_dim]
+            extras = features[:, self.board_dim :] if features.shape[1] > self.board_dim else None
+            return self.inner(board, extras)
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    wrapped = _BoardOnly(net)
+    wrapped = _Fused(net)
     wrapped.eval()
-    dummy = torch.zeros(1, GNUBG_FEAT_DIM)
+    dummy = torch.zeros(1, board_dim + extras_dim)
     torch.onnx.export(
         wrapped,
         (dummy,),
         str(path),
-        input_names=["board"],
+        input_names=["features"],
         output_names=["equity"],
-        dynamic_axes={"board": {0: "batch"}, "equity": {0: "batch"}},
+        dynamic_axes={"features": {0: "batch"}, "equity": {0: "batch"}},
         opset_version=11,
+        dynamo=False,
     )
 
 
@@ -738,12 +765,13 @@ def main() -> None:
                         metavar="PATH",
                         help="After training (and optionally saving the .pt "
                              "checkpoint), export the model to ONNX at PATH. "
-                             "The exported file has a single 'board' input "
-                             "[batch, 198] and a single 'equity' output "
-                             "[batch], matching the bundled base model's "
-                             "interface so the browser ONNX worker can load "
-                             "it directly. Combine with --upload-onnx-to-0g "
-                             "to push the result to 0G Storage.")
+                             "The exported file has a single 'features' input "
+                             "[batch, board_dim + extras_dim] (board encoding "
+                             "concatenated with the style vector) and a single "
+                             "'equity' output [batch]; the browser ONNX worker "
+                             "feeds board+style by inspecting the input width. "
+                             "Combine with --upload-onnx-to-0g to push the "
+                             "result to 0G Storage.")
     parser.add_argument("--upload-onnx-to-0g", action="store_true",
                         help="After --export-onnx, AES-256-GCM-encrypt the "
                              "ONNX file with a fresh key (written as "

--- a/agent/sklearn_agent.py
+++ b/agent/sklearn_agent.py
@@ -3,7 +3,7 @@
 Sklearn agents participate in the round-robin as opponents (no TD-lambda
 gradient updates). After training they are fitted on collected game data
 and exported as ONNX with the correct input/output names expected by the
-inference layer (`board` → `equity`).
+inference layer (`features` → `equity`, where `features` = board ‖ style).
 """
 from __future__ import annotations
 
@@ -19,7 +19,8 @@ if TYPE_CHECKING:
 
 SKLEARN_PATTERN = re.compile(r"\bfrom sklearn\b|\bimport sklearn\b")
 
-FEAT_DIM = 198
+# Board encoding width; the fitted feature vector is this plus the style dim.
+BOARD_DIM = 198
 
 
 def is_sklearn_code(source: str) -> bool:
@@ -32,12 +33,17 @@ class SklearnProxy:
     Before the model is fitted it returns 0.5 for every candidate (random
     play). After `update_model()` is called with a fitted estimator it
     delegates to that estimator's `predict()`.
+
+    Like the MLP, it consumes the uniform agent input — each candidate's board
+    encoding concatenated with the match's style/extras vector. `extras_dim > 0`
+    is the signal to callers (pick_move / search) that this model takes style;
+    a decision-tree ensemble then splits on board and style columns alike, so
+    style×board interaction is native.
     """
 
-    extras = None  # signals to callers: no extras head
-
-    def __init__(self) -> None:
+    def __init__(self, extras_dim: int = 0) -> None:
         self._model = None
+        self.extras_dim = extras_dim
 
     def update_model(self, model) -> None:
         self._model = model
@@ -45,6 +51,9 @@ class SklearnProxy:
     def __call__(self, feats: torch.Tensor, ext=None) -> torch.Tensor:
         if self._model is None:
             return torch.full((feats.shape[0],), 0.5)
+        # Predict on [board ‖ style], matching the rows the model was fitted on.
+        if ext is not None:
+            feats = torch.cat([feats, ext], dim=-1)
         arr = feats.detach().numpy().astype("float32")
         try:
             preds = np.clip(self._model.predict(arr).astype("float32"), 0.0, 1.0)
@@ -89,8 +98,9 @@ def fit_and_export_sklearn(
     """Fit the sklearn model from `source` on (X, y) and export to ONNX.
 
     Returns `(local_onnx_path, root_hash | None)`.
-    The exported ONNX has input name `"board"` [None, 198] and output
-    name `"equity"` [None] matching what onnx_board_state / onnx_worker expect.
+    The exported ONNX has a single input `"features"` [None, X.shape[1]] — the
+    board encoding concatenated with the style vector — and output name
+    `"equity"` [None]: the uniform agent contract the browser worker expects.
     """
     from skl2onnx import convert_sklearn
     from skl2onnx.common.data_types import FloatTensorType
@@ -98,7 +108,8 @@ def fit_and_export_sklearn(
     model = build_sklearn_model(source)
     model.fit(X, y)
 
-    initial_types = [("board", FloatTensorType([None, FEAT_DIM]))]
+    n_features = int(X.shape[1])
+    initial_types = [("features", FloatTensorType([None, n_features]))]
     onnx_model = convert_sklearn(model, initial_types=initial_types)
 
     # skl2onnx names the output "variable" — rename to "equity"

--- a/agent/tests/test_model_agnostic_style.py
+++ b/agent/tests/test_model_agnostic_style.py
@@ -1,0 +1,132 @@
+"""Model-agnostic style tests — the contract must hold for ANY model, not just
+the MLP: random forests and 2-ply search (incl. ply-backoff) all condition on
+[board ‖ style] for both inference and training.
+
+Run with:  cd agent && uv run pytest tests/test_model_agnostic_style.py -v
+
+Why this proves generality: every model is reached through the same
+`(feats, ext) -> equities` boundary. `_make_eval_fn` closes over the style
+vector and broadcasts it onto *every* leaf the search evaluates, so the model —
+whatever it is — sees board+style at each leaf. The contract is therefore
+depth-agnostic (1-ply, 2-ply, or any backoff scheme) and model-agnostic.
+"""
+from __future__ import annotations
+
+import random
+
+import numpy as np
+import torch
+
+from sample_trainer import (
+    BackgammonNet,
+    DEFAULT_EXTRAS_DIM,
+    GNUBG_FEAT_DIM,
+    RaceState,
+    _make_eval_fn,
+    td_lambda_match,
+)
+from search import search_2ply
+from sklearn_agent import SklearnProxy, build_sklearn_model
+
+FOREST_SRC = (
+    "from sklearn.ensemble import RandomForestRegressor\n"
+    "def build_model():\n"
+    "    return RandomForestRegressor(n_estimators=32, random_state=0)\n"
+)
+
+
+def _forest_proxy_conditioned_on_style(style_dim: int = 4) -> SklearnProxy:
+    """A fitted random forest whose label depends only on style column 0, wired
+    through SklearnProxy exactly as the round-robin does."""
+    rng = np.random.default_rng(0)
+    n = 400
+    board = rng.standard_normal((n, GNUBG_FEAT_DIM)).astype("float32")
+    style = rng.standard_normal((n, style_dim)).astype("float32")
+    X = np.concatenate([board, style], axis=1)
+    y = (style[:, 0] > 0.0).astype("float32")
+    model = build_sklearn_model(FOREST_SRC)
+    model.fit(X, y)
+    proxy = SklearnProxy(extras_dim=style_dim)
+    proxy.update_model(model)
+    return proxy
+
+
+# ---------------------------------------------------------------------------
+# The generic eval boundary carries style to any model
+# ---------------------------------------------------------------------------
+
+
+def test_eval_fn_conditions_on_style_for_mlp():
+    """_make_eval_fn — the boundary every search depth goes through — produces
+    different leaf equities for different styles (the MLP fuses board+style)."""
+    torch.manual_seed(0)
+    net = BackgammonNet(extras_dim=DEFAULT_EXTRAS_DIM, extras_seed=2)
+    net.eval()
+    boards = torch.randn(16, GNUBG_FEAT_DIM)
+    eval_a = _make_eval_fn(net, torch.randn(DEFAULT_EXTRAS_DIM))
+    eval_b = _make_eval_fn(net, torch.randn(DEFAULT_EXTRAS_DIM))
+    assert not torch.allclose(eval_a(boards), eval_b(boards))
+
+
+def test_eval_fn_conditions_on_style_for_forest():
+    """Same boundary, arbitrary model: a random forest's leaf equities move with
+    style because SklearnProxy concatenates style before predict()."""
+    proxy = _forest_proxy_conditioned_on_style()
+    boards = torch.randn(16, GNUBG_FEAT_DIM)
+    eval_pos = _make_eval_fn(proxy, torch.tensor([2.0, 0.0, 0.0, 0.0]))
+    eval_neg = _make_eval_fn(proxy, torch.tensor([-2.0, 0.0, 0.0, 0.0]))
+    assert eval_pos(boards).mean() > eval_neg(boards).mean() + 0.2
+
+
+# ---------------------------------------------------------------------------
+# 2-ply search (depth-/backoff-agnostic) conditions on style — MLP and forest
+# ---------------------------------------------------------------------------
+
+
+def test_2ply_value_responds_to_style_mlp():
+    """The 2-ply expectiminimax value changes with style — style propagates to
+    every leaf the search evaluates, so deeper/backoff search keeps it."""
+    torch.manual_seed(0)
+    net = BackgammonNet(extras_dim=DEFAULT_EXTRAS_DIM, extras_seed=4)
+    net.eval()
+    state = RaceState()  # opening race position — successors are non-terminal
+    _, v_a = search_2ply(state, (3, 1), _make_eval_fn(net, torch.randn(DEFAULT_EXTRAS_DIM)), perspective=0)
+    _, v_b = search_2ply(state, (3, 1), _make_eval_fn(net, torch.randn(DEFAULT_EXTRAS_DIM)), perspective=0)
+    assert abs(v_a - v_b) > 1e-6
+
+
+def test_2ply_value_responds_to_style_forest():
+    """A random forest driving the 2-ply search also conditions on style — proves
+    an arbitrary (non-MLP) model gets board+style under search, out of the box."""
+    proxy = _forest_proxy_conditioned_on_style()
+    state = RaceState()
+    _, v_pos = search_2ply(state, (3, 1), _make_eval_fn(proxy, torch.tensor([2.0, 0.0, 0.0, 0.0])), perspective=0)
+    _, v_neg = search_2ply(state, (3, 1), _make_eval_fn(proxy, torch.tensor([-2.0, 0.0, 0.0, 0.0])), perspective=0)
+    assert abs(v_pos - v_neg) > 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Training on board+style works under 2-ply search too
+# ---------------------------------------------------------------------------
+
+
+def test_2ply_training_updates_params_with_style():
+    """A TD(λ) match at search_depth=2 runs and updates the agent — confirming
+    training (not just inference) goes through the style-carrying search path."""
+    random.seed(0)
+    torch.manual_seed(0)
+    agent = BackgammonNet(core_seed=0xBACC, extras_seed=1)
+    opponent = BackgammonNet(core_seed=0xBACC, extras_seed=2)
+    a_ext = torch.randn(DEFAULT_EXTRAS_DIM)
+    o_ext = torch.randn(DEFAULT_EXTRAS_DIM)
+    pre_core = agent.core.weight.clone()
+
+    steps, _won, *_ = td_lambda_match(
+        agent, opponent, a_ext, o_ext,
+        gamma=1.0, lam=0.7, lr=1e-2,
+        search_depth=2, opp_search_depth=2,
+    )
+    assert steps > 0
+    assert not torch.equal(pre_core, agent.core.weight), (
+        "2-ply TD training should update the agent's fused first layer"
+    )

--- a/agent/tests/test_round_robin.py
+++ b/agent/tests/test_round_robin.py
@@ -49,7 +49,9 @@ def _stub_td_match():
         counter["i"] += 1
         steps = 30 + counter["i"]   # distinct plies per match for sanity
         won = counter["i"] % 2      # 0/1 alternation
-        return steps, won
+        # td_lambda_match returns (steps, won, agent_states, opp_states); the
+        # stub mirrors that 4-tuple (empty state lists — no sklearn data path).
+        return steps, won, [], []
 
     return stub, calls
 

--- a/agent/tests/test_sample_trainer.py
+++ b/agent/tests/test_sample_trainer.py
@@ -28,6 +28,7 @@ from sample_trainer import (
     RaceState,
     encode_extras,
     encode_state,
+    export_onnx,
     legal_successors,
     load_checkpoint,
     save_checkpoint,
@@ -295,3 +296,80 @@ def test_career_mode_extras_use_real_encoder():
     # And the encoder is deterministic for a fixed context.
     extras2 = encode_career_context(ctx, dim=DEFAULT_EXTRAS_DIM)
     assert torch.equal(extras, extras2)
+
+
+# ---------------------------------------------------------------------------
+# Style actually affects move selection (board × style fusion)
+# ---------------------------------------------------------------------------
+
+
+def test_style_vector_changes_move_ranking():
+    """The fusion fix: style must be able to change which move looks best.
+
+    The old additive form computed sigmoid(core(board)) + sigmoid(extras(ext)),
+    adding a constant per-style term to every candidate before a monotonic
+    output — so the candidate ranking (hence the 1-ply argmax) was identical
+    for every style. Fusing before the nonlinearity lets style reorder them.
+    """
+    torch.manual_seed(0)
+    net = BackgammonNet(extras_dim=DEFAULT_EXTRAS_DIM, extras_seed=3)
+    net.eval()
+    boards = torch.randn(64, GNUBG_FEAT_DIM)
+    ext_a = torch.randn(DEFAULT_EXTRAS_DIM)
+    ext_b = torch.randn(DEFAULT_EXTRAS_DIM)
+    with torch.no_grad():
+        eq_a = net(boards, ext_a.unsqueeze(0).expand(64, -1))
+        eq_b = net(boards, ext_b.unsqueeze(0).expand(64, -1))
+    assert not torch.equal(eq_a.argsort(), eq_b.argsort()), (
+        "style vector must be able to reorder candidate equities (it could not "
+        "under the old additive fusion)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ONNX export: uniform single `features` (board ‖ style) contract
+# ---------------------------------------------------------------------------
+
+
+def test_export_onnx_single_features_input_matches_forward(tmp_path):
+    """export_onnx emits one `features` input of width board_dim+extras_dim and
+    one `equity` output, and running it reproduces the net's forward on the
+    concatenated [board ‖ style] input."""
+    import numpy as np
+    import onnxruntime as ort
+
+    torch.manual_seed(0)
+    net = BackgammonNet(extras_dim=DEFAULT_EXTRAS_DIM, extras_seed=5)
+    net.eval()
+    path = tmp_path / "m.onnx"
+    export_onnx(net, path)
+
+    sess = ort.InferenceSession(str(path))
+    inputs = sess.get_inputs()
+    assert len(inputs) == 1
+    assert inputs[0].name == "features"
+    assert inputs[0].shape[-1] == GNUBG_FEAT_DIM + DEFAULT_EXTRAS_DIM
+    assert [o.name for o in sess.get_outputs()] == ["equity"]
+
+    board = torch.randn(3, GNUBG_FEAT_DIM)
+    ext = torch.randn(3, DEFAULT_EXTRAS_DIM)
+    feats = torch.cat([board, ext], dim=-1).numpy()
+    out = sess.run(["equity"], {"features": feats})[0].reshape(-1)
+    with torch.no_grad():
+        ref = net(board, ext).numpy().reshape(-1)
+    np.testing.assert_allclose(out, ref, rtol=1e-3, atol=1e-4)
+
+
+def test_export_onnx_board_only_when_no_extras(tmp_path):
+    """A net with extras_dim == 0 exports a board-only `features` input of width
+    GNUBG_FEAT_DIM (so the browser worker can still drive it)."""
+    import onnxruntime as ort
+
+    net = BackgammonNet(extras_dim=0)
+    net.eval()
+    path = tmp_path / "m0.onnx"
+    export_onnx(net, path)
+    sess = ort.InferenceSession(str(path))
+    inputs = sess.get_inputs()
+    assert len(inputs) == 1
+    assert inputs[0].shape[-1] == GNUBG_FEAT_DIM

--- a/agent/tests/test_sklearn_agent.py
+++ b/agent/tests/test_sklearn_agent.py
@@ -1,0 +1,87 @@
+"""Tests for sklearn_agent.py — the random-forest ("reason forest") path.
+
+Run with:  cd agent && uv run pytest tests/test_sklearn_agent.py -v
+
+Covers the uniform agent contract for non-MLP models:
+  - SklearnProxy predicts on [board ‖ style], so a forest conditions on style
+    out of the box (it splits on style columns alongside board columns).
+  - fit_and_export_sklearn emits a single `features` input (board ‖ style) and
+    an `equity` output — the same ONNX contract the MLP export produces.
+"""
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+from sklearn_agent import SklearnProxy, build_sklearn_model, fit_and_export_sklearn
+
+# A minimal random-forest agent, as a mint would supply via model code.
+FOREST_SRC = (
+    "from sklearn.ensemble import RandomForestRegressor\n"
+    "def build_model():\n"
+    "    return RandomForestRegressor(n_estimators=16, random_state=0)\n"
+)
+
+
+def test_sklearn_proxy_conditions_on_style():
+    """Outcome here depends only on a style column — a board-only model could
+    never learn it, but [board ‖ style] rows let the forest split on style, so
+    flipping that style column flips the prediction."""
+    rng = np.random.default_rng(0)
+    n, board_dim, style_dim = 400, 198, 4
+    board = rng.standard_normal((n, board_dim)).astype("float32")
+    style = rng.standard_normal((n, style_dim)).astype("float32")
+    X = np.concatenate([board, style], axis=1)
+    y = (style[:, 0] > 0.0).astype("float32")  # label depends on style[0] only
+
+    model = build_sklearn_model(FOREST_SRC)
+    model.fit(X, y)
+
+    proxy = SklearnProxy(extras_dim=style_dim)
+    proxy.update_model(model)
+    assert proxy.extras_dim == style_dim  # signals "this model takes style"
+
+    feats = torch.from_numpy(board[:32])
+    ext_pos = torch.tensor([2.0, 0.0, 0.0, 0.0]).unsqueeze(0).expand(32, -1)
+    ext_neg = torch.tensor([-2.0, 0.0, 0.0, 0.0]).unsqueeze(0).expand(32, -1)
+
+    p_pos = proxy(feats, ext_pos).mean().item()
+    p_neg = proxy(feats, ext_neg).mean().item()
+    assert p_pos > p_neg + 0.25, (
+        f"style must move the forest's prediction; got pos={p_pos} neg={p_neg}"
+    )
+
+
+def test_sklearn_proxy_unfitted_returns_half():
+    proxy = SklearnProxy(extras_dim=4)
+    out = proxy(torch.zeros(5, 198), torch.zeros(5, 4))
+    assert out.shape == (5,)
+    assert torch.allclose(out, torch.full((5,), 0.5))
+
+
+def test_fit_and_export_sklearn_features_contract(tmp_path):
+    """The exported ONNX has a single `features` input whose width is the
+    fitted feature width (board + style) and an `equity` output."""
+    import onnxruntime as ort
+
+    rng = np.random.default_rng(1)
+    board_dim, style_dim = 198, 4
+    width = board_dim + style_dim
+    X = rng.standard_normal((150, width)).astype("float32")
+    y = (X[:, board_dim] > 0.0).astype("float32")
+
+    path, root_hash = fit_and_export_sklearn(
+        FOREST_SRC, X, y, agent_id=7, checkpoint_dir=tmp_path,
+    )
+    assert path.exists()
+    assert root_hash is None  # upload=False
+
+    sess = ort.InferenceSession(str(path))
+    inputs = sess.get_inputs()
+    assert len(inputs) == 1
+    assert inputs[0].name == "features"
+    assert inputs[0].shape[-1] == width
+    assert "equity" in [o.name for o in sess.get_outputs()]
+
+    res = sess.run(["equity"], {"features": X[:3]})[0]
+    assert res.reshape(-1).shape[0] == 3

--- a/frontend/app/team-demo/page.tsx
+++ b/frontend/app/team-demo/page.tsx
@@ -51,6 +51,7 @@ import { CubeModal } from "./CubeModal";
 import { CubeTransactionOverlay } from "./CubeTransactionOverlay";
 import { loadAgentModel } from "../../lib/onnx_eval";
 import { loadAgentOnnxBytes } from "../../lib/agent_model_loader";
+import { encodeStyleVector } from "../../lib/career_features";
 import { type Board as GameBoard } from "../../lib/rules_engine";
 import { useI18n } from "../i18n";
 
@@ -887,7 +888,19 @@ function TeamDemoPageInner() {
       if (weightsHash && weightsHash !== ZERO_HASH) {
         const onnxBytes = await loadAgentOnnxBytes(weightsHash);
         if (onnxBytes) {
-          await loadAgentModel(onnxBytes).catch(() => {/* fall back to base */});
+          // Feed the agent's own style (self_style) so its trained board×style
+          // model plays with its personality; neutral style on any failure.
+          let styleVec: number[] | undefined;
+          try {
+            const res = await fetch(`${SERVER}/agents/${opponentIds[0]}/profile`);
+            if (res.ok) {
+              const profile = (await res.json()) as { values?: Record<string, number> };
+              if (profile?.values) styleVec = Array.from(encodeStyleVector(profile.values));
+            }
+          } catch {
+            /* server unreachable — worker falls back to a neutral style */
+          }
+          await loadAgentModel(onnxBytes, styleVec).catch(() => {/* fall back to base */});
         }
       }
       const state = newMatch(3);

--- a/frontend/lib/career_features.ts
+++ b/frontend/lib/career_features.ts
@@ -1,0 +1,77 @@
+/**
+ * Browser port of agent/career_features.py's 40-d "extras" layout.
+ *
+ * Builds the style half of the uniform agent input — the second part of the
+ * `features = [board(198) ‖ style(40)]` vector that every per-agent ONNX model
+ * (MLP or sklearn forest) now consumes. Must stay byte-compatible with
+ * career_features.encode_career_context(dim=40); see that file for the layout.
+ */
+
+export const STYLE_DIM = 40;
+
+// Mirrors career_features.ALL_CATEGORIES — order is significant and must match.
+export const ALL_CATEGORIES: readonly string[] = [
+  "opening_slot",
+  "opening_split",
+  "opening_builder",
+  "opening_anchor",
+  "build_5_point",
+  "build_bar_point",
+  "bearoff_efficient",
+  "bearoff_safe",
+  "risk_hit_exposure",
+  "risk_blot_leaving",
+  "hits_blot",
+  "runs_back_checker",
+  "anchors_back",
+  "phase_prime_building",
+  "phase_race_conversion",
+  "phase_back_game",
+  "phase_holding_game",
+  "phase_blitz",
+  "cube_offer_aggressive",
+  "cube_take_aggressive",
+];
+
+// The 18 non-cube axes used in the 40-d layout (ALL_CATEGORIES[:18]).
+export const ACTIVE_AXES: readonly string[] = ALL_CATEGORIES.slice(0, 18);
+
+const STAKE_LOG_DIVISOR = 70.0;
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function project(style: Record<string, number> | null | undefined): number[] {
+  if (!style) return new Array(ACTIVE_AXES.length).fill(0);
+  return ACTIVE_AXES.map((ax) => clamp(Number(style[ax] ?? 0), -1, 1));
+}
+
+export interface StyleContext {
+  stakeWei?: number;
+  tournamentPosition?: number;
+  isTeamMatch?: boolean;
+}
+
+/**
+ * Encode the 40-d style vector: [self(18) | opponent(18) | stake | tourney |
+ * team | bias]. Neutral (all-zero style + bias=1) when called with no args,
+ * which is a valid input that lets any board+style model run.
+ */
+export function encodeStyleVector(
+  selfStyle?: Record<string, number> | null,
+  opponentStyle?: Record<string, number> | null,
+  ctx: StyleContext = {},
+): Float32Array {
+  const out = new Float32Array(STYLE_DIM);
+  const self = project(selfStyle);
+  const opp = project(opponentStyle);
+  for (let i = 0; i < 18; i++) out[i] = self[i];
+  for (let i = 0; i < 18; i++) out[18 + i] = opp[i];
+  const stake = Math.max(0, ctx.stakeWei ?? 0);
+  out[36] = Math.min(Math.log1p(stake) / STAKE_LOG_DIVISOR, 1.0);
+  out[37] = clamp(ctx.tournamentPosition ?? 0, -1, 1);
+  out[38] = ctx.isTeamMatch ? 1.0 : 0.0;
+  out[39] = 1.0; // bias channel
+  return out;
+}

--- a/frontend/lib/onnx_eval.ts
+++ b/frontend/lib/onnx_eval.ts
@@ -101,8 +101,15 @@ export function warmupOnnx(): void {
  *
  * The caller transfers ownership of `modelBytes` — do not use the buffer
  * after calling this function.
+ *
+ * `styleVec` is the agent's 40-d style vector (career_features layout). When
+ * the model is a board+style model it is fed as the second half of
+ * `features = [board ‖ style]`; omit it and the worker uses a neutral style.
  */
-export async function loadAgentModel(modelBytes: ArrayBuffer): Promise<void> {
+export async function loadAgentModel(
+  modelBytes: ArrayBuffer,
+  styleVec?: number[],
+): Promise<void> {
   if (_worker) {
     _worker.terminate();
     _worker = null;
@@ -118,7 +125,7 @@ export async function loadAgentModel(modelBytes: ArrayBuffer): Promise<void> {
     _initResolve = resolve;
     _initReject = reject;
     // Transfer modelBytes so the worker owns the memory.
-    getWorker().postMessage({ type: "init", modelBytes }, [modelBytes]);
+    getWorker().postMessage({ type: "init", modelBytes, styleVec }, [modelBytes]);
   });
   return _initPromise;
 }

--- a/frontend/lib/onnx_worker.ts
+++ b/frontend/lib/onnx_worker.ts
@@ -6,6 +6,7 @@
 import type * as ORT from "onnxruntime-web";
 import { generateLegalMoves, encodeFullBoard, applyMove } from "./rules_engine";
 import type { Board } from "./rules_engine";
+import { STYLE_DIM } from "./career_features";
 
 type OrtNs = typeof ORT;
 
@@ -59,12 +60,70 @@ async function loadModelBytes(): Promise<ArrayBuffer> {
 let _ort: OrtNs | null = null;
 let _session: ORT.InferenceSession | null = null;
 
+// ── Uniform agent input contract ─────────────────────────────────────────────
+// Every per-agent model (MLP or sklearn forest) takes one input that is the
+// board encoding concatenated with the style vector: features = [board ‖ style].
+// The bundled base model is board-only. We don't know the width up front
+// (onnxruntime-web 1.16 exposes input *names* but not shapes), so the first
+// inference probes board-only and falls back to board+style.
+const BOARD_DIM = 198;
+let _styleVec: Float32Array | null = null; // real style for the loaded agent, if any
+let _inputName = "board";
+let _featMode: "unknown" | "board" | "concat" = "unknown";
+
+function styleHalf(): Float32Array {
+  if (_styleVec && _styleVec.length === STYLE_DIM) return _styleVec;
+  // Neutral style: all-zero with the bias channel set, matching the trainer's
+  // encode_career_context bias slot — a valid input that lets any model run.
+  const s = new Float32Array(STYLE_DIM);
+  s[STYLE_DIM - 1] = 1.0;
+  return s;
+}
+
+function concatFeatures(board: Float32Array): Float32Array {
+  const f = new Float32Array(BOARD_DIM + STYLE_DIM);
+  f.set(board, 0);
+  f.set(styleHalf(), BOARD_DIM);
+  return f;
+}
+
+async function runEquity(board: Float32Array): Promise<number> {
+  const ort = _ort!;
+  const session = _session!;
+  const runBoard = async () => {
+    const t = new ort.Tensor("float32", board, [1, BOARD_DIM]);
+    const r = await session.run({ [_inputName]: t });
+    return r.equity.data[0] as number;
+  };
+  const runConcat = async () => {
+    const feats = concatFeatures(board);
+    const t = new ort.Tensor("float32", feats, [1, feats.length]);
+    const r = await session.run({ [_inputName]: t });
+    return r.equity.data[0] as number;
+  };
+  if (_featMode === "board") return runBoard();
+  if (_featMode === "concat") return runConcat();
+  // First call: detect the contract. Board-only models (base/legacy) succeed
+  // here; board+style models reject the 198-wide input, so we retry with style.
+  try {
+    const v = await runBoard();
+    _featMode = "board";
+    return v;
+  } catch {
+    const v = await runConcat();
+    _featMode = "concat";
+    return v;
+  }
+}
+
 async function initORT(modelBytes?: ArrayBuffer): Promise<void> {
   const ort = (await import("onnxruntime-web")) as OrtNs;
   ort.env.wasm.wasmPaths = "/js/";
   ort.env.wasm.numThreads = 1;
   const buf = modelBytes ?? await loadModelBytes();
   _session = await ort.InferenceSession.create(buf, { executionProviders: ["wasm"] });
+  _inputName = _session.inputNames?.[0] ?? "board";
+  _featMode = "unknown";
   _ort = ort;
 }
 
@@ -76,6 +135,10 @@ interface InitMsg {
    *  these bytes instead of fetching /backgammon_net.onnx. Transfer the
    *  ArrayBuffer as a Transferable so the main thread cedes ownership. */
   modelBytes?: ArrayBuffer;
+  /** Optional style vector (career_features 40-d layout) for the loaded agent.
+   *  Fed as the second half of `features = [board ‖ style]`. When omitted, a
+   *  neutral style is used so board+style models still run. */
+  styleVec?: number[];
 }
 interface EvaluateMsg {
   type: "evaluate";
@@ -97,8 +160,10 @@ workerScope.onmessage = async (event: MessageEvent<InitMsg | EvaluateMsg>) => {
   const msg = event.data;
 
   if (msg.type === "init") {
+    const initMsg = msg as InitMsg;
+    _styleVec = initMsg.styleVec ? Float32Array.from(initMsg.styleVec) : null;
     try {
-      await initORT((msg as InitMsg).modelBytes);
+      await initORT(initMsg.modelBytes);
       workerScope.postMessage({ type: "init_ok" });
     } catch (e) {
       workerScope.postMessage({ type: "init_err", message: String(e) });
@@ -118,9 +183,7 @@ workerScope.onmessage = async (event: MessageEvent<InitMsg | EvaluateMsg>) => {
       for (const moveStr of moves) {
         const nextBoard = applyMove(board, side, moveStr);
         const feat = encodeFullBoard(nextBoard, 1 - side);
-        const tensor = new _ort.Tensor("float32", feat, [1, 198]);
-        const results = await _session.run({ board: tensor });
-        const prob = results.equity.data[0] as number;
+        const prob = await runEquity(feat);
         candidates.push({ move: moveStr, equity: 1 - prob });
       }
       candidates.sort((a, b) => b.equity - a.equity);


### PR DESCRIPTION
## Summary

Makes **every per-agent model** consume one uniform input — `features = [board(198) ‖ style(40)]` — for both **training and inference**, and wires the browser path to match. Before this, only the MLP saw style (loosely), sklearn agents ignored it, and the browser ran board-only.

- **MLP & 2-ply** (`sample_trainer.py`): fuse the style vector before the nonlinearity; the 2-ply leaf evaluator carries the same style into every leaf, so conditioning is depth-agnostic.
- **sklearn / any minted `build_model()`** (`sklearn_agent.py`, `round_robin_trainer.py`): train on `[board‖style]` rows and infer via `SklearnProxy` on the same concatenated input — RandomForest, GBM, SVR, etc.
- **Uniform ONNX**: every model exports with a single `features` input (board ‖ style).
- **Browser** (`onnx_worker.ts`, `onnx_eval.ts`, `career_features.ts`, `team-demo/page.tsx`): the worker builds `[board ‖ style]` and runs under the model's actual input name, auto-detecting the contract (onnxruntime-web 1.16 exposes input names but not shapes) by probing board-only and falling back to board+style. `team-demo` fetches the opponent's `style_values` from `/agents/{id}/profile` and feeds it as `self_style`; a neutral bias-only style is the fallback so any model still runs. `career_features.ts` is a byte-compatible port of the Python 40-d `encode_career_context` layout.

## Test plan

- [x] `agent` suite: **307 passed, 7 failed**. The 7 failures are pre-existing — verified identical on `origin/master` (agent-profile summary, round-robin pairing count, status-file CLI) and unrelated to this change. New passing tests added here: `test_model_agnostic_style.py`, `test_sklearn_agent.py`, and additions to `test_sample_trainer.py` proving the `[board‖style]` contract for MLP, forests, and 2-ply across both inference and training.
- [x] Frontend: `tsc --noEmit` clean for the changed files (only pre-existing missing contract-artifact errors remain); zero new eslint problems.
- [ ] **Not verified in this container:** browser runtime — confirm in-browser that a trained agent plays with its style (`cd frontend && pnpm install && pnpm run build`).

https://claude.ai/code/session_013vJxZFrWut8y4j6mJPv69v

---
_Generated by [Claude Code](https://claude.ai/code/session_013vJxZFrWut8y4j6mJPv69v)_