### PR TITLE
Enforce one ENS name per address + revocation script

### DIFF
--- a/contracts/script/deploy_registrar.js
+++ b/contracts/script/deploy_registrar.js
@@ -55,14 +55,27 @@ async function main() {
   }
   const existing = JSON.parse(fs.readFileSync(deploymentPath, "utf8"));
 
+  const nameWrapperAddr = existing.contracts?.NameWrapper;
+  const resolverAddr = existing.contracts?.PublicResolver;
+  if (!nameWrapperAddr) throw new Error("NameWrapper address missing from deployment JSON");
+  if (!resolverAddr) throw new Error("PublicResolver address missing from deployment JSON");
+
   const PlayerSubnameRegistrar = await ethers.getContractFactory("PlayerSubnameRegistrar");
-  const registrar = await PlayerSubnameRegistrar.deploy(ENS_PARENT_NODE);
+  const registrar = await PlayerSubnameRegistrar.deploy(
+    ENS_PARENT_NODE,
+    nameWrapperAddr,
+    resolverAddr,
+  );
   await registrar.waitForDeployment();
   const registrarAddr = await registrar.getAddress();
   console.log(
     `PlayerSubnameRegistrar deployed: ${registrarAddr} (parent node ${ENS_PARENT_NODE})`,
   );
-  await verifyContract(registrarAddr, [ENS_PARENT_NODE]);
+  console.log(`  NameWrapper: ${nameWrapperAddr}`);
+  console.log(`  PublicResolver: ${resolverAddr}`);
+  console.log(`NOTE: approve the new registrar in ENS NameWrapper:`);
+  console.log(`  nameWrapper.setApprovalForAll("${registrarAddr}", true)`);
+  await verifyContract(registrarAddr, [ENS_PARENT_NODE, nameWrapperAddr, resolverAddr]);
 
   const merged = {
     ...existing,
@@ -72,6 +85,8 @@ async function main() {
     },
     playerSubnameRegistrarConstructorArgs: {
       parentNode: ENS_PARENT_NODE,
+      nameWrapper: nameWrapperAddr,
+      resolver: resolverAddr,
     },
     registrarDeployedAt: new Date().toISOString(),
   };

