### PR TITLE
Fix matchmaking: deduplicate presence events by wallet address

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -231,7 +231,15 @@ function EloHome() {
     const myEloNum = Number(chainEloRaw ?? 1500) || 1500;
     nostr.startPresence({ ensLabel: "", address: address ?? "", sessionPubkey: nostr.pubkey, elo: myEloNum }, PRESENCE_INTERVAL_MS);
     const unsub = nostr.subscribePresence((p, pubkey, at) => {
-      searchersRef.current.set(pubkey, { s: { pubkey, elo: p.elo ?? 1500 }, at });
+      // Skip ghost sessions from my own wallet (same address, different Nostr pubkey).
+      if (p.address && address && p.address.toLowerCase() === address.toLowerCase()) return;
+      // Key by wallet address so multiple Nostr sessions from the same wallet
+      // collapse to one entry; keep whichever arrived most recently.
+      const key = p.address || pubkey;
+      const existing = searchersRef.current.get(key);
+      if (!existing || at >= existing.at) {
+        searchersRef.current.set(key, { s: { pubkey, elo: p.elo ?? 1500 }, at });
+      }
     });
     // First attempt after presence has had time to stabilize.
     const stabilizeTimer = setTimeout(() => tryConnect(nostr, myEloNum), STABILIZE_MS);


### PR DESCRIPTION
## Problem

When the same wallet has multiple `.chaingammon.eth` subnames (e.g. oleg, test-fedd8129, test-50e8d789), each active Nostr session published its own presence event with a different ephemeral pubkey. The matchmaker treated each one as a separate searcher.

With 4 apparent searchers instead of 2, `computePairing()` would sort them by ELO and pair by pubkey tiebreak. The tiebreak is random per session, so sometimes the real player (oleg) paired with a ghost session (test-fedd8129) that had no one listening. The WebRTC offer sat unread, timed out, and the match never formed.

## Fix

Key `searchersRef` by wallet address instead of Nostr pubkey. Multiple sessions from the same wallet collapse to the most recent one. Also skip presence events from my own wallet address (eliminates ghost events from old tabs of the same wallet).

## Test plan

- [ ] Two wallets on different browsers can find and match each other even when one wallet has multiple registered subnames
- [ ] Opening the same wallet in two tabs does not create duplicate searcher entries

https://claude.ai/code/session_0192MDk764uixMnb69qobUtz

---
_Generated by [Claude Code](https://claude.ai/code/session_0192MDk764uixMnb69qobUtz)_