### PR TITLE
Show all registered chaingammon names in a dropdown

### DIFF
--- a/frontend/app/ProfileBadge.tsx
+++ b/frontend/app/ProfileBadge.tsx
@@ -244,7 +244,7 @@ export function ClaimForm() {
 
 export function ProfileBadge({ address }: { address: `0x${string}` }) {
   const { t } = useI18n();
-  const { label, name, isLoading: nameLoading } = useChaingammonName(address);
+  const { label, labels, name, isLoading: nameLoading, setPreferred } = useChaingammonName(address);
   const { elo: ensElo, matchCount } = useChaingammonProfile(label);
   const { sync, syncing } = useSyncEnsProfile();
   const [syncError, setSyncError] = useState<string | null>(null);
@@ -288,22 +288,43 @@ export function ProfileBadge({ address }: { address: `0x${string}` }) {
           fontSize: 13,
         }}
       >
-        <a
-          href={`https://app.ens.domains/${name}`}
-          target="_blank"
-          rel="noreferrer"
-          title={name ?? undefined}
-          style={{ color: "var(--cg-fg-1)", textDecoration: "none" }}
-          onMouseEnter={(e) => { (e.currentTarget as HTMLAnchorElement).style.color = "var(--cg-brass)"; }}
-          onMouseLeave={(e) => { (e.currentTarget as HTMLAnchorElement).style.color = "var(--cg-fg-1)"; }}
-        >
-          {/* Narrow screens see just the label (e.g. "oleg") so the connected
-              header fits inside a phone-width viewport without horizontal
-              scroll; ≥640px (sm: breakpoint) sees the full subname. The
-              tooltip exposes the full name on either size. */}
-          <span className="sm:hidden">{label}</span>
-          <span className="hidden sm:inline">{name}</span>
-        </a>
+        {labels.length > 1 ? (
+          <select
+            title={name ?? undefined}
+            value={label ?? ""}
+            onChange={(e) => setPreferred(e.target.value)}
+            style={{
+              background: "none",
+              border: "none",
+              color: "var(--cg-fg-1)",
+              fontFamily: "var(--cg-font-mono)",
+              fontSize: 13,
+              cursor: "pointer",
+              padding: 0,
+            }}
+          >
+            {labels.map((l) => (
+              <option key={l} value={l}>{l}.chaingammon.eth</option>
+            ))}
+          </select>
+        ) : (
+          <a
+            href={`https://app.ens.domains/${name}`}
+            target="_blank"
+            rel="noreferrer"
+            title={name ?? undefined}
+            style={{ color: "var(--cg-fg-1)", textDecoration: "none" }}
+            onMouseEnter={(e) => { (e.currentTarget as HTMLAnchorElement).style.color = "var(--cg-brass)"; }}
+            onMouseLeave={(e) => { (e.currentTarget as HTMLAnchorElement).style.color = "var(--cg-fg-1)"; }}
+          >
+            {/* Narrow screens see just the label (e.g. "oleg") so the connected
+                header fits inside a phone-width viewport without horizontal
+                scroll; ≥640px (sm: breakpoint) sees the full subname. The
+                tooltip exposes the full name on either size. */}
+            <span className="sm:hidden">{label}</span>
+            <span className="hidden sm:inline">{name}</span>
+          </a>
+        )}
         {elo ? (
           <span
             title={t("elo_rating_label")}

--- a/frontend/app/useChaingammonName.ts
+++ b/frontend/app/useChaingammonName.ts
@@ -23,6 +23,10 @@ const SUBNAME_MINTED_EVENT = parseAbiItem(
   "event SubnameMinted(string label, bytes32 indexed node, address indexed subnameOwner, uint256 inftId)",
 );
 
+function preferredKey(address: string) {
+  return `cg:preferred-name:${address.toLowerCase()}`;
+}
+
 export function useChaingammonName(address: `0x${string}` | undefined) {
   const chainId = useActiveChainId();
   // Pin the public client to the active chain so log scans hit the
@@ -32,8 +36,17 @@ export function useChaingammonName(address: `0x${string}` | undefined) {
   const { playerSubnameRegistrar } = useChainContracts();
   const deployedBlock = useActiveChain()?.deployedBlock;
 
-  const [label, setLabel] = useState<string | null>(null);
+  const [labels, setLabels] = useState<string[]>([]);
+  const [preferred, setPreferredState] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!address) { setPreferredState(null); return; }
+    const stored = typeof window !== "undefined"
+      ? window.localStorage.getItem(preferredKey(address))
+      : null;
+    setPreferredState(stored);
+  }, [address]);
 
   useEffect(() => {
     if (
@@ -42,7 +55,7 @@ export function useChaingammonName(address: `0x${string}` | undefined) {
       !playerSubnameRegistrar ||
       playerSubnameRegistrar.length < 4
     ) {
-      setLabel(null);
+      setLabels([]);
       return;
     }
     let cancelled = false;
@@ -114,17 +127,13 @@ export function useChaingammonName(address: `0x${string}` | undefined) {
             log.args?.inftId === 0n &&
             (log.args?.subnameOwner as string | undefined)?.toLowerCase() === addrLower,
         );
-        if (humanLogs.length > 0) {
-          // A wallet could in theory own multiple subnames; take the most
-          // recently-minted one as the canonical display name.
-          const latest = humanLogs[humanLogs.length - 1];
-          setLabel(latest.args?.label ?? null);
-        } else {
-          setLabel(null);
-        }
+        const found = humanLogs
+          .map((log) => log.args?.label as string | undefined)
+          .filter((l): l is string => !!l);
+        setLabels(found);
       })
       .catch(() => {
-        if (!cancelled) setLabel(null);
+        if (!cancelled) setLabels([]);
       })
       .finally(() => {
         if (!cancelled) setIsLoading(false);
@@ -134,6 +143,16 @@ export function useChaingammonName(address: `0x${string}` | undefined) {
     };
   }, [address, client, playerSubnameRegistrar, chainId, deployedBlock]);
 
+  const setPreferred = (l: string) => {
+    if (!address) return;
+    window.localStorage.setItem(preferredKey(address), l);
+    setPreferredState(l);
+  };
+
+  // Pick preferred if it's still registered, otherwise oldest registration.
+  const label = (preferred && labels.includes(preferred))
+    ? preferred
+    : (labels[0] ?? null);
   const name = label ? `${label}.chaingammon.eth` : null;
-  return { label, name, isLoading };
+  return { label, labels, name, isLoading, setPreferred };
 }


### PR DESCRIPTION
When a wallet has multiple .chaingammon.eth subnames, the profile badge now shows a <select> so the user can choose which name to display. The choice is persisted in localStorage keyed by address.

useChaingammonName now returns labels[] (all registered names) plus setPreferred(), in addition to the existing label/name/isLoading.

https://claude.ai/code/session_0192MDk764uixMnb69qobUtz