--- a/contracts/script/revoke_player_subnames.js
+++ b/contracts/script/revoke_player_subnames.js
@@ -1,0 +1,72 @@
+// Revoke a list of chaingammon.eth subnames owned by a player.
+//
+// Run this against the EXISTING deployed contract (before any redeployment)
+// to clean up test registrations. The deployer key is required because
+// revokeSubname is owner-only.
+//
+// Usage:
+//   pnpm exec hardhat run script/revoke_player_subnames.js --network sepolia
+//
+// Edit LABELS_TO_REVOKE below before running. Do NOT include labels you
+// want to keep (e.g. "oleg", "oleg1").
+
+const fs = require("fs");
+const path = require("path");
+const { ethers, network } = require("hardhat");
+
+// ── Edit this list before running ──────────────────────────────────────────
+const LABELS_TO_REVOKE = [
+  "test-fedd8129",
+  "test-50e8d789",
+  "test-866fc1ef",
+  "test-5218e675",
+  "test-148707e3",
+  "test-0dcef85d",
+];
+// ───────────────────────────────────────────────────────────────────────────
+
+const REGISTRAR_ABI = [
+  "function revokeSubname(string calldata label) external",
+  "function ownerOf(string calldata label) external view returns (address)",
+];
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  console.log(`Revoking from ${deployer.address} on ${network.name}`);
+
+  const deploymentPath = path.join(
+    __dirname, "..", "deployments", `${network.name}.json`
+  );
+  if (!fs.existsSync(deploymentPath)) {
+    throw new Error(`No deployment file at ${deploymentPath}`);
+  }
+  const deployment = JSON.parse(fs.readFileSync(deploymentPath, "utf8"));
+  const registrarAddr = deployment.contracts?.PlayerSubnameRegistrar;
+  if (!registrarAddr) throw new Error("PlayerSubnameRegistrar not found in deployment");
+
+  console.log(`PlayerSubnameRegistrar: ${registrarAddr}`);
+  const registrar = new ethers.Contract(registrarAddr, REGISTRAR_ABI, deployer);
+
+  for (const label of LABELS_TO_REVOKE) {
+    const current = await registrar.ownerOf(label).catch(() => ethers.ZeroAddress);
+    if (current === ethers.ZeroAddress) {
+      console.log(`  ${label}: already unowned, skipping`);
+      continue;
+    }
+    console.log(`  ${label}: owner=${current} — revoking…`);
+    try {
+      const tx = await registrar.revokeSubname(label);
+      await tx.wait();
+      console.log(`  ${label}: revoked (tx ${tx.hash})`);
+    } catch (e) {
+      console.error(`  ${label}: FAILED — ${e.message}`);
+    }
+  }
+
+  console.log("Done.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/contracts/src/PlayerSubnameRegistrar.sol
+++ b/contracts/src/PlayerSubnameRegistrar.sol
@@ -75,9 +75,14 @@ contract PlayerSubnameRegistrar is Ownable {
     event SubnameRevoked(string label, bytes32 indexed node);
     event AuthorizedMinterSet(address indexed minter, bool authorized);
 
+    /// @notice Tracks which addresses have already claimed a subname via
+    ///         selfMintSubname so that duplicate self-registrations are blocked.
+    mapping(address => bool) public hasClaimed;
+
     error EmptyLabel();
     error NotAuthorized();
     error ZeroAddressOwner();
+    error AlreadyRegistered();
 
     constructor(bytes32 _parentNode, address _nameWrapper, address _resolver) Ownable(msg.sender) {
         parentNode = _parentNode;
@@ -145,9 +150,12 @@ contract PlayerSubnameRegistrar is Ownable {
     }
 
     /// @notice Open self-registration: anyone can claim a subname for
-    ///         themselves. Delegates to NameWrapper.
+    ///         themselves. Delegates to NameWrapper. Each address may claim
+    ///         at most one subname; use selfRevokeSubname to release the claim.
     function selfMintSubname(string calldata label) external returns (bytes32 node) {
         if (bytes(label).length == 0) revert EmptyLabel();
+        if (hasClaimed[msg.sender]) revert AlreadyRegistered();
+        hasClaimed[msg.sender] = true;
 
         node = nameWrapper.setSubnodeRecord(
             parentNode,
@@ -166,18 +174,28 @@ contract PlayerSubnameRegistrar is Ownable {
     }
 
     /// @notice Revoke a subname. Owner / authorized minter only.
-    ///         Clears the NameWrapper owner to address(0).
+    ///         Clears the NameWrapper owner to address(0) and releases the
+    ///         hasClaimed flag so the previous owner may re-register.
     function revokeSubname(string calldata label) external {
         if (msg.sender != owner() && !_authorizedMinters[msg.sender]) revert NotAuthorized();
 
-        bytes32 node = nameWrapper.setSubnodeOwner(
-            parentNode,
-            label,
-            address(0),
-            0,
-            0
-        );
+        bytes32 _node = subnameNode(label);
+        (address current, , ) = nameWrapper.getData(uint256(_node));
+        if (current != address(0)) hasClaimed[current] = false;
 
+        bytes32 node = nameWrapper.setSubnodeOwner(parentNode, label, address(0), 0, 0);
+        emit SubnameRevoked(label, node);
+    }
+
+    /// @notice Self-service revocation: the subname owner can release their
+    ///         own claim, clearing hasClaimed so they may later register a
+    ///         different name.
+    function selfRevokeSubname(string calldata label) external {
+        bytes32 _node = subnameNode(label);
+        (address current, , ) = nameWrapper.getData(uint256(_node));
+        if (current != msg.sender) revert NotAuthorized();
+        hasClaimed[msg.sender] = false;
+        bytes32 node = nameWrapper.setSubnodeOwner(parentNode, label, address(0), 0, 0);
         emit SubnameRevoked(label, node);
     }
 

--- a/contracts/test/phase10_PlayerSubnameRegistrar.test.js
+++ b/contracts/test/phase10_PlayerSubnameRegistrar.test.js
@@ -138,4 +138,14 @@ describe("Phase 10 — PlayerSubnameRegistrar (NameWrapper-backed)", function ()
       expect(await registrar.ownerOf("alice")).to.equal(alice.address);
     });
   });
+
+  describe("revokeSubname clears hasClaimed", function () {
+    it("owner revoking a self-minted label releases hasClaimed for the previous owner", async function () {
+      const { registrar, alice } = await deployFixture();
+      await registrar.connect(alice).selfMintSubname("alice");
+      expect(await registrar.hasClaimed(alice.address)).to.be.true;
+      await registrar.revokeSubname("alice");
+      expect(await registrar.hasClaimed(alice.address)).to.be.false;
+    });
+  });
 });

