### PR TITLE
fix: use metamask:// URI scheme + tighten branching docs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -307,9 +307,13 @@ Approval is **per-commit, not per-workflow**. A previously approved flow does no
 
 ### Branching workflow
 
-One branch per PR. When the session scaffold assigns a branch (e.g. `claude/epic-ride-XXXXX`), use it for the first PR. If the owner merges that PR mid-session and asks for follow-up work, **create a new branch** off `master` rather than reusing the merged one. A merged branch is done — continuing to push to it after merge causes diverged history and forces a rebase before the next PR can be opened cleanly.
+One branch per PR, always — regardless of whether a previous PR has been merged yet. Each distinct change (feature, fix, docs update) gets its own branch and its own PR. Never add an unrelated commit to a branch that already has commits, even if that branch has not been merged yet.
 
-Naming for follow-up branches: append a counter (`claude/epic-ride-XXXXX-2`, `-3`, etc.) or use a short descriptor (`claude/epic-ride-XXXXX-fix-login`). Never push follow-up work to `master` directly.
+When the session scaffold assigns a branch (e.g. `claude/epic-ride-XXXXX`), use it for the first PR only. Every subsequent piece of work — even in the same session, even before the first PR is merged — gets a new branch off `master`.
+
+A merged branch is done. Do not push to it again after merge.
+
+Naming: append a counter (`claude/epic-ride-XXXXX-2`, `-3`, etc.) or a short descriptor. Never push directly to `master`.
 
 ## Test-Driven Development
 

--- a/frontend/app/ConnectButton.tsx
+++ b/frontend/app/ConnectButton.tsx
@@ -145,7 +145,7 @@ function ConnectButtonInner() {
       </button>
       {showDeepLink && (
         <a
-          href={`https://metamask.app.link/dapp/${window.location.host}${window.location.pathname}${window.location.search}`}
+          href={`metamask://dapp/${window.location.host}${window.location.pathname}${window.location.search}`}
           data-testid="open-in-metamask"
           style={{ ...pillBase, background: "#F6851B", color: "#fff", border: "1px solid rgba(0,0,0,0.2)", textDecoration: "none" }}
         >

--- a/frontend/tests/privy-metamask-login.spec.ts
+++ b/frontend/tests/privy-metamask-login.spec.ts
@@ -338,7 +338,7 @@ test.describe("MetaMask mobile - Chrome Android UA (no window.ethereum)", () => 
     const link = page.getByTestId("open-in-metamask");
     await expect(link).toBeVisible({ timeout: 10_000 });
     const href = await link.getAttribute("href");
-    expect(href).toContain("metamask.app.link/dapp/");
+    expect(href).toContain("metamask://dapp/");
     expect(href).toContain("localhost:3000");
   });
 
@@ -384,7 +384,7 @@ test.describe("MetaMask mobile - Firefox Android UA (no window.ethereum)", () =>
     const link = page.getByTestId("open-in-metamask");
     await expect(link).toBeVisible({ timeout: 10_000 });
     const href = await link.getAttribute("href");
-    expect(href).toContain("metamask.app.link/dapp/");
+    expect(href).toContain("metamask://dapp/");
     expect(href).toContain("localhost:3000");
   });
 });


### PR DESCRIPTION
ConnectButton: swap metamask.app.link (Branch.io redirect, falls through to Play Store on Firefox and sometimes Chrome) for the metamask:// custom URI scheme, which the OS routes directly to the MetaMask app when installed.

CONTEXT.md: tighten branching rule — one branch per PR regardless of merge status, not only after a merge. Each distinct change needs its own branch even if the previous branch is still open.

https://claude.ai/code/session_0192MDk764uixMnb69qobUtz