### PR TITLE
fix(ens): use selfMintSubname on-chain for embedded wallet registration

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -58,6 +58,11 @@ jobs:
           # skipped at build time and the UI degrades gracefully.
           NEXT_PUBLIC_PRIVY_APP_ID: ${{ secrets.PRIVY_APP_ID }}
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID }}
+          # Backend server URL for training/agent endpoints. ENS subname
+          # registration uses selfMintSubname on-chain (no server needed).
+          # Set SERVER_URL secret to a deployed backend if training features
+          # should be accessible from the GitHub Pages deployment.
+          NEXT_PUBLIC_SERVER_URL: ${{ secrets.SERVER_URL }}
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/frontend/app/ProfileBadge.tsx
+++ b/frontend/app/ProfileBadge.tsx
@@ -7,22 +7,22 @@
 // surfaces a fallback suggestion (<label><3-digit suffix>) so the user
 // can claim a name without starting over.
 //
-// Phase 22+: ENS minting is server-paid — ClaimForm POSTs to the backend
-// which calls mintSubname with the deployer key. No ETH or gas required
-// from the user's wallet.
+// Phase 22+: ClaimForm calls selfMintSubname on-chain so the user never
+// needs a backend server. Privy's useSponsoredWrite covers gas for
+// embedded-wallet (email/Google) users; MetaMask/WalletConnect users
+// pay their own gas as usual.
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { useReadContract } from "wagmi";
+import { useReadContract, useWaitForTransactionReceipt } from "wagmi";
 
 import { useChaingammonName } from "./useChaingammonName";
 import { useChaingammonProfile, useSyncEnsProfile } from "./useChaingammonProfile";
 import { useActiveChainId } from "./chains";
-import { MatchRegistryABI, useChainContracts } from "./contracts";
+import { MatchRegistryABI, PlayerSubnameRegistrarABI, useChainContracts } from "./contracts";
 import { recordTransaction } from "./transactions";
 import { useI18n } from "./i18n";
-
-const SERVER = process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:8000";
+import { useSponsoredWrite } from "./useSponsoredWrite";
 
 function shorten(addr: string) {
   return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
@@ -46,52 +46,72 @@ function randomSuffix(): string {
 }
 
 
-export function ClaimForm({ address }: { address: `0x${string}` }) {
+export function ClaimForm() {
   const { t } = useI18n();
   const [claimInput, setClaimInput] = useState("");
   const [suggestion, setSuggestion] = useState<string | null>(null);
-  const [claiming, setClaiming] = useState(false);
   const [claimError, setClaimError] = useState<string | null>(null);
+  const [txHash, setTxHash] = useState<`0x${string}` | undefined>();
   const submittedLabelRef = useRef<string>("");
+
+  const chainId = useActiveChainId();
+  const { playerSubnameRegistrar } = useChainContracts();
+  const { writeContractAsync, isPending } = useSponsoredWrite();
+
+  const { isLoading: isConfirming, isSuccess: isConfirmed } = useWaitForTransactionReceipt({
+    hash: txHash,
+    chainId,
+    query: { enabled: !!txHash },
+  });
+
+  const claiming = isPending || isConfirming;
+
+  // Reload once the subname transaction is confirmed on-chain so
+  // useChaingammonName re-scans and finds the new SubnameMinted event.
+  useEffect(() => {
+    if (!isConfirmed || !txHash) return;
+    recordTransaction({
+      type: "ens_subname",
+      description: `ENS subname registered: ${submittedLabelRef.current}.chaingammon.eth`,
+    });
+    window.location.reload();
+  }, [isConfirmed, txHash]);
 
   const submit = async (labelToUse?: string) => {
     const trimmed = (labelToUse ?? claimInput).trim();
     if (!trimmed || !isValidLabel(trimmed)) return;
     submittedLabelRef.current = trimmed;
-    setClaiming(true);
     setClaimError(null);
     setSuggestion(null);
+    setTxHash(undefined);
     try {
-      const res = await fetch(`${SERVER}/subname/mint`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ label: trimmed, owner: address }),
+      const hash = await writeContractAsync({
+        address: playerSubnameRegistrar,
+        abi: PlayerSubnameRegistrarABI,
+        functionName: "selfMintSubname",
+        args: [trimmed],
+        chainId,
       });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({ detail: res.statusText })) as { detail?: string };
-        const msg = body.detail ?? res.statusText;
-        if (msg.toLowerCase().includes("already") || msg.toLowerCase().includes("exists")) {
-          setSuggestion(`${trimmed}${randomSuffix()}`);
-          setClaimError(`"${trimmed}" is already taken.`);
-        } else {
-          setClaimError(msg);
-        }
-        return;
-      }
-      recordTransaction({
-        type: "ens_subname",
-        description: `ENS subname registered: ${trimmed}.chaingammon.eth`,
-      });
-      window.location.reload();
+      setTxHash(hash);
     } catch (e) {
-      setClaimError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setClaiming(false);
+      const msg = e instanceof Error ? e.message : String(e);
+      if (
+        msg.toLowerCase().includes("already") ||
+        msg.toLowerCase().includes("exists") ||
+        msg.toLowerCase().includes("revert") ||
+        msg.toLowerCase().includes("taken")
+      ) {
+        setSuggestion(`${trimmed}${randomSuffix()}`);
+        setClaimError(`"${trimmed}" is already taken.`);
+      } else {
+        setClaimError(msg);
+      }
     }
   };
 
   const validationError = claimInput ? labelValidationMessage(claimInput, t) : null;
