### PR TITLE
Show shortened wallet address in navbar profile badge

### DIFF
--- a/frontend/app/ProfileBadge.tsx
+++ b/frontend/app/ProfileBadge.tsx
@@ -329,6 +329,12 @@ export function ProfileBadge({ address }: { address: `0x${string}` }) {
             <span className="hidden sm:inline">{name}</span>
           </a>
         )}
+        <span
+          title={address}
+          style={{ fontSize: 11, color: "var(--cg-fg-3)", fontFamily: "var(--cg-font-mono)" }}
+        >
+          {shorten(address)}
+        </span>
         {elo ? (
           <span
             title={t("elo_rating_label")}


### PR DESCRIPTION
## Summary

Adds the truncated wallet address (e.g. `0xf39F…2266`) next to the ENS name in the navbar. Hovering shows the full address as a tooltip.

Useful when comparing sessions — e.g. MetaMask vs Privy embedded wallet — to confirm which address is actually connected.

## Test plan

- [ ] Connected wallet with ENS name shows `name · 0xABCD…1234 · ELO XXXX`
- [ ] Connected wallet without ENS name shows the ClaimForm (unchanged)
- [ ] Full address appears on hover

https://claude.ai/code/session_0192MDk764uixMnb69qobUtz

---
_Generated by [Claude Code](https://claude.ai/code/session_0192MDk764uixMnb69qobUtz)_