### PR TITLE
Remove broken MetaMask (Basic) button

### DIFF
--- a/frontend/app/ConnectButton.tsx
+++ b/frontend/app/ConnectButton.tsx
@@ -26,7 +26,7 @@
 // click handler guards on `ready` so a click before init is a safe no-op.
 
 import { usePrivy } from "@privy-io/react-auth";
-import { useAccount, useConnect } from "wagmi";
+import { useAccount } from "wagmi";
 import { useState, useEffect } from "react";
 
 import { NetworkDropdown } from "./NetworkDropdown";
@@ -71,7 +71,6 @@ function ConnectButtonInner() {
   const { t } = useI18n();
   const { ready, authenticated, login, logout } = usePrivy();
   const { address, isConnected } = useAccount();
-  const { connect, connectors } = useConnect();
   // Lazy-initialized once at mount (ConnectButton guards this component
   // behind a mounted check, so window/navigator are always available here).
   const [isMobile] = useState(() => /Android|iPhone|iPad|iPod/i.test(navigator.userAgent));
@@ -127,11 +126,10 @@ function ConnectButtonInner() {
 
   // Not authenticated → "Log in". Shown regardless of `ready`; the handler
   // is a no-op until Privy finishes initialising.
-  const injectedConnector = connectors.find(c => c.id === "injected");
-  // Chrome Android and Firefox mobile don't inject window.ethereum. On those
-  // browsers, show a universal link that opens the page inside MetaMask
-  // Mobile's built-in browser where window.ethereum IS provided natively —
-  // the simplest mobile MetaMask path (no WalletConnect, no QR scan).
+  //
+  // On mobile without window.ethereum, also show a deep link that opens the
+  // page inside MetaMask Mobile's browser, which injects window.ethereum
+  // natively so the user can log in through the Privy modal from there.
   const showDeepLink = isMobile && !hasInjected;
 
   return (
@@ -145,7 +143,7 @@ function ConnectButtonInner() {
       >
         {t("log_in")}
       </button>
-      {showDeepLink ? (
+      {showDeepLink && (
         <a
           href={`https://metamask.app.link/dapp/${window.location.host}${window.location.pathname}${window.location.search}`}
           data-testid="open-in-metamask"
@@ -153,15 +151,6 @@ function ConnectButtonInner() {
         >
           Open in MetaMask
         </a>
-      ) : (
-        <button
-          type="button"
-          data-testid="metamask-basic"
-          onClick={() => { if (injectedConnector) connect({ connector: injectedConnector }); }}
-          style={{ ...primaryBtn, background: "rgba(255, 255, 255, 0.1)", color: "var(--cg-fg-1)", border: "1px solid var(--cg-line-1)", boxShadow: "none" }}
-        >
-          MetaMask (Basic)
-        </button>
       )}
     </div>
   );
@@ -172,18 +161,9 @@ export function ConnectButton() {
   useEffect(() => { setMounted(true); }, []);
   if (!mounted) {
     return (
-      <div style={{ display: 'flex', gap: '8px' }}>
-        <button type="button" style={primaryBtn} className="cg-btn-primary">
-          Log in
-        </button>
-        <button
-          type="button"
-          data-testid="metamask-basic"
-          style={{ ...primaryBtn, background: "rgba(255, 255, 255, 0.1)", color: "var(--cg-fg-1)", border: "1px solid var(--cg-line-1)", boxShadow: "none" }}
-        >
-          MetaMask (Basic)
-        </button>
-      </div>
+      <button type="button" style={primaryBtn} className="cg-btn-primary">
+        Log in
+      </button>
     );
   }
   return <ConnectButtonInner />;

--- a/frontend/tests/privy-metamask-login.spec.ts
+++ b/frontend/tests/privy-metamask-login.spec.ts
@@ -276,11 +276,6 @@ test.describe("MetaMask desktop (window.ethereum)", () => {
     await setupPage(page);
   });
 
-  test("MetaMask Basic button is visible on desktop", async ({ page }) => {
-    await waitForLoggedOut(page);
-    await expect(page.getByTestId("metamask-basic")).toBeVisible();
-  });
-
   test("Open in MetaMask deep link is absent on desktop", async ({ page }) => {
     await waitForLoggedOut(page);
     await expect(page.getByTestId("open-in-metamask")).not.toBeVisible();
@@ -318,8 +313,7 @@ test.describe("MetaMask desktop (window.ethereum)", () => {
 // ── 5. MetaMask mobile — Chrome Android UA (no injected wallet) ───────────────
 //
 // Simulates Chrome on Android: navigator.userAgent matches the mobile regex
-// but window.ethereum is absent.  The app should show the deep link instead
-// of the "MetaMask (Basic)" injected-connector button.
+// but window.ethereum is absent.  The app should show the deep link.
 
 test.describe("MetaMask mobile - Chrome Android UA (no window.ethereum)", () => {
   test.setTimeout(60_000);
@@ -334,10 +328,9 @@ test.describe("MetaMask mobile - Chrome Android UA (no window.ethereum)", () => 
     await setupPage(page);
   });
 
-  test("shows Open in MetaMask link instead of MetaMask Basic", async ({ page }) => {
+  test("shows Open in MetaMask link on mobile without ethereum", async ({ page }) => {
     await waitForLoggedOut(page);
     await expect(page.getByTestId("open-in-metamask")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByTestId("metamask-basic")).not.toBeVisible();
   });
 
   test("Open in MetaMask href points to metamask.app.link/dapp/", async ({ page }) => {
@@ -366,8 +359,7 @@ test.describe("MetaMask mobile - Chrome Android UA (no window.ethereum)", () => 
 // ── 6. MetaMask mobile — Firefox Android UA (no injected wallet) ──────────────
 //
 // Simulates Firefox on Android: navigator.userAgent matches mobile regex,
-// no window.ethereum (Firefox doesn't have MetaMask extension on Android).
-// Same deep-link fallback should appear.
+// no window.ethereum. Same deep-link should appear.
 
 test.describe("MetaMask mobile - Firefox Android UA (no window.ethereum)", () => {
   test.setTimeout(60_000);
@@ -381,10 +373,10 @@ test.describe("MetaMask mobile - Firefox Android UA (no window.ethereum)", () =>
     await setupPage(page);
   });
 
-  test("shows Open in MetaMask link instead of MetaMask Basic", async ({ page }) => {
+  test("shows Open in MetaMask link on mobile without ethereum (Firefox)", async ({ page }) => {
     await waitForLoggedOut(page);
     await expect(page.getByTestId("open-in-metamask")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByTestId("metamask-basic")).not.toBeVisible();
+    await expect(page.getByTestId("login-button")).toBeVisible({ timeout: 10_000 });
   });
 
   test("Open in MetaMask href points to metamask.app.link/dapp/", async ({ page }) => {
@@ -400,8 +392,8 @@ test.describe("MetaMask mobile - Firefox Android UA (no window.ethereum)", () =>
 // ── 7. MetaMask mobile — in MetaMask's in-app browser ─────────────────────────
 //
 // Simulates being inside MetaMask Mobile's built-in browser: mobile UA but
-// window.ethereum IS present (MetaMask injects it).  The app should show
-// the normal "MetaMask (Basic)" button, not the deep link.
+// window.ethereum IS present (MetaMask injects it).  The deep link should
+// be hidden (no need to redirect to MetaMask — already inside it).
 
 test.describe("MetaMask mobile in-app browser (window.ethereum injected on mobile)", () => {
   test.setTimeout(120_000);
@@ -417,11 +409,9 @@ test.describe("MetaMask mobile in-app browser (window.ethereum injected on mobil
     await setupPage(page);
   });
 
-  test("shows MetaMask Basic (not deep link) when ethereum is injected on mobile", async ({
-    page,
-  }) => {
+  test("deep link absent when ethereum is injected on mobile", async ({ page }) => {
     await waitForLoggedOut(page);
-    await expect(page.getByTestId("metamask-basic")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("login-button")).toBeVisible({ timeout: 10_000 });
     await expect(page.getByTestId("open-in-metamask")).not.toBeVisible();
   });
 


### PR DESCRIPTION
The button called wagmi's connect() with the raw injected() connector, which updates wagmi state but never touches Privy auth. Because the connected UI requires both authenticated && isConnected, the button appeared to do nothing — wagmi connected in the background but the UI never changed.

wagmi.ts already documents the intent: "We do NOT pre-register injected() here; Privy owns the wallet list." There is no way to satisfy Privy's authenticated flag without going through login(). The Log in button already shows MetaMask as an option inside the Privy modal.

On mobile without window.ethereum the Open in MetaMask deep link (metamask.app.link/dapp/…) remains — that opens the page inside MetaMask Mobile's in-app browser where window.ethereum IS injected, so the user can log in through the Privy modal normally from there.

https://claude.ai/code/session_0192MDk764uixMnb69qobUtz