--- a/contracts/test/phase22_selfMintSubname.test.js
+++ b/contracts/test/phase22_selfMintSubname.test.js
@@ -81,4 +81,56 @@ describe("Phase 22 — selfMintSubname", function () {
     expect(await registrar.ownerOf("alice")).to.equal(alice.address);
     expect(await registrar.ownerOf("bob")).to.equal(bob.address);
   });
+
+  it("hasClaimed is false before any mint", async function () {
+    const { registrar, alice } = await deployFixture();
+    expect(await registrar.hasClaimed(alice.address)).to.be.false;
+  });
+
+  it("hasClaimed is true after selfMintSubname", async function () {
+    const { registrar, alice } = await deployFixture();
+    await registrar.connect(alice).selfMintSubname("alice");
+    expect(await registrar.hasClaimed(alice.address)).to.be.true;
+  });
+
+  it("second selfMintSubname from the same address reverts with AlreadyRegistered", async function () {
+    const { registrar, alice } = await deployFixture();
+    await registrar.connect(alice).selfMintSubname("alice");
+    let reverted = false;
+    try {
+      await registrar.connect(alice).selfMintSubname("alice2");
+    } catch {
+      reverted = true;
+    }
+    expect(reverted).to.be.true;
+  });
+
+  it("selfRevokeSubname clears hasClaimed and the ENS owner", async function () {
+    const { registrar, alice } = await deployFixture();
+    await registrar.connect(alice).selfMintSubname("alice");
+    await registrar.connect(alice).selfRevokeSubname("alice");
+    expect(await registrar.hasClaimed(alice.address)).to.be.false;
+    expect(await registrar.ownerOf("alice")).to.equal(ethers.ZeroAddress);
+  });
+
+  it("address can selfMintSubname again after selfRevokeSubname", async function () {
+    const { registrar, alice } = await deployFixture();
+    await registrar.connect(alice).selfMintSubname("alice");
+    await registrar.connect(alice).selfRevokeSubname("alice");
+    await registrar.connect(alice).selfMintSubname("alice-new");
+    expect(await registrar.ownerOf("alice-new")).to.equal(alice.address);
+    expect(await registrar.hasClaimed(alice.address)).to.be.true;
+  });
+
+  it("selfRevokeSubname reverts when caller does not own the label", async function () {
+    const { registrar, alice, bob } = await deployFixture();
+    await registrar.connect(alice).selfMintSubname("alice");
+    let reverted = false;
+    try {
+      await registrar.connect(bob).selfRevokeSubname("alice");
+    } catch {
+      reverted = true;
+    }
+    expect(reverted).to.be.true;
+  });
 });

