### PR TITLE
Show all registered chaingammon names in a dropdown

### DIFF
--- a/frontend/app/ProfileBadge.tsx
+++ b/frontend/app/ProfileBadge.tsx
@@ -244,7 +244,7 @@ export function ClaimForm() {
 
 export function ProfileBadge({ address }: { address: `0x${string}` }) {
   const { t } = useI18n();
-  const { label, labels, name, isLoading: nameLoading, setPreferred } = useChaingammonName(address);
+  const { label, entries, selectedIdx, name, isLoading: nameLoading, setPreferred } = useChaingammonName(address);
   const { elo: ensElo, matchCount } = useChaingammonProfile(label);
   const { sync, syncing } = useSyncEnsProfile();
   const [syncError, setSyncError] = useState<string | null>(null);
@@ -288,11 +288,11 @@ export function ProfileBadge({ address }: { address: `0x${string}` }) {
           fontSize: 13,
         }}
       >
-        {labels.length > 1 ? (
+        {entries.length > 1 ? (
           <select
             title={name ?? undefined}
-            value={label ?? ""}
-            onChange={(e) => setPreferred(e.target.value)}
+            value={selectedIdx}
+            onChange={(e) => setPreferred(Number(e.target.value))}
             style={{
               background: "none",
               border: "none",
@@ -303,9 +303,13 @@ export function ProfileBadge({ address }: { address: `0x${string}` }) {
               padding: 0,
             }}
           >
-            {labels.map((l) => (
-              <option key={l} value={l}>{l}.chaingammon.eth</option>
-            ))}
+            {entries.map((entry, i) => {
+              const isDup = entries.some((e, j) => j !== i && e.label === entry.label);
+              const text = isDup
+                ? `${entry.label}.chaingammon.eth (block ${entry.blockNumber})`
+                : `${entry.label}.chaingammon.eth`;
+              return <option key={i} value={i}>{text}</option>;
+            })}
           </select>
         ) : (
           <a

--- a/frontend/app/useChaingammonName.ts
+++ b/frontend/app/useChaingammonName.ts
@@ -23,8 +23,10 @@ const SUBNAME_MINTED_EVENT = parseAbiItem(
   "event SubnameMinted(string label, bytes32 indexed node, address indexed subnameOwner, uint256 inftId)",
 );
 
+export interface NameEntry { label: string; blockNumber: bigint; }
+
 function preferredKey(address: string) {
-  return `cg:preferred-name:${address.toLowerCase()}`;
+  return `cg:preferred-idx:${address.toLowerCase()}`;
 }
 
 export function useChaingammonName(address: `0x${string}` | undefined) {
@@ -36,16 +38,16 @@ export function useChaingammonName(address: `0x${string}` | undefined) {
   const { playerSubnameRegistrar } = useChainContracts();
   const deployedBlock = useActiveChain()?.deployedBlock;
 
-  const [labels, setLabels] = useState<string[]>([]);
-  const [preferred, setPreferredState] = useState<string | null>(null);
+  const [entries, setEntries] = useState<NameEntry[]>([]);
+  const [preferredIdx, setPreferredIdxState] = useState<number>(0);
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    if (!address) { setPreferredState(null); return; }
+    if (!address) { setPreferredIdxState(0); return; }
     const stored = typeof window !== "undefined"
       ? window.localStorage.getItem(preferredKey(address))
       : null;
-    setPreferredState(stored);
+    setPreferredIdxState(stored !== null ? Number(stored) : 0);
   }, [address]);
 
   useEffect(() => {
@@ -127,15 +129,16 @@ export function useChaingammonName(address: `0x${string}` | undefined) {
             log.args?.inftId === 0n &&
             (log.args?.subnameOwner as string | undefined)?.toLowerCase() === addrLower,
         );
-        const found = [...new Set(
-          humanLogs
-            .map((log) => log.args?.label as string | undefined)
-            .filter((l): l is string => !!l),
-        )];
-        setLabels(found);
+        const found: NameEntry[] = humanLogs
+          .map((log) => ({
+            label: log.args?.label as string | undefined,
+            blockNumber: log.blockNumber ?? 0n,
+          }))
+          .filter((e): e is NameEntry => !!e.label);
+        setEntries(found);
       })
       .catch(() => {
-        if (!cancelled) setLabels([]);
+        if (!cancelled) setEntries([]);
       })
       .finally(() => {
         if (!cancelled) setIsLoading(false);
@@ -145,16 +148,14 @@ export function useChaingammonName(address: `0x${string}` | undefined) {
     };
   }, [address, client, playerSubnameRegistrar, chainId, deployedBlock]);
 
-  const setPreferred = (l: string) => {
+  const setPreferred = (idx: number) => {
     if (!address) return;
-    window.localStorage.setItem(preferredKey(address), l);
-    setPreferredState(l);
+    window.localStorage.setItem(preferredKey(address), String(idx));
+    setPreferredIdxState(idx);
   };
 
-  // Pick preferred if it's still registered, otherwise oldest registration.
-  const label = (preferred && labels.includes(preferred))
-    ? preferred
-    : (labels[0] ?? null);
+  const selectedIdx = preferredIdx < entries.length ? preferredIdx : 0;
+  const label = entries[selectedIdx]?.label ?? null;
   const name = label ? `${label}.chaingammon.eth` : null;
-  return { label, labels, name, isLoading, setPreferred };
+  return { label, entries, selectedIdx, name, isLoading, setPreferred };
 }

--- a/frontend/app/useChaingammonName.ts
+++ b/frontend/app/useChaingammonName.ts
@@ -127,9 +127,11 @@ export function useChaingammonName(address: `0x${string}` | undefined) {
             log.args?.inftId === 0n &&
             (log.args?.subnameOwner as string | undefined)?.toLowerCase() === addrLower,
         );
-        const found = humanLogs
-          .map((log) => log.args?.label as string | undefined)
-          .filter((l): l is string => !!l);
+        const found = [...new Set(
+          humanLogs
+            .map((log) => log.args?.label as string | undefined)
+            .filter((l): l is string => !!l),
+        )];
         setLabels(found);
       })
       .catch(() => {


### PR DESCRIPTION
## Summary

- When a wallet has multiple `.chaingammon.eth` subnames, the profile badge now shows a dropdown `<select>` instead of a plain link
- Duplicate registrations of the same name (e.g. "oleg" registered 3 times) show the block number in parentheses so each registration is distinguishable
- The selected name is persisted in localStorage keyed by address
- `useChaingammonName` now returns `entries[]` (label + blockNumber), `selectedIdx`, and `setPreferred(idx)` in addition to the existing `label`/`name`/`isLoading`

## Test plan

- [ ] Connect wallet with multiple registered names — dropdown appears in header
- [ ] Duplicate labels show `(block XXXXXXX)` suffix; unique labels show plain
- [ ] Selecting a name from the dropdown persists across page reload
- [ ] Single-name wallets still show the plain link (no dropdown)

https://claude.ai/code/session_0192MDk764uixMnb69qobUtz

---
_Generated by [Claude Code](https://claude.ai/code/session_0192MDk764uixMnb69qobUtz)_