### PR TITLE
Add legal move destination indicators on hover

### DIFF
--- a/frontend/app/Board.tsx
+++ b/frontend/app/Board.tsx
@@ -2,6 +2,7 @@
 
 import React, { useRef, useState, PointerEvent } from "react";
 import { BOARD_THEMES, type BoardThemeKey, type CheckerImageSpec } from "./boardThemes";
+import { getFirstMoveDests, Board as RulesBoard } from "../lib/rules_engine";
 
 interface BoardProps {
   board: number[];          // length 24; board[i] = checkers on point (i+1). Positive = player 0, negative = player 1
@@ -14,6 +15,7 @@ interface BoardProps {
   onOffClick?: () => void;
   selectedPoint?: number | null;  // 1-24 = board point, 25 = bar
   ghostMove?: string | null;      // A move string to preview on hover, e.g. "24/18 13/7"
+  dice?: [number, number] | null;
   onDragStart?: (point: number) => void;
   onDrop?: (point: number) => void;
   themeKey?: BoardThemeKey;
@@ -61,6 +63,7 @@ export function Board({
   onOffClick,
   selectedPoint,
   ghostMove,
+  dice,
   onDragStart,
   onDrop,
   themeKey = "walnut",
@@ -117,6 +120,7 @@ export function Board({
   const containerRef = useRef<HTMLDivElement>(null);
   const [dragState, setDragState] = useState<DragState>(null);
   const [pendingDrop, setPendingDrop] = useState<number | "off" | null>(null);
+  const [hoveredSource, setHoveredSource] = useState<number | "bar" | null>(null);
 
   // When a drop requires selecting the source point first, we must wait for
   // `selectedPoint` to update before triggering the destination click.
@@ -163,6 +167,16 @@ export function Board({
     if (!ghostArrivals[seg.to]) ghostArrivals[seg.to] = [];
     ghostArrivals[seg.to].push(seg.segIndex);
   });
+
+  const legalLandingSet = React.useMemo(() => {
+    if (hoveredSource === null || turn !== 0 || !dice) return new Set<number | "off">();
+    const rulesBoard: RulesBoard = {
+      points: board,
+      bar: [bar[0] ?? 0, bar[1] ?? 0] as [number, number],
+      off: [off[0] ?? 0, off[1] ?? 0] as [number, number],
+    };
+    return new Set<number | "off">(getFirstMoveDests(rulesBoard, 0, dice, hoveredSource));
+  }, [hoveredSource, dice, board, bar, off, turn]);
 
   const turnLabel = turn === 0 ? "Your turn" : `${opponentName ?? "Agent"}'s turn`;
   const turnColor = turn === 0 ? "var(--cg-player-warm)" : "var(--cg-player-cool)";
@@ -259,6 +273,7 @@ export function Board({
     svgRef.current?.setPointerCapture(e.pointerId);
     const { x, y } = clientToSvg(e.clientX, e.clientY);
     setDragState({ fromPoint: point, isP0, svgX: x, svgY: y });
+    setHoveredSource(null);
     if (onDragStart && typeof point === "number") onDragStart(point);
   };
 
@@ -565,8 +580,23 @@ export function Board({
           onPointerDown={(e) => {
             if (count > 0 && turn === 0) handlePointerDown(e, point, true);
           }}
+          onMouseEnter={() => { if (turn === 0 && count > 0) setHoveredSource(point); }}
+          onMouseLeave={() => setHoveredSource(null)}
           style={{ touchAction: "none" }}
         />
+
+        {/* Legal Landing Indicator */}
+        {legalLandingSet.has(point) && (
+          <circle
+            cx={checkerCx}
+            cy={tipY}
+            r={6}
+            fill="rgba(255,255,255,0.85)"
+            stroke="rgba(0,0,0,0.15)"
+            strokeWidth={1}
+            pointerEvents="none"
+          />
+        )}
 
         {/* Checkers */}
         <g pointerEvents="none">
@@ -686,6 +716,8 @@ export function Board({
           onPointerDown={(e) => {
             if (p0Bar > 0 && turn === 0) handlePointerDown(e, "bar", true);
           }}
+          onMouseEnter={() => { if (turn === 0 && p0Bar > 0) setHoveredSource("bar"); }}
+          onMouseLeave={() => setHoveredSource(null)}
           style={{ touchAction: "none" }}
         />
 
@@ -802,6 +834,18 @@ export function Board({
             width={BEAR_W}
             height={INNER_H}
             fill="rgba(0,0,0,0.15)"
+          />
+        )}
+        {/* P0 Bear-off Landing Indicator */}
+        {legalLandingSet.has("off") && (
+          <circle
+            cx={rightOffCx}
+            cy={FRAME + 15}
+            r={6}
+            fill="rgba(255,255,255,0.85)"
+            stroke="rgba(0,0,0,0.15)"
+            strokeWidth={1}
+            pointerEvents="none"
           />
         )}
         {/* P0 Off Mini Checkers */}

--- a/frontend/app/team-demo/page.tsx
+++ b/frontend/app/team-demo/page.tsx
@@ -1755,6 +1755,7 @@ function TeamDemoPageInner() {
               onBarClick={isHumanTurn && currentBar[0] > 0 ? () => setSelectedSource(25) : undefined}
               onOffClick={isHumanTurn && selectedSource !== null ? () => stageMove(selectedSource === 25 ? "bar" : selectedSource, "off") : undefined}
               selectedPoint={selectedSource}
+              dice={isHumanTurn ? game.dice : null}
               playerAvatarUrls={gameCoins ?? undefined}
             />
             </div>

--- a/frontend/lib/rules_engine.ts
+++ b/frontend/lib/rules_engine.ts
@@ -563,3 +563,29 @@ export function hasLegalMoves(
 ): boolean {
   return generateLegalMoves(board, side, dice).length > 0;
 }
+
+/**
+ * Returns the unique first-step destinations reachable by a checker at `from`
+ * given the current dice, restricted to fully-legal move sequences.
+ */
+export function getFirstMoveDests(
+  board: Board,
+  side: number,
+  dice: [number, number],
+  from: number | "bar",
+): Array<number | "off"> {
+  const legalMoves = generateLegalMoves(board, side, dice);
+  const barSrc = side === 0 ? BAR_SRC : BAR_SRC_P1;
+  const offDst = side === 0 ? OFF_DST : OFF_DST_P1;
+  const srcNum = from === "bar" ? barSrc : (from as number);
+
+  const dests = new Set<number | "off">();
+  for (const moveStr of legalMoves) {
+    const pieces = parseMove(moveStr, side);
+    if (pieces.length > 0 && pieces[0].src === srcNum) {
+      const dst = pieces[0].dst;
+      dests.add(dst === offDst ? "off" : dst);
+    }
+  }
+  return Array.from(dests);
+}


### PR DESCRIPTION
## Summary
Add visual indicators showing legal landing destinations when hovering over a checker or the bar during the player's turn. This helps players understand their available moves before committing to a drag action.

## Key Changes
- **Board component**: 
  - Added `dice` prop to receive current dice values
  - Added `hoveredSource` state to track which point/bar the mouse is over
  - Added `legalLandingSet` memoized computation that uses the rules engine to determine valid destinations from the hovered source
  - Added mouse enter/leave handlers to board points and bar to update hover state
  - Added visual indicators (white circles with subtle borders) at legal landing destinations

- **Rules engine**:
  - Added `getFirstMoveDests()` function that returns the unique first-step destinations reachable from a given source point, filtered to only include destinations that are part of fully-legal move sequences

- **Team demo page**:
  - Pass `dice` prop to Board component when it's the human player's turn

## Implementation Details
The legal destinations are computed by parsing all legal moves from the rules engine and extracting the first destination of any move that starts from the hovered source. This ensures only destinations that are part of valid complete move sequences are highlighted, respecting all game rules including forced moves and point blocking.

https://claude.ai/code/session_01BtSc9z1BCHJMXhX6EEUes4