### PR TITLE
fix: use WalletConnect over injected MetaMask in Privy to fix mobile deep linking

### DIFF
--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -72,7 +72,7 @@ const PRIVY_APP_ID =
 // WalletConnect Project ID — Privy forwards this to the WalletConnect
 // connector it constructs internally. Get a free Project ID from
 // https://cloud.walletconnect.com. Without it, the WalletConnect option
-// in the Privy modal is disabled (email/Google/MetaMask still work).
+// in the Privy modal is disabled (email/Google still work).
 const WALLETCONNECT_PROJECT_ID = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID;
 
 export function Providers({ children }: { children: React.ReactNode }) {
@@ -97,7 +97,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
         appearance: {
           theme: "dark",
           accentColor: "#C99B5C",
-          walletList: ["metamask", "wallet_connect"],
+          walletList: ["wallet_connect"],
           showWalletLoginFirst: false,
         },
         embeddedWallets: {


### PR DESCRIPTION
This resolves an issue where Android users attempting to connect with MetaMask via the Privy modal are incorrectly redirected to the Google Play Store instead of opening the MetaMask app.

By explicitly removing `"metamask"` from the `walletList` array and keeping `"wallet_connect"`, Privy is forced to use the more reliable WalletConnect flow, which resolves the deep linking issues on mobile platforms.

---
*PR created automatically by Jules for task [8971529957414251592](https://jules.google.com/task/8971529957414251592) started by @oslinin*