--- a/frontend/app/useChaingammonName.ts
+++ b/frontend/app/useChaingammonName.ts
@@ -17,7 +17,7 @@ import { parseAbiItem } from "viem";
 import { usePublicClient } from "wagmi";
 
 import { useActiveChain, useActiveChainId } from "./chains";
-import { useChainContracts } from "./contracts";
+import { PlayerSubnameRegistrarABI, useChainContracts } from "./contracts";
 
 const SUBNAME_MINTED_EVENT = parseAbiItem(
   "event SubnameMinted(string label, bytes32 indexed node, address indexed subnameOwner, uint256 inftId)",
@@ -57,7 +57,7 @@ export function useChaingammonName(address: `0x${string}` | undefined) {
       !playerSubnameRegistrar ||
       playerSubnameRegistrar.length < 4
     ) {
-      setLabels([]);
+      setEntries([]);
       return;
     }
     let cancelled = false;
@@ -121,7 +121,7 @@ export function useChaingammonName(address: `0x${string}` | undefined) {
     const addrLower = address.toLowerCase();
     computeFromBlock()
       .then((fromBlock) => scanChunked(fromBlock))
-      .then((logs) => {
+      .then(async (logs) => {
         if (cancelled) return;
         // Filter client-side: human names (inftId == 0) owned by this address.
         const humanLogs = logs.filter(
@@ -129,13 +129,38 @@ export function useChaingammonName(address: `0x${string}` | undefined) {
             log.args?.inftId === 0n &&
             (log.args?.subnameOwner as string | undefined)?.toLowerCase() === addrLower,
         );
-        const found: NameEntry[] = humanLogs
+        const allFound: NameEntry[] = humanLogs
           .map((log) => ({
             label: log.args?.label as string | undefined,
             blockNumber: log.blockNumber ?? 0n,
           }))
           .filter((e): e is NameEntry => !!e.label);
-        setEntries(found);
+
+        // Deduplicate by label — multiple SubnameMinted events can share the
+        // same label (ENS allows overwrites); keep only the latest per label.
+        const deduped = new Map<string, NameEntry>();
+        for (const e of allFound) {
+          const prev = deduped.get(e.label);
+          if (!prev || e.blockNumber > prev.blockNumber) deduped.set(e.label, e);
+        }
+
+        // Verify current ENS ownership to filter out revoked names.
+        const verified = await Promise.all(
+          [...deduped.values()].map(async (e) => {
+            try {
+              const owner = await client!.readContract({
+                address: playerSubnameRegistrar as `0x${string}`,
+                abi: PlayerSubnameRegistrarABI,
+                functionName: "ownerOf",
+                args: [e.label],
+              });
+              return (owner as string).toLowerCase() === addrLower ? e : null;
+            } catch {
+              return null;
+            }
+          }),
+        );
+        if (!cancelled) setEntries(verified.filter((e): e is NameEntry => e !== null));
       })
       .catch(() => {
         if (!cancelled) setEntries([]);


### PR DESCRIPTION
- PlayerSubnameRegistrar: add `hasClaimed` mapping so `selfMintSubname`
  reverts with `AlreadyRegistered` if the caller already has a registered
  name. Add `selfRevokeSubname` so players can release their claim and pick
  a different name. Update `revokeSubname` (owner path) to also clear
  `hasClaimed` for the previous owner.

- useChaingammonName: deduplicate entries by label (keep latest blockNumber)
  and verify current ENS ownership via `ownerOf` so revoked names are
  filtered out without needing SubnameRevoked event scans.

- contracts/script/revoke_player_subnames.js: new one-shot Hardhat script
  for the deployer to bulk-revoke test labels; edit LABELS_TO_REVOKE and
  run against Sepolia before redeployment.

- deploy_registrar.js: fix constructor call that was missing the required
  NameWrapper and resolver arguments; add reminder to re-approve the new
  contract in ENS NameWrapper after deployment.

https://claude.ai/code/session_0192MDk764uixMnb69qobUtz