### PR TITLE
Use detected_wallets instead of explicit metamask in walletList

### DIFF
--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -97,7 +97,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
         appearance: {
           theme: "dark",
           accentColor: "#C99B5C",
-          walletList: ["metamask", "wallet_connect"],
+          walletList: ["detected_wallets", "wallet_connect"],
           showWalletLoginFirst: false,
         },
         embeddedWallets: {


### PR DESCRIPTION
"metamask" in Privy's walletList triggers a metamask.app.link deep link
on mobile when window.ethereum is absent, producing a broken /undefined
URL. "detected_wallets" surfaces injected wallets (MetaMask on desktop)
without deep-link behaviour on mobile.

https://claude.ai/code/session_0192MDk764uixMnb69qobUtz