### PR TITLE
Fix human vs human bugs

### DIFF
--- a/frontend/app/Board.tsx
+++ b/frontend/app/Board.tsx
@@ -24,6 +24,7 @@ interface BoardProps {
   onCubeClick?: () => void; // called when the human clicks the cube to offer a double
   playerAvatarUrls?: { warm: string; cool: string };
   prefer3d?: boolean;
+  isMyTurn?: boolean;       // overrides default behavior (turn === 0 = you) for HvH
 }
 
 const FRAME = 20;
@@ -72,6 +73,7 @@ export function Board({
   onCubeClick,
   playerAvatarUrls,
   prefer3d = false,
+  isMyTurn,
 }: BoardProps) {
   const theme = BOARD_THEMES[themeKey] ?? BOARD_THEMES.walnut;
   // Image-based themes own the board look entirely — skip the SVG-painted
@@ -178,8 +180,9 @@ export function Board({
     return new Set<number | "off">(getFirstMoveDests(rulesBoard, 0, dice, hoveredSource));
   }, [hoveredSource, dice, board, bar, off, turn]);
 
-  const turnLabel = turn === 0 ? "Your turn" : `${opponentName ?? "Agent"}'s turn`;
-  const turnColor = turn === 0 ? "var(--cg-player-warm)" : "var(--cg-player-cool)";
+  const effIsMyTurn = isMyTurn !== undefined ? isMyTurn : turn === 0;
+  const turnLabel = effIsMyTurn ? "Your turn" : `${opponentName ?? "Agent"}'s turn`;
+  const turnColor = effIsMyTurn ? "var(--cg-player-warm)" : "var(--cg-player-cool)";
 
   const getColXOffset = (col: number, rightHalf: boolean) => {
     const baseX = rightHalf ? R_QUAD_X : L_QUAD_X;

--- a/frontend/app/play-human/PlayHumanClient.tsx
+++ b/frontend/app/play-human/PlayHumanClient.tsx
@@ -124,6 +124,7 @@ function HumanMatchInner() {
 
   // ── Nonces from chain ──────────────────────────────────────────────────
   const [oppAddress, setOppAddress] = useState<`0x${string}` | null>(null);
+  const { label: oppLiveLabel } = useChaingammonName(oppAddress ?? undefined);
 
   const nonceCalls =
     address && oppAddress && matchRegistry
@@ -397,7 +398,7 @@ function HumanMatchInner() {
 
         if (next.game_over) {
           // Settlement handled by effect below.
-        } else {
+        } else if (next.turn !== mySideRef.current) {
           // Now it's the opponent's turn.
           waitingForRollRef.current = true;
         }
@@ -527,10 +528,13 @@ function HumanMatchInner() {
           setGame(next);
           waitingForMoveRef.current = false;
 
-          if (!next.game_over) {
+          if (!next.game_over && next.turn === mySideVal) {
             // My turn — roll.
             waitingForRollRef.current = false;
             await rollMyDice(next);
+          } else if (!next.game_over && next.turn !== mySideVal) {
+             // Opponent rolled a partial move and hasn't finished their turn yet.
+             // Or they skipped. We wait for their next roll/move.
           }
         } catch {/* ignore */}
       }
@@ -882,8 +886,9 @@ function HumanMatchInner() {
     stagedMoves.length === 0 &&
     (game?.cubeOwner === -1 || game?.cubeOwner === mySideRef.current);
 
-  const oppName = oppInfo?.ensLabel
-    ? `${oppInfo.ensLabel}.chaingammon.eth`
+  const oppLabel = oppLiveLabel || oppInfo?.ensLabel;
+  const oppName = oppLabel
+    ? `${oppLabel}.chaingammon.eth`
     : oppAddress
     ? `${oppAddress.slice(0, 8)}…`
     : "Opponent";
@@ -958,6 +963,7 @@ function HumanMatchInner() {
           bar={currentBar}
           off={currentOff}
           turn={game?.turn ?? 0}
+          isMyTurn={isMyTurn}
           opponentName={oppName}
           themeKey={themeKey}
           cubeValue={game?.cubeValue ?? 1}


### PR DESCRIPTION
Fixes 3 reported issues with Human vs Human matches:
1. Opponent's ENS label now successfully displays by doing a local lookup for the opponent's address.
2. The UI turn display properly updates for the opponent when Player 1 finishes their turn and now handles the automatic dice roll properly.
3. Both players no longer see "Your turn" at the start of the game, since `Board.tsx` now correctly calculates "Your turn" from a provided `isMyTurn` prop instead of assuming side 0 is always the human.

---
*PR created automatically by Jules for task [7925651783125704688](https://jules.google.com/task/7925651783125704688) started by @oslinin*