### PR TITLE
docs: add branching workflow guidance to Git Policy

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -305,6 +305,12 @@ The flow at the end of every phase is **always**:
 
 Approval is **per-commit, not per-workflow**. A previously approved flow does not stand as approval for future commits. When in doubt, stop and ask.
 
+### Branching workflow
+
+One branch per PR. When the session scaffold assigns a branch (e.g. `claude/epic-ride-XXXXX`), use it for the first PR. If the owner merges that PR mid-session and asks for follow-up work, **create a new branch** off `master` rather than reusing the merged one. A merged branch is done — continuing to push to it after merge causes diverged history and forces a rebase before the next PR can be opened cleanly.
+
+Naming for follow-up branches: append a counter (`claude/epic-ride-XXXXX-2`, `-3`, etc.) or use a short descriptor (`claude/epic-ride-XXXXX-fix-login`). Never push follow-up work to `master` directly.
+
 ## Test-Driven Development
 
 This project follows TDD strictly:


### PR DESCRIPTION
After a PR is merged mid-session, follow-up work must go on a new branch off master rather than reusing the merged one. Documents the naming convention (counter suffix or short descriptor) and explains why reuse causes diverged history.

https://claude.ai/code/session_0192MDk764uixMnb69qobUtz