-  const canSubmit = !claiming && isValidLabel(claimInput);
+  const registrarReady = playerSubnameRegistrar !== "0x0000000000000000000000000000000000000000";
+  const canSubmit = !claiming && isValidLabel(claimInput) && registrarReady;
 
   return (
     <div data-testid="profile-badge" style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 4 }}>
@@ -150,12 +170,20 @@ export function ClaimForm({ address }: { address: `0x${string}` }) {
         </button>
       </div>
 
-      {validationError ? (
+      {!registrarReady ? (
+        <span style={{ fontSize: 11, color: "var(--cg-warn)", textAlign: "right", maxWidth: 240 }}>
+          Switch to Sepolia to claim a name
+        </span>
+      ) : validationError ? (
         <span
           data-testid="ens-validation-error"
           style={{ fontSize: 11, color: "var(--cg-warn)", textAlign: "right", maxWidth: 240 }}
         >
           {validationError}
+        </span>
+      ) : txHash && isConfirming ? (
+        <span style={{ fontSize: 11, color: "var(--cg-fg-3)", textAlign: "right" }}>
+          Confirming…
         </span>
       ) : null}
 
@@ -313,5 +341,5 @@ export function ProfileBadge({ address }: { address: `0x${string}` }) {
     );
   }
 
-  return <ClaimForm address={address} />;
+  return <ClaimForm />;
 }

--- a/server/app/ens_client.py
+++ b/server/app/ens_client.py
@@ -43,6 +43,7 @@ _PLAYER_SUBNAME_REGISTRAR_ABI = [
         "inputs": [
             {"name": "label", "type": "string"},
             {"name": "subnameOwner_", "type": "address"},
+            {"name": "inftId", "type": "uint256"},
         ],
         "outputs": [{"name": "node", "type": "bytes32"}],
     },
@@ -191,6 +192,7 @@ class EnsClient:
         tx = self.registrar.functions.mintSubname(
             label,
             Web3.to_checksum_address(subname_owner),
+            0,  # inftId: 0 for human registrations
         ).build_transaction(
             {
                 "from": self.account.address,


### PR DESCRIPTION
ENS subname registration was broken for Google-login (Privy embedded wallet) users. The frontend was POSTing to the backend server at NEXT_PUBLIC_SERVER_URL, which was never set in the GitHub Pages build — so it defaulted to http://localhost:8000. On the deployed HTTPS page that triggers a mixed-content block, producing "NetworkError when attempting to fetch resource." Embedded-wallet users always create fresh wallets with no prior ENS subname, so they always hit the ClaimForm and encountered this error, while MetaMask users with pre-existing names skipped it.

ClaimForm (frontend/app/ProfileBadge.tsx, updated):
- Drops the server fetch entirely; uses useSponsoredWrite to call selfMintSubname directly on the PlayerSubnameRegistrar contract.
  - selfMintSubname is open (no owner restriction): any wallet can call it to register a subname for msg.sender.
  - useSponsoredWrite routes through Privy's native gas sponsorship for embedded wallets, so email/Google users transact without holding ETH; MetaMask/WalletConnect users pay their own gas as before.
- Tracks the tx hash in state; useWaitForTransactionReceipt waits for on-chain confirmation before reloading so useChaingammonName re-scans SubnameMinted events and shows the new name.
- Guards on registrarReady (playerSubnameRegistrar !== zero-address) and shows "Switch to Sepolia" when the registrar is not deployed on the connected chain.
- Adds "Confirming…" status while the receipt is pending.
- Removes the address prop from ClaimForm — selfMintSubname uses msg.sender, so the caller's address is no longer passed in the request body.

ENS client ABI fix (server/app/ens_client.py, updated):
- The PlayerSubnameRegistrar.mintSubname ABI was missing the third parameter inftId (uint256) added in a prior phase. Updated the embedded ABI and the mint_subname call to pass inftId=0 for human registrations, matching the deployed contract's function selector.

GitHub Pages workflow (github/workflows/pages.yml, updated):
- Documents NEXT_PUBLIC_SERVER_URL as an optional secret (SERVER_URL) so operators deploying a backend can wire it in; ENS registration now works without it.