### PR TITLE
[EthGlobalNYC26] Add ETHGlobal NYC 2026 continuity-track plan

### DIFF
--- a/docs/superpowers/plans/2026-06-13-ethglobal-nyc-2026.md
+++ b/docs/superpowers/plans/2026-06-13-ethglobal-nyc-2026.md
@@ -1,0 +1,117 @@
+# ETHGlobal NYC 2026 — Continuity Track Plan
+
+> **Status:** roadmap. This doc enumerates four integration streams. Each stream ships as
+> its own **simple, sequential, human-approved PR** — no big-bang rewrite. Every commit
+> title is prefixed `[EthGlobalNYC26]`.
+
+## What Chaingammon is
+
+Chaingammon is on-chain backgammon where players — human and AI — actually own their game.
+
+- **Own your Elo.** Ratings are recorded on-chain in `contracts/src/MatchRegistry.sol`,
+  surfaced as ENS text records on `<name>.chaingammon.eth`, and agents are iNFTs in
+  `contracts/src/AgentRegistry.sol`. Your rating and history are portable, not locked inside
+  a platform account.
+- **Trust the platform.** Provably fair **VRF dice** from drand
+  (`keccak256(round_digest, turn_index) mod 36`), **open-source matching & settlement**
+  (session-key `settleWithSessionKeys`, KeeperHub workflows), and **verifiable saved game
+  history** — full game records are stored off-chain with their hash committed on-chain via
+  `MatchRegistry.gameRecordHash`.
+- **Money games.** A match is free (Elo-only) or staked; per-side USDC deposits live in
+  `contracts/src/MatchEscrowUsdc.sol` and the winner takes the pot.
+- **The ancient game, shifted into the future.** `BackgammonNet` is an AI that innovates on
+  the current state of the art (GNUBG) via self-play and a challenge marketplace — opening
+  the path to **star AI players and derivatives** on their performance.
+
+## Continuity narrative
+
+The Continuity track is about the agent persisting **independently of any one server,
+provider, or model**: it owns its own wallet (identity + funds), its own equity (a dividend
+vault), and decentralized storage. Today these are custodial/centralized — agent funds sit in
+`contracts/src/AgentVault.sol` under a server operator key (`server/app/agent_wallets.py`),
+the server distributes payouts, and learned weights live in 0G behind the centralized
+`og-bridge` (a Python→TypeScript workaround for 0G having no Python SDK).
+
+**Ground rule — all balances are denominated in USDC** (agent wallet, deposits, stakes,
+dividends, settlement). The legacy ETH `AgentVault.sol` path is dropped.
+
+---
+
+## Stream 1 — Privy agentic wallets (replace AgentVault)
+
+**Why:** the agent owns its wallet, so [Privy](https://docs.privy.io/recipes/agent-integrations/agent-cli)
+distributes winnings instead of the server — simplifying money-game settlement and giving the
+agent a persistent identity. Privy server wallets give the agent *signer* access (P-256),
+never the raw key, with policies (spend limits, allowed contracts, chain restrictions). The
+frontend already uses Privy embedded wallets (`frontend/app/providers.tsx`), so this extends
+an existing dependency. Replaces `contracts/src/AgentVault.sol` /
+`contracts/src/AgentVaultToken.sol` + `server/app/agent_wallets.py`.
+
+- **PR 1.1** — Provision a Privy server wallet per agent (env `PRIVY_APP_SECRET`); store the
+  wallet id alongside the agent; expose its USDC balance. Additive — nothing removed yet.
+- **PR 1.2** — Pay staked winnings from the agent's Privy wallet instead of the server
+  operator key + escrow split (replace the payout half of `/finalize-direct-staked` /
+  `chain_client.settle_with_session_keys`). Elo recording stays on `MatchRegistry`.
+- **PR 1.3** — Remove the AgentVault contracts + operator; rework
+  `frontend/app/AgentWalletPanel.tsx` to show the Privy wallet.
+- **PR 1.4** — **Dividend-vault MVP:** stakeholders hold equity in the agent; the agent pays
+  USDC dividends from tournament winnings — the simplest agent-equity derivative. Add
+  **placeholders only** (interfaces + notes) for: ERC-4626 tokenized vault + bonding curve to
+  capture growing P/E, basket/index bets across agents, "elo-collateralized" borrowing by
+  agents, and puts on agent performance to hedge equity.
+
+## Stream 2 — Privy Universal Deposit Address
+
+**Why:** frictionless onboarding. With a
+[universal deposit address](https://docs.privy.io/wallets/funding/crypto-deposit-addresses)
+the user just sends their **Arbitrum ETH** to one address and Privy *automagically* bridges,
+swaps, and deposits **Base USDC** into their account so they can play.
+
+- **PR 2.1** — Add a "Deposit crypto (any chain)" option in
+  `frontend/app/UsdcBalanceDisplay.tsx` using Privy's `useDepositAddress` hook; destination =
+  Base USDC; show bridge/swap status.
+
+## Stream 3 — blink.cash one-tap deposit
+
+**Why:** [blink.cash](https://docs.blink.cash/introduction) lets users deposit stablecoins in
+one tap without leaving the app.
+
+- **PR 3.1** — Embed blink.cash in the funding UI to **credit the user's Privy wallet in
+  USDC**. Agent staking and money games then draw from that USDC credit — blink does not route
+  to stakes directly. (Exact SDK surface to be confirmed from the blink.cash docs at
+  implementation time.)
+
+## Stream 4 — Walrus storage (replace 0G)
+
+**Why:** [Walrus](https://mystenlabs.github.io/evm-sui/) exposes a plain HTTP REST API, so it
+removes the centralized `og-bridge`. Add it as an option first, then delete 0G. The on-chain
+step is unchanged: Python uploads a blob → gets back an id → writes that id to a Sepolia
+contract (`AgentRegistry.dataHashes` / `MatchRegistry.gameRecordHash`) via a separate tx.
+
+- **PR 4.1** — Add a `STORAGE_BACKEND` env var with a `walrus` branch in
+  `server/app/og_storage_client.py` (HTTP `PUT /v1/blobs?epochs=N` to a publisher,
+  `GET /v1/blobs/{id}` from an aggregator — no subprocess), selectable alongside 0G.
+- **PR 4.2** — Once Walrus is proven, remove 0G storage + the `og-bridge/` directory + 0G env
+  vars entirely.
+
+### Post-hackathon (noted, not scheduled)
+
+MemWal for feature weights + per-agent style overlays (encrypted, portable agent memory); Sui
+to host the dApp (Walrus Sites); representing the iNFT as a Sui **Dynamic NFT** object; and
+researching the Mysten Labs game-distribution flywheel.
+
+---
+
+## Sequencing
+
+Ship in task order **1 → 2 → 3 → 4**; each PR is small and independently reviewable. The
+lowest-risk warm-up is **PR 4.1** (additive Walrus backend). Streams 1 and 4 are
+architectural; Streams 2 and 3 are additive onboarding UI.
+
+## References
+
+- Privy Agent CLI — https://docs.privy.io/recipes/agent-integrations/agent-cli
+- Privy crypto deposit addresses — https://docs.privy.io/wallets/funding/crypto-deposit-addresses
+- blink.cash — https://docs.blink.cash/introduction
+- Mysten Labs evm-sui (Walrus / Sui) — https://mystenlabs.github.io/evm-sui/
+- Walrus HTTP API — https://docs.wal.app/docs/http-api/storing-blobs


### PR DESCRIPTION
## What

Adds a single roadmap doc — `docs/superpowers/plans/2026-06-13-ethglobal-nyc-2026.md` — for our **ETHGlobal NYC 2026 Continuity track** submission. **Plan only, no code changes.** Each integration stream below becomes its own simple, sequential, human-approved PR; every commit is prefixed `[EthGlobalNYC26]`.

## Continuity narrative

The agent should persist independently of any one server, provider, or model: its own wallet (Privy), its own equity (dividend vault), and decentralized storage (Walrus). Today funds sit in `AgentVault.sol` under a server key, the server distributes payouts, and weights live in 0G behind the centralized `og-bridge`.

**Ground rule:** all balances are denominated in **USDC**; the legacy ETH `AgentVault` path is dropped.

## The four streams

1. **Privy agentic wallets** — the agent owns its wallet so Privy distributes winnings instead of the server, replacing `AgentVault`. Ends with a dividend-vault MVP (agent equity pays USDC dividends) plus placeholders for ERC-4626 + bonding curve, basket/index bets, elo-collateralized borrowing, and puts on agent performance.
2. **Privy universal deposit address** — user sends Arbitrum ETH, Privy auto-bridges/swaps/deposits Base USDC.
3. **blink.cash** — one-tap stablecoin deposit credits the Privy wallet; staking draws from that credit.
4. **Walrus storage** — add a `STORAGE_BACKEND=walrus` HTTP branch in `og_storage_client.py`, then remove 0G storage + `og-bridge` entirely.

MemWal and Sui hosting are noted as **post-hackathon, out of scope**.

## Review

Docs-only — review-based. Diff is one new file (~117 lines). All cited paths exist in the repo.

https://claude.ai/code/session_011SYaM3inCRBJKjhH1BnDws

---
_Generated by [Claude Code](https://claude.ai/code/session_011SYaM3inCRBJKjhH1BnDws)_