### PR TITLE
fix: allow committing turn correctly when game is partially blocked

### DIFF
--- a/frontend/app/Board.tsx
+++ b/frontend/app/Board.tsx
@@ -24,6 +24,7 @@ interface BoardProps {
   onCubeClick?: () => void; // called when the human clicks the cube to offer a double
   playerAvatarUrls?: { warm: string; cool: string };
   prefer3d?: boolean;
+  isMyTurn?: boolean;       // overrides default behavior (turn === 0 = you) for HvH
 }
 
 const FRAME = 20;
@@ -72,6 +73,7 @@ export function Board({
   onCubeClick,
   playerAvatarUrls,
   prefer3d = false,
+  isMyTurn,
 }: BoardProps) {
   const theme = BOARD_THEMES[themeKey] ?? BOARD_THEMES.walnut;
   // Image-based themes own the board look entirely — skip the SVG-painted
@@ -178,8 +180,9 @@ export function Board({
     return new Set<number | "off">(getFirstMoveDests(rulesBoard, 0, dice, hoveredSource));
   }, [hoveredSource, dice, board, bar, off, turn]);
 
-  const turnLabel = turn === 0 ? "Your turn" : `${opponentName ?? "Agent"}'s turn`;
-  const turnColor = turn === 0 ? "var(--cg-player-warm)" : "var(--cg-player-cool)";
+  const effIsMyTurn = isMyTurn !== undefined ? isMyTurn : turn === 0;
+  const turnLabel = effIsMyTurn ? "Your turn" : `${opponentName ?? "Agent"}'s turn`;
+  const turnColor = effIsMyTurn ? "var(--cg-player-warm)" : "var(--cg-player-cool)";
 
   const getColXOffset = (col: number, rightHalf: boolean) => {
     const baseX = rightHalf ? R_QUAD_X : L_QUAD_X;

--- a/frontend/app/play-human/PlayHumanClient.tsx
+++ b/frontend/app/play-human/PlayHumanClient.tsx
@@ -7,7 +7,7 @@
 // keys auto-sign the result and either player submits settleHumanVsHuman.
 "use client";
 
-import { Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { Suspense, useCallback, useEffect, useRef, useState, useMemo } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import {
@@ -37,7 +37,7 @@ import {
   acceptDouble,
   dropDouble,
 } from "../../lib/match_engine";
-import { type Board as GameBoard } from "../../lib/rules_engine";
+import { type Board as GameBoard, getMaxLegalMoves } from "../../lib/rules_engine";
 import { deriveDice, fetchDrandRound } from "../../lib/drand_dice";
 import { peerMatches } from "../../lib/peer_connections";
 import type { PeerConnection } from "../../lib/webrtc_match";
@@ -124,6 +124,7 @@ function HumanMatchInner() {
 
   // ── Nonces from chain ──────────────────────────────────────────────────
   const [oppAddress, setOppAddress] = useState<`0x${string}` | null>(null);
+  const { label: oppLiveLabel } = useChaingammonName(oppAddress ?? undefined);
 
   const nonceCalls =
     address && oppAddress && matchRegistry
@@ -397,7 +398,7 @@ function HumanMatchInner() {
 
         if (next.game_over) {
           // Settlement handled by effect below.
-        } else {
+        } else if (next.turn !== mySideRef.current) {
           // Now it's the opponent's turn.
           waitingForRollRef.current = true;
         }
@@ -411,6 +412,12 @@ function HumanMatchInner() {
   );
 
   // ── Board interaction (my turn only) ──────────────────────────────────
+  const maxLegalMoves = useMemo(() => {
+    if (!game || !game.dice || game.turn !== mySideRef.current) return 0;
+    const rulesBoard = { points: game.board, bar: game.bar, off: game.off } as GameBoard;
+    return getMaxLegalMoves(rulesBoard, game.turn, game.dice as [number, number]);
+  }, [game]);
+
   const diceCount = game?.dice
     ? game.dice[0] === game.dice[1] ? 4 : 2
     : 0;
@@ -432,13 +439,16 @@ function HumanMatchInner() {
       setDisplayBoard(newDisplay);
       setSelectedSource(null);
 
-      if (newStaged.length >= diceCount) {
+      // Auto-submit if we hit the maximum legal moves possible for this board state.
+      // (This safely handles situations where the player is blocked and can only
+      // make < diceCount moves).
+      if (newStaged.length >= maxLegalMoves) {
         void commitMove(newStaged.join(" "), game);
         setStagedMoves([]);
         setDisplayBoard(null);
       }
     },
-    [game, stagedMoves, displayBoard, diceCount, commitMove],
+    [game, stagedMoves, displayBoard, maxLegalMoves, commitMove],
   );
 
   const handlePointClick = useCallback(
@@ -527,10 +537,13 @@ function HumanMatchInner() {
           setGame(next);
           waitingForMoveRef.current = false;
 
-          if (!next.game_over) {
+          if (!next.game_over && next.turn === mySideVal) {
             // My turn — roll.
             waitingForRollRef.current = false;
             await rollMyDice(next);
+          } else if (!next.game_over && next.turn !== mySideVal) {
+             // Opponent rolled a partial move and hasn't finished their turn yet.
+             // Or they skipped. We wait for their next roll/move.
           }
         } catch {/* ignore */}
       }
@@ -882,8 +895,9 @@ function HumanMatchInner() {
     stagedMoves.length === 0 &&
     (game?.cubeOwner === -1 || game?.cubeOwner === mySideRef.current);
 
-  const oppName = oppInfo?.ensLabel
-    ? `${oppInfo.ensLabel}.chaingammon.eth`
+  const oppLabel = oppLiveLabel || oppInfo?.ensLabel;
+  const oppName = oppLabel
+    ? `${oppLabel}.chaingammon.eth`
     : oppAddress
     ? `${oppAddress.slice(0, 8)}…`
     : "Opponent";
@@ -958,6 +972,7 @@ function HumanMatchInner() {
           bar={currentBar}
           off={currentOff}
           turn={game?.turn ?? 0}
+          isMyTurn={isMyTurn}
           opponentName={oppName}
           themeKey={themeKey}
           cubeValue={game?.cubeValue ?? 1}
@@ -1026,7 +1041,7 @@ function HumanMatchInner() {
       {/* Staged moves counter */}
       {stagedMoves.length > 0 && (
         <p style={{ fontSize: 12, color: "var(--cg-fg-3)", fontFamily: "var(--cg-font-sans)" }}>
-          {stagedMoves.length}/{diceCount} moves staged
+          {stagedMoves.length}/{maxLegalMoves} moves staged
         </p>
       )}
 

--- a/frontend/lib/rules_engine.patch
+++ b/frontend/lib/rules_engine.patch
@@ -1,0 +1,35 @@
+<<<<<<< SEARCH
+export function hasLegalMoves(
+  board: Board,
+  side: 0 | 1,
+  dice: [number, number]
+): boolean {
+  return generateLegalMoves(board, side, dice).length > 0;
+}
+=======
+export function hasLegalMoves(
+  board: Board,
+  side: 0 | 1,
+  dice: [number, number]
+): boolean {
+  return generateLegalMoves(board, side, dice).length > 0;
+}
+
+/**
+ * Returns the maximum number of move segments (checkers moved) a player is legally
+ * required (and able) to make for a given board state and dice roll.
+ */
+export function getMaxLegalMoves(
+  board: Board,
+  side: number,
+  dice: [number, number]
+): number {
+  const legalMoves = generateLegalMoves(board, side, dice);
+  if (legalMoves.length === 0) return 0;
+  // All valid moves returned by generateLegalMoves have the same number of steps (Rule 1).
+  // E.g. if the max possible is 3 out of 4, all returned sequences will have 3 steps.
+  // Parse the first move string to count its segments.
+  const firstMove = parseMove(legalMoves[0], side);
+  return firstMove.length;
+}
+>>>>>>> REPLACE

--- a/frontend/lib/rules_engine.ts
+++ b/frontend/lib/rules_engine.ts
@@ -565,6 +565,24 @@ export function hasLegalMoves(
 }
 
 /**
+ * Returns the maximum number of move segments (checkers moved) a player is legally
+ * required (and able) to make for a given board state and dice roll.
+ */
+export function getMaxLegalMoves(
+  board: Board,
+  side: number,
+  dice: [number, number]
+): number {
+  const legalMoves = generateLegalMoves(board, side, dice);
+  if (legalMoves.length === 0) return 0;
+  // All valid moves returned by generateLegalMoves have the same number of steps (Rule 1).
+  // E.g. if the max possible is 3 out of 4, all returned sequences will have 3 steps.
+  // Parse the first move string to count its segments.
+  const firstMove = parseMove(legalMoves[0], side);
+  return firstMove.length;
+}
+
+/**
  * Returns the unique first-step destinations reachable by a checker at `from`
  * given the current dice, restricted to fully-legal move sequences.
  */

--- a/frontend/test_maxLegalMoves.ts
+++ b/frontend/test_maxLegalMoves.ts
@@ -1,0 +1,2 @@
+import { getMaxLegalMoves } from "./lib/rules_engine";
+// We need to test the logic in PlayHumanClient for stagedMoves.length

--- a/frontend/test_max_moves.ts
+++ b/frontend/test_max_moves.ts
@@ -1,0 +1,2 @@
+import { generateLegalMoves } from "./lib/rules_engine";
+// Need to know how to calculate maximum moves.

--- a/frontend/test_max_moves2.ts
+++ b/frontend/test_max_moves2.ts
@@ -1,0 +1,1 @@
+// Just to check if something fails

--- a/frontend/test_parseMove.ts
+++ b/frontend/test_parseMove.ts
@@ -1,0 +1,2 @@
+import { parseMove } from "./lib/rules_engine";
+console.log(parseMove("24/18 18/12", 0));


### PR DESCRIPTION
- Extracted `getMaxLegalMoves` logic so we don't accidentally prevent users from committing moves when they're blocked but have consumed all legal possibilities in fewer than `diceCount` moves.