### PR TITLE
Fix ENS name claim for Privy embedded wallets; don't show ClaimForm o…

### DIFF
--- a/frontend/app/ProfileBadge.tsx
+++ b/frontend/app/ProfileBadge.tsx
@@ -56,35 +56,7 @@ export function ClaimForm() {
 
   const chainId = useActiveChainId();
   const { playerSubnameRegistrar } = useChainContracts();
-  const { writeContractAsync, isPending, sponsored } = useSponsoredWrite();
-  const { address } = useAccount();
-
-  // Server-pays mint — used for Privy embedded wallets (Google/email logins)
-  // which have no gas. The deployer key on the server signs and pays.
-  const [serverMinting, setServerMinting] = useState(false);
-  const submitViaServer = async (label: string) => {
-    if (!address) throw new Error("No wallet connected");
-    setServerMinting(true);
-    try {
-      const SERVER = process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:8000";
-      const res = await fetch(`${SERVER}/subname/mint`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ label, owner: address }),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.detail || `HTTP ${res.status}`);
-      }
-      recordTransaction({
-        type: "ens_subname",
-        description: `ENS subname registered: ${label}.chaingammon.eth`,
-      });
-      window.location.reload();
-    } finally {
-      setServerMinting(false);
-    }
-  };
+  const { writeContractAsync, isPending } = useSponsoredWrite();
 
   const { isLoading: isConfirming, isSuccess: isConfirmed } = useWaitForTransactionReceipt({
     hash: txHash,
@@ -92,7 +64,7 @@ export function ClaimForm() {
     query: { enabled: !!txHash },
   });
 
-  const claiming = isPending || isConfirming || serverMinting;
+  const claiming = isPending || isConfirming;
 
   // Reload once the subname transaction is confirmed on-chain so
   // useChaingammonName re-scans and finds the new SubnameMinted event.
@@ -113,12 +85,6 @@ export function ClaimForm() {
     setSuggestion(null);
     setTxHash(undefined);
     try {
-      // Privy embedded wallets (Google/email) have no gas — route through the
-      // server-pays endpoint so the deployer key covers the transaction.
-      if (sponsored) {
-        await submitViaServer(trimmed);
-        return;
-      }
       const hash = await writeContractAsync({
         address: playerSubnameRegistrar,
         abi: PlayerSubnameRegistrarABI,
@@ -244,7 +210,7 @@ export function ClaimForm() {
 
 export function ProfileBadge({ address }: { address: `0x${string}` }) {
   const { t } = useI18n();
-  const { label, entries, selectedIdx, name, isLoading: nameLoading, setPreferred } = useChaingammonName(address);
+  const { label, entries, selectedIdx, name, isLoading: nameLoading, isError: nameError, setPreferred } = useChaingammonName(address);
   const { elo: ensElo, matchCount } = useChaingammonProfile(label);
   const { sync, syncing } = useSyncEnsProfile();
   const [syncError, setSyncError] = useState<string | null>(null);
@@ -263,7 +229,7 @@ export function ProfileBadge({ address }: { address: `0x${string}` }) {
   const chainElo = chainEloRaw != null ? String(chainEloRaw) : undefined;
   const elo = chainElo ?? ensElo;
 
-  if (nameLoading) {
+  if (nameLoading || (nameError && !label)) {
     return (
       <span
         data-testid="profile-badge"

--- a/frontend/app/useChaingammonName.ts
+++ b/frontend/app/useChaingammonName.ts
@@ -41,6 +41,7 @@ export function useChaingammonName(address: `0x${string}` | undefined) {
   const [entries, setEntries] = useState<NameEntry[]>([]);
   const [preferredIdx, setPreferredIdxState] = useState<number>(0);
   const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
 
   useEffect(() => {
     if (!address) { setPreferredIdxState(0); return; }
@@ -62,6 +63,7 @@ export function useChaingammonName(address: `0x${string}` | undefined) {
     }
     let cancelled = false;
     setIsLoading(true);
+    setIsError(false);
 
     // Public testnet RPCs cap eth_getLogs to a fixed block range
     // (publicnode Sepolia: 50000 blocks; many providers: 10000). A
@@ -168,7 +170,10 @@ export function useChaingammonName(address: `0x${string}` | undefined) {
         if (!cancelled) setEntries(verified.filter((e): e is NameEntry => e !== null));
       })
       .catch(() => {
-        if (!cancelled) setEntries([]);
+        // Scan failed (RPC error, rate limit, etc.). Don't clear existing
+        // entries so a known name isn't hidden, and set isError so the
+        // caller can avoid showing the ClaimForm on a mere network failure.
+        if (!cancelled) setIsError(true);
       })
       .finally(() => {
         if (!cancelled) setIsLoading(false);
@@ -187,5 +192,5 @@ export function useChaingammonName(address: `0x${string}` | undefined) {
   const selectedIdx = preferredIdx < entries.length ? preferredIdx : 0;
   const label = entries[selectedIdx]?.label ?? null;
   const name = label ? `${label}.chaingammon.eth` : null;
-  return { label, entries, selectedIdx, name, isLoading, setPreferred };
+  return { label, entries, selectedIdx, name, isLoading, isError, setPreferred };
 }


### PR DESCRIPTION
…n RPC error

ClaimForm was routing Privy embedded-wallet mints through a custom server endpoint (submitViaServer) that expected a running backend. useSponsoredWrite already handles embedded wallets natively via Privy's sendTransaction({ sponsor: true }), so the server path was dead weight causing "NetworkError when attempting to fetch resources" whenever the server was down. Removed submitViaServer entirely; writeContractAsync now handles all wallets uniformly.

useChaingammonName now tracks scan failures (getLogs / RPC errors) with isError. ProfileBadge shows the shortened address instead of the ClaimForm when isError is true and no entries are cached, preventing the form from appearing due to a transient network outage.

https://claude.ai/code/session_0192MDk764uixMnb69qobUtz